### PR TITLE
サボタージュマスター関係とショートカットの追加

### DIFF
--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -53,7 +53,7 @@ namespace TownOfHost
                     canceled = true;
                     if (arg == "")
                     {
-                        __instance.AddChat(PlayerControl.LocalPlayer, "使用可能な引数: jester, madmate, bait, terrorist, sidekick, vampire, fox, troll");
+                        __instance.AddChat(PlayerControl.LocalPlayer, "使用可能な引数: jester, madmate, bait, terrorist, sidekick, vampire, sabotagemaster, fox, troll");
                     }
                     else if (arg == "jester")
                     {
@@ -78,6 +78,10 @@ namespace TownOfHost
                     else if (arg == "vampire")
                     {
                         main.SendToAll(main.getLang(lang.VampireInfoLong));
+                    }
+                    else if (arg == "sabotagemaster")
+                    {
+                        main.SendToAll(main.getLang(lang.SabotageMasterInfoLong));
                     }
                     else if (arg == "fox")
                     {

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -48,46 +48,46 @@ namespace TownOfHost
                     if(main.NoGameEnd){ main.SendToAll(main.getLang(lang.NoGameEndInfo)); }
                     if(main.SyncButtonMode){ main.SendToAll(main.getLang(lang.SyncButtonModeInfo)); }
                 }
-                if (getCommand("/h roles", text, out arg))
+                if (getCommand("/h roles", text, out arg) || getCommand("/h r", text, out arg))
                 {
                     canceled = true;
                     if (arg == "")
                     {
                         __instance.AddChat(PlayerControl.LocalPlayer, "使用可能な引数: jester, madmate, bait, terrorist, sidekick, vampire, sabotagemaster, fox, troll");
                     }
-                    else if (arg == "jester")
+                    else if (arg == "jester" || arg == "je")
                     {
                         main.SendToAll(main.getLang(lang.JesterInfoLong));
                     }
-                    else if (arg == "madmate")
+                    else if (arg == "madmate" || arg == "ma")
                     {
                         main.SendToAll(main.getLang(lang.MadmateInfoLong));
                     }
-                    else if (arg == "bait")
+                    else if (arg == "bait" || arg == "ba")
                     {
                         main.SendToAll(main.getLang(lang.BaitInfoLong));
                     }
-                    else if (arg == "terrorist")
+                    else if (arg == "terrorist" || arg == "te")
                     {
                         main.SendToAll(main.getLang(lang.TerroristInfoLong));
                     }
-                    else if (arg == "sidekick")
+                    else if (arg == "sidekick" || arg == "si")
                     {
                         main.SendToAll(main.getLang(lang.SidekickInfoLong));
                     }
-                    else if (arg == "vampire")
+                    else if (arg == "vampire" || arg == "va")
                     {
                         main.SendToAll(main.getLang(lang.VampireInfoLong));
                     }
-                    else if (arg == "sabotagemaster")
+                    else if (arg == "sabotagemaster" || arg == "sa")
                     {
                         main.SendToAll(main.getLang(lang.SabotageMasterInfoLong));
                     }
-                    else if (arg == "fox")
+                    else if (arg == "fox" || arg == "fo")
                     {
                         main.SendToAll(main.getLang(lang.FoxInfoLong));
                     }
-                    else if (arg == "troll")
+                    else if (arg == "troll" || arg == "tr")
                     {
                         main.SendToAll(main.getLang(lang.TrollInfoLong));
                     }
@@ -96,22 +96,22 @@ namespace TownOfHost
                         __instance.AddChat(PlayerControl.LocalPlayer, CommandReturn(lang.commandError, lang.InvalidArgs));
                     }
                 }
