### PR TITLE
ロビーでCを押すとゲームコードがコピーできるように変更

### DIFF
--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -42,6 +42,7 @@ namespace TownOfHost
             // | N | ホスト | ID1の名前をDesyncさせる |
             // | I | ホスト | プレイヤー全員を自分の名前にする（全視点） |
             // | U | ホスト | 全員自分だけがインポスターだと認識させる |
+            // | C | ロビー | クリップボードにゲームコードをコピーする |
             //====================
             if (Input.GetKeyDown(KeyCode.X) && AmongUsClient.Instance.GameMode == GameModes.FreePlay)
             {

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -82,6 +82,12 @@ namespace TownOfHost
                     }
                 }
             }
+            if (Input.GetKeyDown(KeyCode.C))
+            {
+                string code = InnerNet.GameCode.IntToGameName(AmongUsClient.Instance.GameId);
+                GUIUtility.systemCopyBuffer = code;
+                Logger.info($"[ClipBoard]{code}");
+            }
             if (Input.GetKeyDown(KeyCode.M))
             {
                 if (AmongUsClient.Instance.GameMode == GameModes.FreePlay)

--- a/Patches/UnrestrictNumImpostor.cs
+++ b/Patches/UnrestrictNumImpostor.cs
@@ -80,9 +80,6 @@ namespace TownOfHost
             {
                 // Reset lobby countdown timer
                 timer = 600f;
-                // Copy lobby code
-                string code = InnerNet.GameCode.IntToGameName(AmongUsClient.Instance.GameId);
-                GUIUtility.systemCopyBuffer = code;
                 lobbyCodehide = $"<color={main.modColor}>Town Of Host</color>";
             }
         }


### PR DESCRIPTION
・ロビーでCを押すとゲームコードがコピーできるように変更（クリップボードが勝手に破壊されるのを防ぐため）