-                if (getCommand("/h modes", text, out arg))
+                if (getCommand("/h modes", text, out arg) || getCommand("/h m", text, out arg))
                 {
                     canceled = true;
                     if (arg == "")
                     {
                         __instance.AddChat(PlayerControl.LocalPlayer, "使用可能な引数: hideandseek, nogameend, syncbuttonmode");
                     }
-                    else if (arg == "hideandseek")
+                    else if (arg == "hideandseek" || arg == "has")
                     {
                         main.SendToAll(main.getLang(lang.HideAndSeekInfo));
                     }
-                    else if (arg == "nogameend")
+                    else if (arg == "nogameend" || arg == "nge")
                     {
                         main.SendToAll(main.getLang(lang.NoGameEndInfo));
                     }
-                    else if (arg == "syncbuttonmode")
+                    else if (arg == "syncbuttonmode" || arg == "sb")
                     {
                         main.SendToAll(main.getLang(lang.SyncButtonModeInfo));
                     }

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -41,6 +41,7 @@ namespace TownOfHost
                     if(main.currentEngineer == EngineerRoles.Terrorist){ main.SendToAll(main.getLang(lang.TerroristInfoLong)); }
                     if(main.currentScientist == ScientistRoles.Bait){ main.SendToAll(main.getLang(lang.BaitInfoLong)); }
                     if(main.currentScientist == ScientistRoles.Jester){ main.SendToAll(main.getLang(lang.JesterInfoLong)); }
+                    if(main.currentScientist == ScientistRoles.SabotageMaster){ main.SendToAll(main.getLang(lang.SabotageMasterInfoLong)); }
                     if(main.FoxCount > 0 ){ main.SendToAll(main.getLang(lang.FoxInfoLong)); }
                     if(main.TrollCount > 0 ){ main.SendToAll(main.getLang(lang.TrollInfoLong)); }
                     if(main.IsHideAndSeek){ main.SendToAll(main.getLang(lang.HideAndSeekInfo)); }

--- a/main.cs
+++ b/main.cs
@@ -484,6 +484,7 @@ namespace TownOfHost
                 {lang.TerroristInfoLong, "テロリスト(エンジニア):自身のタスクを全て完了させた状態で死亡したときに単独勝利となる第三陣営の役職。死因はキルと追放のどちらでもよい。タスクを完了させずに死亡したり、死亡しないまま試合が終了すると敗北する。"},
                 {lang.SidekickInfoLong, "相棒(シェイプシフター):初期状態でベントやサボタージュ、変身は可能だが、キルはできない。相棒ではないインポスターが全員死亡すると、相棒もキルが可能となる。"},
                 {lang.VampireInfoLong, "吸血鬼(インポスター):キルボタンを押してから10秒(変更可能)経って実際にキルが発生する役職。キルをしたときのテレポートは発生しない。また、キルボタンを押してから10秒経つまでに会議が始まるとその瞬間にキルが発生する。"},
+                {lang.SabotageMasterInfoLong, "サボタージュマスター(科学者):リアクター・O2は片方修理すれば両方直る。停電は一か所のクリックですべて直る。設定でONにするとドアを開けた際にその部屋のドアがすべて開く。"},
                 {lang.FoxInfoLong, "狐(HideAndSeek):トロールを除くいずれかの陣営が勝利したときに生き残っていれば追加勝利となる。"},
                 {lang.TrollInfoLong, "トロール(HideAndSeek):インポスターにキルされたときに単独勝利となる。この場合、狐が生き残っていても狐は追加勝利することができない。"},
                 //モード名
@@ -534,6 +535,7 @@ namespace TownOfHost
                 {lang.TerroristInfoLong, "Terrorist(Engineer):自身のタスクを全て完了させた状態で死亡したときに単独勝利となる第三陣営の役職。死因はキルと追放のどちらでもよい。タスクを完了させずに死亡したり、死亡しないまま試合が終了すると敗北する。"},
                 {lang.SidekickInfoLong, "Sidekick(Shapeshifter):初期状態でベントやサボタージュ、変身は可能だが、キルはできない。Sidekickではないインポスターが全員死亡すると、Sidekickもキルが可能となる。"},
                 {lang.VampireInfoLong, "Vampire(Impostor):キルボタンを押してから10秒経って実際にキルが発生する役職。キルをしたときのテレポートは発生しない。また、キルボタンを押してから10秒経つまでに会議が始まるとその瞬間にキルが発生する。"},
+                {lang.SabotageMasterInfoLong, "SabotageMaster(Scientist):リアクター・O2は片方修理すれば両方直る。停電は一か所のクリックですべて直る。設定でONにするとドアを開けた際にその部屋のドアがすべて開く。"},
                 {lang.FoxInfoLong, "Fox(HideAndSeek):Trollを除くいずれかの陣営が勝利したときに生き残っていれば追加勝利となる。"},
                 {lang.TrollInfoLong, "Troll(HideAndSeek):インポスターにキルされたときに単独勝利となる。この場合、Foxが生き残っていてもFoxは追加勝利することができない。"},
                 //モード名
@@ -548,7 +550,7 @@ namespace TownOfHost
                 {lang.AdvancedRoleOptions, "Advanced Options"},
                 {lang.VampireKillDelay, "Vampire Kill Delay(s)"},
                 {lang.SabotageMasterFixesDoors, "Sabotage master fixes multiple doors"},
-                {lang.HideAndSeekOptions, "HideAndSeekの設定"},
+                {lang.HideAndSeekOptions, "HideAndSeek Options"},
                 {lang.AllowCloseDoors, "Allow Close Doors"},
                 {lang.HideAndSeekWaitingTime, "Impostor waiting time"},
                 {lang.IgnoreCosmetics, "Ignore Cosmetics"},


### PR DESCRIPTION
・サボタージュマスターの説明を追加
・ショートカットを追加
/h roles = /h r
/h modes = /h m
役職の頭文字2文字で指定可能
（例：/h roles sabotagemaster = /h r sa）