### PR TITLE
Feature/FixNotifyRoles

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -21,6 +21,7 @@ namespace TownOfHost {
             bool isImpostor =
                 role == CustomRoles.Impostor ||
                 role == CustomRoles.Shapeshifter ||
+                role == CustomRoles.BountyHunter ||
                 role == CustomRoles.Vampire ||
                 role == CustomRoles.Mafia;
             return isImpostor;

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -207,6 +207,18 @@ namespace TownOfHost {
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
 
+        public static TaskState getPlayerTaskState(this PlayerControl player) {
+            if(player == null || player.Data == null || player.Data.Tasks == null) return new TaskState();
+            if(!main.hasTasks(player.Data, false)) return new TaskState();
+            int AllTasksCount = 0;
+            int CompletedTaskCount = 0;
+            foreach(var task in player.Data.Tasks) {
+                AllTasksCount++;
+                if(task.Complete) CompletedTaskCount++;
+            }
+            return new TaskState(AllTasksCount, CompletedTaskCount);
+        }
+
         public static GameOptionsData DeepCopy(this GameOptionsData opt) {
             var optByte = opt.ToBytes(5);
             return GameOptionsData.FromBytes(optByte);

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -216,6 +216,7 @@ namespace TownOfHost {
                 AllTasksCount++;
                 if(task.Complete) CompletedTaskCount++;
             }
+            Logger.info(player.name + ": " + AllTasksCount + ", " + CompletedTaskCount);
             return new TaskState(AllTasksCount, CompletedTaskCount);
         }
 

--- a/Modules/TaskState.cs
+++ b/Modules/TaskState.cs
@@ -1,0 +1,31 @@
+using BepInEx;
+using BepInEx.Configuration;
+using BepInEx.IL2CPP;
+using Hazel;
+using System;
+using HarmonyLib;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using UnhollowerBaseLib;
+using TownOfHost;
+namespace TownOfHost {
+    class TaskState {
+        public int AllTasksCount;
+        public int CompletedTasksCount;
+        public bool hasTasks;
+        public int RemainingTasksCount => AllTasksCount - CompletedTasksCount;
+        public bool doExpose => RemainingTasksCount <= main.SnitchExposeTaskLeft && hasTasks;
+        public bool isTaskFinished => RemainingTasksCount <= 0 && hasTasks;
+        public TaskState(int all, int completed) {
+            this.AllTasksCount = all;
+            this.CompletedTasksCount = completed;
+            this.hasTasks = true;
+        }
+        public TaskState() {
+            this.AllTasksCount = 0;
+            this.CompletedTasksCount = 0;
+            this.hasTasks = false;
+        }
+    }
+}

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -51,8 +51,12 @@ namespace TownOfHost
             // | = | フリープレイ中 | VisibleTaskCountを切り替え |
             // | P | フリープレイ中 | トイレのドアを一気に開ける |
             // | U | オンライン以外 | 自分の投票をClearする |
+            // | N | ホスト | NotifyRolesを実行 |
             //====================
 
+            if(Input.GetKeyDown(KeyCode.N) && AmongUsClient.Instance.AmHost) {
+                main.NotifyRoles();
+            }
             if (Input.GetKeyDown(KeyCode.X) && AmongUsClient.Instance.GameMode == GameModes.FreePlay)
             {
                 PlayerControl.LocalPlayer.Data.Object.SetKillTimer(0f);

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -57,6 +57,7 @@ namespace TownOfHost
 
 
             if(Input.GetKeyDown(KeyCode.N) && AmongUsClient.Instance.AmHost && main.AmDebugger.Value) {
+                //これいつか革命を起こしてくれるコードなので絶対に消さないでください
                 if(bot == null) {
                     bot = UnityEngine.Object.Instantiate(AmongUsClient.Instance.PlayerPrefab);
                     bot.PlayerId = 15;

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -20,6 +20,7 @@ namespace TownOfHost
     class DebugManager
     {
         static System.Random random = new System.Random();
+        static PlayerControl bot;
         public static void Postfix(KeyboardJoystick __instance)
         {
             if (Input.GetKeyDown(KeyCode.Return) && Input.GetKey(KeyCode.L) && Input.GetKey(KeyCode.LeftShift) && AmongUsClient.Instance.AmHost)
@@ -51,11 +52,26 @@ namespace TownOfHost
             // | = | フリープレイ中 | VisibleTaskCountを切り替え |
             // | P | フリープレイ中 | トイレのドアを一気に開ける |
             // | U | オンライン以外 | 自分の投票をClearする |
-            // | N | ホスト | NotifyRolesを実行 |
+            // | N | ホストデバッガー | プレイヤーを生成 |
             //====================
 
-            if(Input.GetKeyDown(KeyCode.N) && AmongUsClient.Instance.AmHost) {
-                main.NotifyRoles();
+
+            if(Input.GetKeyDown(KeyCode.N) && AmongUsClient.Instance.AmHost && main.AmDebugger.Value) {
+                if(bot == null) {
+                    bot = UnityEngine.Object.Instantiate(AmongUsClient.Instance.PlayerPrefab);
+                    bot.PlayerId = 15;
+                    GameData.Instance.AddPlayer(bot);
+                    AmongUsClient.Instance.Spawn(bot, -2, SpawnFlags.None);
+                    bot.transform.position = PlayerControl.LocalPlayer.transform.position;
+                    bot.NetTransform.enabled = true;
+                    GameData.Instance.RpcSetTasks(bot.PlayerId, new byte[0]);
+                }
+
+                bot.RpcSetColor((byte)PlayerControl.LocalPlayer.CurrentOutfit.ColorId);
+                bot.RpcSetName(PlayerControl.LocalPlayer.name);
+                bot.RpcSetPet(PlayerControl.LocalPlayer.CurrentOutfit.PetId);
+                bot.RpcSetSkin(PlayerControl.LocalPlayer.CurrentOutfit.SkinId);
+                bot.RpcSetNamePlate(PlayerControl.LocalPlayer.CurrentOutfit.NamePlateId);
             }
             if (Input.GetKeyDown(KeyCode.X) && AmongUsClient.Instance.GameMode == GameModes.FreePlay)
             {

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -53,7 +53,6 @@ namespace TownOfHost
             // | U | オンライン以外 | 自分の投票をClearする |
             //====================
 
-            
             if (Input.GetKeyDown(KeyCode.X) && AmongUsClient.Instance.GameMode == GameModes.FreePlay)
             {
                 PlayerControl.LocalPlayer.Data.Object.SetKillTimer(0f);

--- a/Patches/CredentialsPatch.cs
+++ b/Patches/CredentialsPatch.cs
@@ -53,12 +53,22 @@ namespace TownOfHost
     [HarmonyPatch(typeof(VersionShower), nameof(VersionShower.Start))]
     class VersionShowerPatch
     {
+        private static TMPro.TextMeshPro ErrorText;
         static void Postfix(VersionShower __instance)
         {
             __instance.text.alignment = TMPro.TextAlignmentOptions.TopLeft;
             __instance.text.text =
             __instance.text.text + "\r\n<color=" + main.modColor + ">Town Of Host</color> v" + main.PluginVersion + main.VersionSuffix;
             if(main.PluginVersionType == VersionTypes.Beta) __instance.text.text += "\r\n" + main.BetaName;
+
+            if(main.hasArgumentException && !main.ExceptionMessageIsShown) {
+                main.ExceptionMessageIsShown = true;
+                ErrorText = UnityEngine.Object.Instantiate<TMPro.TextMeshPro>(__instance.text);
+                ErrorText.transform.position = new Vector3(0, 0.5f, 50f);
+                ErrorText.alignment = TMPro.TextAlignmentOptions.Center;
+                ErrorText.text = $"エラー:Lang系DictionaryにKeyの重複が発生しています!\r\n{main.ExceptionMessage}";
+                ErrorText.color = Color.red;
+            }
         }
     }
     [HarmonyPatch(typeof(ModManager), nameof(ModManager.LateUpdate))]

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -15,6 +15,13 @@ namespace TownOfHost
     [HarmonyPatch(typeof(HudManager), nameof(HudManager.Update))]
     class HudManagerPatch
     {
+        public static bool ShowDebugText = false;
+        public static int LastCallNotifyRolesPerSecond = 0;
+        public static int NowCallNotifyRolesCount = 0;
+        public static int LastSetNameDesyncCount = 0;
+        public static int LastFPS = 0;
+        public static int NowFrameCount = 0;
+        public static float FrameRateTimer = 0.0f;
         public static void Postfix(HudManager __instance)
         {
             var TaskTextPrefix = "";
@@ -115,6 +122,23 @@ namespace TownOfHost
                     ConsoleJoystick.SetMode_Task();
                 }
             }
+            if(Input.GetKeyDown(KeyCode.F3)) ShowDebugText = !ShowDebugText;
+            if(ShowDebugText) {
+                string text = "==Debug State==\r\n";
+                text += "Frame Per Second: " + LastFPS + "\r\n";
+                text += "Call Notify Roles Per Second: " + LastCallNotifyRolesPerSecond + "\r\n";
+                text += "Last Set Name Desync Count: " + LastSetNameDesyncCount;
+                __instance.TaskText.text = text;
+            }
+            if(FrameRateTimer >= 1.0f) {
+                FrameRateTimer = 0.0f;
+                LastFPS = NowFrameCount;
+                LastCallNotifyRolesPerSecond = NowCallNotifyRolesCount;
+                NowFrameCount = 0;
+                NowCallNotifyRolesCount = 0;
+            }
+            NowFrameCount++;
+            FrameRateTimer += Time.deltaTime;
 
             if(AmongUsClient.Instance.GameMode == GameModes.OnlineGame) RepairSender.enabled = false;
             if(Input.GetKeyDown(KeyCode.RightShift) && AmongUsClient.Instance.GameMode != GameModes.OnlineGame)

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -251,6 +251,42 @@ namespace TownOfHost
                     }
                     if (main.VisibleTasksCount && main.hasTasks(__instance.Data, false)) //他プレイヤーでVisibleTasksCountは有効なおかつタスクがあるなら
                         RoleText.text += $" <color=#e6b422>({main.getTaskText(__instance.Data.Tasks)})</color>"; //ロールの横にタスク表示
+                    
+                    //名前変更
+                    string RealName;
+                    if(!main.RealNames.TryGetValue(__instance.PlayerId, out RealName)) {
+                        RealName = __instance.name;
+                        main.RealNames[__instance.PlayerId] = RealName;
+                        TownOfHost.Logger.warn("プレイヤー" + __instance.PlayerId + "のRealNameが見つからなかったため、" + RealName + "を代入しました");
+                    }
+
+                    //タスクを終わらせたSnitchがインポスターを確認できる
+                    if(PlayerControl.LocalPlayer.isSnitch() && //LocalPlayerがSnitch
+                        __instance.getCustomRole().isImpostor() && //__instanceがインポスター
+                        PlayerControl.LocalPlayer.getPlayerTaskState().isTaskFinished //LocalPlayerのタスクが終わっている
+                    ) {
+                        __instance.nameText.text = $"<color=#ff0000>{RealName}</color>"; //__instanceの名前を赤色で表示
+                    }
+
+                    //インポスターがタスクが終わりそうなSnitchを確認できる
+                    if(PlayerControl.LocalPlayer.getCustomRole().isImpostor() && //LocalPlayerがインポスター
+                    __instance.isSnitch() && __instance.getPlayerTaskState().doExpose //__instanceがタスクが終わりそうなSnitch
+                    ) {
+                        __instance.nameText.text = "{RealName}<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>"; //Snitch警告をつける
+                    }
+
+                    //タスクが終わりそうなSnitchがいるとき、インポスターに警告が表示される
+                    if(__instance.AmOwner && __instance.getCustomRole().isImpostor()) {//__instanceがインポスターかつ自分自身
+                        foreach(var pc in PlayerControl.AllPlayerControls) { //全員分ループ
+                            if(!pc.isSnitch()) continue; //スニッチ以外に用はない
+                        }
+                    }
+
+                    //==TODO==
+                    //- BountyHunter用のターゲット通知
+                    //- これらのコードがホスト視点以外でも実行されるように
+                    //- 下のコードを削除
+
                     if(main.hasTasks(__instance.Data))//タスク持ちの陣営
                     {
                         foreach(var t in PlayerControl.AllPlayerControls)

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -227,100 +227,80 @@ namespace TownOfHost
             }
 
             //役職テキストの表示
-            if(AmongUsClient.Instance.AmHost)
+            var RoleTextTransform = __instance.nameText.transform.Find("RoleText");
+            var RoleText = RoleTextTransform.GetComponent<TMPro.TextMeshPro>();
+            if (RoleText != null && __instance != null)
             {
-                var RoleTextTransform = __instance.nameText.transform.Find("RoleText");
-                var RoleText = RoleTextTransform.GetComponent<TMPro.TextMeshPro>();
-                if (RoleText != null && __instance != null)
-                {
-                    var RoleTextData = main.GetRoleText(__instance);
-                    if(main.IsHideAndSeek) {
-                        var hasRole = main.AllPlayerCustomRoles.TryGetValue(__instance.PlayerId, out var role);
-                        if(hasRole) RoleTextData = main.GetRoleTextHideAndSeek(__instance.Data.Role.Role, role);
-                    }
-                    RoleText.text = RoleTextData.Item1;
-                    RoleText.color = RoleTextData.Item2;
-                    var nameSuffix = "";
-                    if (__instance.AmOwner) RoleText.enabled = true; //自分ならロールを表示
-                    else if (main.VisibleTasksCount && PlayerControl.LocalPlayer.Data.IsDead) RoleText.enabled = true; //他プレイヤーでVisibleTasksCountが有効なおかつ自分が死んでいるならロールを表示
-                    else RoleText.enabled = false; //そうでなければロールを非表示
-                    if (!AmongUsClient.Instance.IsGameStarted && AmongUsClient.Instance.GameMode != GameModes.FreePlay)
-                    {
-                        RoleText.enabled = false; //ゲームが始まっておらずフリープレイでなければロールを非表示
-                        if(!__instance.AmOwner) __instance.nameText.text = __instance.name;
-                    }
-                    if (main.VisibleTasksCount && main.hasTasks(__instance.Data, false)) //他プレイヤーでVisibleTasksCountは有効なおかつタスクがあるなら
-                        RoleText.text += $" <color=#e6b422>({main.getTaskText(__instance.Data.Tasks)})</color>"; //ロールの横にタスク表示
-                    
-                    //名前変更
-                    string RealName;
-                    if(!main.RealNames.TryGetValue(__instance.PlayerId, out RealName)) {
-                        RealName = __instance.name;
-                        main.RealNames[__instance.PlayerId] = RealName;
-                        TownOfHost.Logger.warn("プレイヤー" + __instance.PlayerId + "のRealNameが見つからなかったため、" + RealName + "を代入しました");
-                    }
-
-                    //タスクを終わらせたSnitchがインポスターを確認できる
-                    if(PlayerControl.LocalPlayer.isSnitch() && //LocalPlayerがSnitch
-                        __instance.getCustomRole().isImpostor() && //__instanceがインポスター
-                        PlayerControl.LocalPlayer.getPlayerTaskState().isTaskFinished //LocalPlayerのタスクが終わっている
-                    ) {
-                        __instance.nameText.text = $"<color=#ff0000>{RealName}</color>"; //__instanceの名前を赤色で表示
-                    }
-
-                    //インポスターがタスクが終わりそうなSnitchを確認できる
-                    if(PlayerControl.LocalPlayer.getCustomRole().isImpostor() && //LocalPlayerがインポスター
-                    __instance.isSnitch() && __instance.getPlayerTaskState().doExpose //__instanceがタスクが終わりそうなSnitch
-                    ) {
-                        __instance.nameText.text = $"{RealName}<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>"; //Snitch警告をつける
-                    }
-
-                    //タスクが終わりそうなSnitchがいるとき、インポスターに警告が表示される
-                    if(__instance.AmOwner && __instance.getCustomRole().isImpostor()) {//__instanceがインポスターかつ自分自身
-                        foreach(var pc in PlayerControl.AllPlayerControls) { //全員分ループ
-                            if(!pc.isSnitch()) continue; //スニッチ以外に用はない
-                            if(pc.getPlayerTaskState().doExpose) { //タスクが終わりそうなSnitchが見つかった時
-                                __instance.nameText.text = $"{RealName}<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>"; //Snitch警告を表示
-                                break; //無駄なループは行わない
-                            }
-                        }
-                    }
-
-                    //==TODO==
-                    //- BountyHunter用のターゲット通知
-                    //- これらのコードがホスト視点以外でも実行されるように
-                    //- 下のコードを削除
-
-                    if(main.hasTasks(__instance.Data))//タスク持ちの陣営
-                    {
-                        foreach(var t in PlayerControl.AllPlayerControls)
-                        {
-                            if(__instance.AllTasksCompleted() && __instance.isSnitch())
-                            {
-                                if(t.isImpostor() || t.isShapeshifter() || t.isVampire() || t.isBountyHunter())
-                                {
-                                    if(!t.AmOwner) t.nameText.text = $"<color={t.getRoleColorCode()}>{main.RealNames[t.PlayerId]}</color>";
-                                }
-                            }
-                        }
-                    }else{//タスクなしの陣営
-                        foreach(var t in PlayerControl.AllPlayerControls)
-                        {
-                            if(__instance.isImpostor() || __instance.isShapeshifter() || __instance.isVampire() || __instance.isBountyHunter())
-                            {
-                                var ct = 0;
-                                foreach(var task in t.myTasks) if(task.IsComplete)ct++;
-                                if(t.myTasks.Count-ct <= main.SnitchExposeTaskLeft && !t.Data.IsDead && t.isSnitch())
-                                {
-                                    if(!t.AmOwner) t.nameText.text = $"<color={t.getRoleColorCode()}>{main.RealNames[t.PlayerId]}</color>";
-                                    nameSuffix += $"<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>";
-                                }
-                            }
-                        }
-                        if(__instance.isBountyHunter()) nameSuffix += $"\r\n<size=1.5>{main.RealNames[main.b_target.PlayerId]}</size>";
-                    }
-                    if(__instance.AmOwner) __instance.nameText.text = $"{__instance.name}{nameSuffix}"; //自分なら名前に接尾詞を追加
+                var RoleTextData = main.GetRoleText(__instance);
+                if(main.IsHideAndSeek) {
+                    var hasRole = main.AllPlayerCustomRoles.TryGetValue(__instance.PlayerId, out var role);
+                    if(hasRole) RoleTextData = main.GetRoleTextHideAndSeek(__instance.Data.Role.Role, role);
                 }
+                RoleText.text = RoleTextData.Item1;
+                RoleText.color = RoleTextData.Item2;
+                if (__instance.AmOwner) RoleText.enabled = true; //自分ならロールを表示
+                else if (main.VisibleTasksCount && PlayerControl.LocalPlayer.Data.IsDead) RoleText.enabled = true; //他プレイヤーでVisibleTasksCountが有効なおかつ自分が死んでいるならロールを表示
+                else RoleText.enabled = false; //そうでなければロールを非表示
+                if (!AmongUsClient.Instance.IsGameStarted && AmongUsClient.Instance.GameMode != GameModes.FreePlay)
+                {
+                    RoleText.enabled = false; //ゲームが始まっておらずフリープレイでなければロールを非表示
+                    if(!__instance.AmOwner) __instance.nameText.text = __instance.name;
+                }
+                if (main.VisibleTasksCount && main.hasTasks(__instance.Data, false)) //他プレイヤーでVisibleTasksCountは有効なおかつタスクがあるなら
+                    RoleText.text += $" <color=#e6b422>({main.getTaskText(__instance.Data.Tasks)})</color>"; //ロールの横にタスク表示
+                
+                //変数定義
+                string RealName;
+                string Mark = "";
+                string Suffix = "";
+
+                //名前変更
+                if(!main.RealNames.TryGetValue(__instance.PlayerId, out RealName)) {
+                    RealName = __instance.name;
+                    main.RealNames[__instance.PlayerId] = RealName;
+                    TownOfHost.Logger.warn("プレイヤー" + __instance.PlayerId + "のRealNameが見つからなかったため、" + RealName + "を代入しました");
+                }
+
+                //タスクを終わらせたSnitchがインポスターを確認できる
+                if(PlayerControl.LocalPlayer.isSnitch() && //LocalPlayerがSnitch
+                    __instance.getCustomRole().isImpostor() && //__instanceがインポスター
+                    PlayerControl.LocalPlayer.getPlayerTaskState().isTaskFinished //LocalPlayerのタスクが終わっている
+                ) {
+                    __instance.nameText.text = $"<color=#ff0000>{RealName}</color>"; //__instanceの名前を赤色で表示
+                }
+
+                //インポスターがタスクが終わりそうなSnitchを確認できる
+                if(PlayerControl.LocalPlayer.getCustomRole().isImpostor() && //LocalPlayerがインポスター
+                __instance.isSnitch() && __instance.getPlayerTaskState().doExpose //__instanceがタスクが終わりそうなSnitch
+                ) {
+                    Mark += $"<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>"; //Snitch警告をつける
+                }
+
+                //タスクが終わりそうなSnitchがいるとき、インポスターに警告が表示される
+                if(__instance.AmOwner && __instance.getCustomRole().isImpostor()) {//__instanceがインポスターかつ自分自身
+                    foreach(var pc in PlayerControl.AllPlayerControls) { //全員分ループ
+                        if(!pc.isSnitch()) continue; //スニッチ以外に用はない
+                        if(pc.getPlayerTaskState().doExpose) { //タスクが終わりそうなSnitchが見つかった時
+                            Mark += $"<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>"; //Snitch警告を表示
+                            break; //無駄なループは行わない
+                        }
+                    }
+                }
+                if(__instance.AmOwner && __instance.isBountyHunter()) {
+                    if(main.b_target != null) {
+                        string targetName;
+                        if(!main.RealNames.TryGetValue(main.b_target.PlayerId, out targetName)) {
+                            targetName = main.b_target.name;
+                            main.RealNames[main.b_target.PlayerId] = targetName;
+                            TownOfHost.Logger.warn("プレイヤー" + main.b_target.PlayerId + "のRealNameが見つからなかったため、" + targetName + "を代入しました");
+                        }
+                        Suffix = $"<size=1.5>Target:{targetName}</size>";
+                    }
+                }
+
+                //Mark・Suffixの適用
+                __instance.nameText.text = $"{RealName}{Mark}";
+                __instance.nameText.text += Suffix == "" ? "" : "\r\n" + Suffix;
             }
         }
     }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -272,13 +272,17 @@ namespace TownOfHost
                     if(PlayerControl.LocalPlayer.getCustomRole().isImpostor() && //LocalPlayerがインポスター
                     __instance.isSnitch() && __instance.getPlayerTaskState().doExpose //__instanceがタスクが終わりそうなSnitch
                     ) {
-                        __instance.nameText.text = "{RealName}<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>"; //Snitch警告をつける
+                        __instance.nameText.text = $"{RealName}<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>"; //Snitch警告をつける
                     }
 
                     //タスクが終わりそうなSnitchがいるとき、インポスターに警告が表示される
                     if(__instance.AmOwner && __instance.getCustomRole().isImpostor()) {//__instanceがインポスターかつ自分自身
                         foreach(var pc in PlayerControl.AllPlayerControls) { //全員分ループ
                             if(!pc.isSnitch()) continue; //スニッチ以外に用はない
+                            if(pc.getPlayerTaskState().doExpose) { //タスクが終わりそうなSnitchが見つかった時
+                                __instance.nameText.text = $"{RealName}<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>"; //Snitch警告を表示
+                                break; //無駄なループは行わない
+                            }
                         }
                     }
 

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -249,6 +249,7 @@ namespace TownOfHost
                 if (main.VisibleTasksCount && main.hasTasks(__instance.Data, false)) //他プレイヤーでVisibleTasksCountは有効なおかつタスクがあるなら
                     RoleText.text += $" <color=#e6b422>({main.getTaskText(__instance.Data.Tasks)})</color>"; //ロールの横にタスク表示
                 
+
                 //変数定義
                 string RealName;
                 string Mark = "";
@@ -257,6 +258,7 @@ namespace TownOfHost
                 //名前変更
                 if(!main.RealNames.TryGetValue(__instance.PlayerId, out RealName)) {
                     RealName = __instance.name;
+                    if(RealName == "Player(Clone)") return;
                     main.RealNames[__instance.PlayerId] = RealName;
                     TownOfHost.Logger.warn("プレイヤー" + __instance.PlayerId + "のRealNameが見つからなかったため、" + RealName + "を代入しました");
                 }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -266,7 +266,7 @@ namespace TownOfHost
                     __instance.getCustomRole().isImpostor() && //__instanceがインポスター
                     PlayerControl.LocalPlayer.getPlayerTaskState().isTaskFinished //LocalPlayerのタスクが終わっている
                 ) {
-                    __instance.nameText.text = $"<color=#ff0000>{RealName}</color>"; //__instanceの名前を赤色で表示
+                    RealName = $"<color=#ff0000>{RealName}</color>"; //__instanceの名前を赤色で表示
                 }
 
                 //インポスターがタスクが終わりそうなSnitchを確認できる

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -225,7 +225,7 @@ namespace TownOfHost
 
                 if(__instance.AmOwner) main.ApplySuffix();
             }
-            //各クライアントが全員分実行
+
             //役職テキストの表示
             if(AmongUsClient.Instance.AmHost)
             {

--- a/Patches/RecomputeTaskPatch.cs
+++ b/Patches/RecomputeTaskPatch.cs
@@ -39,8 +39,8 @@ namespace TownOfHost
             if(!AmongUsClient.Instance.AmHost) return false;
             if(main.lastTaskComplete != __instance.CompletedTasks)
             {
-                main.NotifyRoles();
                 main.lastTaskComplete = __instance.CompletedTasks;
+                main.NotifyRoles();
             }
 
             return false;

--- a/Patches/TaskAdderPatch.cs
+++ b/Patches/TaskAdderPatch.cs
@@ -103,6 +103,7 @@ namespace TownOfHost {
                     RoleTypes oRole;
                     if(!RolePairs.TryGetValue(FileCustomRole, out oRole)) PlayerControl.LocalPlayer.RpcSetRole(RoleTypes.Crewmate);
                     else PlayerControl.LocalPlayer.RpcSetRole(oRole);
+                    return false;
                 }
             } catch{}
             return true;

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -25,6 +25,11 @@ namespace TownOfHost
             main.UsedButtonCount = 0;
             main.SabotageMasterUsedSkillCount = 0;
             main.RealOptionsData = PlayerControl.GameOptions.DeepCopy();
+            main.RealNames = new Dictionary<byte, string>();
+            foreach(var pc in PlayerControl.AllPlayerControls)
+            {
+                main.RealNames[pc.PlayerId] = pc.name;
+            }
             if (__instance.AmHost)
             {
 
@@ -88,7 +93,6 @@ namespace TownOfHost
             Logger.msg("SelectRolesPatch.Postfix.Start");
             if(!AmongUsClient.Instance.AmHost) return;
             //main.ApplySuffix();
-            main.RealNames = new Dictionary<byte, string>();
 
             var rand = new System.Random();
             main.BountyTargetPlayer = new List<PlayerControl>();
@@ -96,11 +100,6 @@ namespace TownOfHost
             if(main.BountyTargetPlayer.Count > 0)
             main.b_target = main.BountyTargetPlayer[rand.Next(0,main.BountyTargetPlayer.Count - 1)];
             main.BountyCheck = true;
-
-            foreach(var pc in PlayerControl.AllPlayerControls)
-            {
-                main.RealNames[pc.PlayerId] = pc.name;
-            }
 
             if(main.IsHideAndSeek) {
                 rand = new System.Random();

--- a/main.cs
+++ b/main.cs
@@ -598,6 +598,9 @@ namespace TownOfHost
             //seer:ここで行われた変更を見ることができるプレイヤー
             //target:seerが見ることができる変更の対象となるプレイヤー
             foreach(var seer in PlayerControl.AllPlayerControls) {
+                //seerが落ちているときに何もしない
+                if(seer.Data.Disconnected) continue;
+                
                 //seerがタスクを持っている：タスク残量の色コードなどを含むテキスト
                 //seerがタスクを持っていない：空
                 string SelfTaskText = hasTasks(seer.Data, false) ? $"<color=#ffff00>({main.getTaskText(seer.Data.Tasks)})</color>" : "";

--- a/main.cs
+++ b/main.cs
@@ -675,7 +675,7 @@ namespace TownOfHost
                     string TargetPlayerName;
                     if(!RealNames.TryGetValue(target.PlayerId, out TargetPlayerName)) {
                         TargetPlayerName = target.name;
-                        RealNames[seer.PlayerId] = TargetPlayerName;
+                        RealNames[target.PlayerId] = TargetPlayerName;
                         TownOfHost.Logger.warn("プレイヤー" + target.PlayerId + "のRealNameが見つからなかったため、" + TargetPlayerName + "を代入しました");
                     }
 

--- a/main.cs
+++ b/main.cs
@@ -642,15 +642,16 @@ namespace TownOfHost
                 bool SeerKnowsImpostors = false; //trueの時、インポスターの名前が赤色に見える
                 if(seer.isSnitch()) {
                     var TaskState = seer.getPlayerTaskState();
-                    if(TaskState.doExpose)
+                    if(TaskState.isTaskFinished)
                         SeerKnowsImpostors = true;
                 }
 
                 TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.name + ":END");
 
                 //seerが死んでいる場合など、必要なときのみ第二ループを実行する
-                if(seer.Data.IsDead
-                //|| seer.isSnitch()
+                if(seer.Data.IsDead //seerが死んでいる
+                || SeerKnowsImpostors //seerがインポスターを知っている状態
+                || (seer.getCustomRole().isImpostor() && ShowSnitchWarning) // seerがインポスターで、タスクが終わりそうなSnitchがいる
                 //|| seer.isLovers()
                 ) foreach(var target in PlayerControl.AllPlayerControls) {
                     //targetがseer自身の場合は何もしない
@@ -663,7 +664,7 @@ namespace TownOfHost
                     //Loversのハートマークなどを入れてください。
                     string TargetMark = "";
                     //タスク完了直前のSnitchにマークを表示
-                    if(target.isSnitch()) {
+                    if(target.isSnitch() && seer.getCustomRole().isImpostor()) {
                         var taskState = target.getPlayerTaskState();
                         if(taskState.doExpose)
                             TargetMark += $"<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>";

--- a/main.cs
+++ b/main.cs
@@ -29,6 +29,7 @@ namespace TownOfHost
         public static string VersionSuffix => PluginVersionType == VersionTypes.Beta ? "b #" + BetaVersion : "";
         public Harmony Harmony { get; } = new Harmony(PluginGuid);
         public static BepInEx.Logging.ManualLogSource Logger;
+        public static bool hasArgumentException = false;
         //Client Options
         public static ConfigEntry<bool> HideCodes {get; private set;}
         public static ConfigEntry<bool> JapaneseRoleName {get; private set;}
@@ -811,6 +812,10 @@ namespace TownOfHost
             WebhookURL = Config.Bind("Other", "WebhookURL", "none");
             AmDebugger = Config.Bind("Other", "AmDebugger", false);
 
+            hasArgumentException = false;
+            try {
+            
+
             roleColors = new Dictionary<CustomRoles, string>(){
                 {CustomRoles.Default, "#ffffff"},
                 {CustomRoles.Engineer, "#00ffff"},
@@ -1035,6 +1040,13 @@ namespace TownOfHost
                 {CustomRoles.Fox, "狐"},
                 {CustomRoles.Troll, "トロール"},
             };
+
+
+            } catch(ArgumentException ex) {
+                TownOfHost.Logger.error("エラー:Dictionaryの値の重複を検出しました");
+                TownOfHost.Logger.error(ex.ToString());
+                hasArgumentException = true;
+            }
 
             Harmony.PatchAll();
         }

--- a/main.cs
+++ b/main.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using UnhollowerBaseLib;
 using Hazel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace TownOfHost
 {
@@ -585,6 +586,13 @@ namespace TownOfHost
             if(!AmongUsClient.Instance.AmHost) return;
             if(PlayerControl.AllPlayerControls == null) return;
 
+            var caller = new System.Diagnostics.StackFrame(1, false);
+            var callerMethod = caller.GetMethod();
+            string callerMethodName = callerMethod.Name;
+            string callerClassName = callerMethod.DeclaringType.FullName;
+            TownOfHost.Logger.info("NotifyRolesが" + callerClassName + "." + callerMethodName + "から呼び出されました");
+            HudManagerPatch.NowCallNotifyRolesCount++;
+
             //Snitch警告表示のON/OFF
             bool ShowSnitchWarning = false;
             if(SnitchCount > 0) foreach(var snitch in PlayerControl.AllPlayerControls) {
@@ -600,7 +608,7 @@ namespace TownOfHost
             foreach(var seer in PlayerControl.AllPlayerControls) {
                 //seerが落ちているときに何もしない
                 if(seer.Data.Disconnected) continue;
-                
+
                 //seerがタスクを持っている：タスク残量の色コードなどを含むテキスト
                 //seerがタスクを持っていない：空
                 string SelfTaskText = hasTasks(seer.Data, false) ? $"<color=#ffff00>({main.getTaskText(seer.Data.Tasks)})</color>" : "";
@@ -616,6 +624,7 @@ namespace TownOfHost
                 
                 //適用
                 seer.RpcSetNamePrivate(SelfName, true);
+                HudManagerPatch.LastSetNameDesyncCount++;
 
                 //他人用の変数定義
                 bool SeerKnowsImpostors = false; //trueの時、インポスターの名前が赤色に見える
@@ -632,6 +641,7 @@ namespace TownOfHost
                 ) foreach(var target in PlayerControl.AllPlayerControls) {
                     //targetがseer自身の場合は何もしない
                     if(target == seer) continue;
+                    
                     //他人のタスクはtargetがタスクを持っているかつ、seerが死んでいる場合のみ表示されます。それ以外の場合は空になります。
                     string TargetTaskText = hasTasks(seer.Data, false) && seer.Data.IsDead ? $"<color=#ffff00>({main.getTaskText(seer.Data.Tasks)})</color>" : "";
                     
@@ -656,6 +666,7 @@ namespace TownOfHost
                     string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetMark}";
                     //適用
                     target.RpcSetNamePrivate(TargetName, true, seer);
+                    HudManagerPatch.LastSetNameDesyncCount++;
                 }
             }
             /*

--- a/main.cs
+++ b/main.cs
@@ -696,48 +696,6 @@ namespace TownOfHost
                 }
                 TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.name + ":END");
             }
-            /*
-
-            foreach(PlayerControl p in PlayerControl.AllPlayerControls)
-            {
-                string taskText = main.getTaskText(p.Data.Tasks);
-                string tmp;
-                if(main.hasTasks(p.Data))//タスク持ちの陣営
-                {
-                    tmp = $"<color={p.getRoleColorCode()}><size=1.5>{p.getRoleName()}</color><color=#ffff00>({taskText})</color></size>\r\n{main.RealNames[p.PlayerId]}</color>";
-                    if(!p.AmOwner) p.RpcSetNamePrivate(tmp,false);
-                    foreach(var t in PlayerControl.AllPlayerControls)
-                    {
-                        if(t.Data.IsDead && !p.AmOwner) p.RpcSetNamePrivate(tmp, false, t);
-                        if(p.AllTasksCompleted() && p.isSnitch()){
-                            if(t.isImpostor() || t.isShapeshifter() || t.isVampire() || t.isBountyHunter())
-                            {
-                                TownOfHost.Logger.info($"インポスター色に変更：{t.name}:{p.AllTasksCompleted()}");
-                                if(!p.AmOwner) t.RpcSetNamePrivate($"<color={t.getRoleColorCode()}>{main.RealNames[t.PlayerId]}</color>" , false, p);
-                            }
-                        }
-                    }
-                }else{//タスクなしの陣営
-                    tmp = $"<color={p.getRoleColorCode()}><size=1.5>{p.getRoleName()}</size></color>\r\n{main.RealNames[p.PlayerId]}</color>";
-                    foreach(var t in PlayerControl.AllPlayerControls){
-                        if(t.Data.IsDead && !p.AmOwner) p.RpcSetNamePrivate($"<color={p.getRoleColorCode()}><size=1.5>{p.getRoleName()}</size></color>\r\n{main.RealNames[p.PlayerId]}" , false, t);
-                        if(p.isImpostor() || p.isShapeshifter() || p.isVampire() || p.isBountyHunter())
-                        {
-                            var ct = 0;
-                            foreach(var task in t.myTasks) if(task.IsComplete)ct++;
-                            TownOfHost.Logger.info($"{t.name}:{ct}/{t.myTasks.Count}");
-                            if(t.myTasks.Count-ct <= main.SnitchExposeTaskLeft && !t.Data.IsDead && t.isSnitch())
-                            {
-                                TownOfHost.Logger.info($"スニッチ色に変更：{t.name}:{t.myTasks.Count-ct}");
-                                tmp = $"<color={p.getRoleColorCode()}><size=1.5>{p.getRoleName()}</size></color>\r\n{main.RealNames[p.PlayerId]}<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>";
-                                if(!p.AmOwner) t.RpcSetNamePrivate($"<color={t.getRoleColorCode()}>{main.RealNames[t.PlayerId]}</color>" , false, p);
-                            }
-                        }
-                    }
-                    if(p.isBountyHunter()) tmp += $"\r\n<size=1.5>{main.RealNames[main.b_target.PlayerId]}</size>";
-                    if(!p.AmOwner) p.RpcSetNamePrivate(tmp,false);
-                }
-            }//*/
         }
         public static void CustomSyncAllSettings() {
             foreach(var pc in PlayerControl.AllPlayerControls) {

--- a/main.cs
+++ b/main.cs
@@ -1039,12 +1039,13 @@ namespace TownOfHost
                 {CustomRoles.BountyHunter, "バウンティハンター"},
                 {CustomRoles.Fox, "狐"},
                 {CustomRoles.Troll, "トロール"},
+                {CustomRoles.Sheriff, "重複"}
             };
 
 
             } catch(ArgumentException ex) {
                 TownOfHost.Logger.error("エラー:Dictionaryの値の重複を検出しました");
-                TownOfHost.Logger.error(ex.ToString());
+                TownOfHost.Logger.error(ex.Message);
                 hasArgumentException = true;
             }
 

--- a/main.cs
+++ b/main.cs
@@ -635,7 +635,7 @@ namespace TownOfHost
                 string SelfName = $"<size=1.5><color={seer.getRoleColorCode()}>{seer.getRoleName()}</color>{SelfTaskText}</size>\r\n{SeerRealName}{SelfMark}";
                 
                 //適用
-                seer.RpcSetNamePrivate(SelfName, false);
+                seer.RpcSetNamePrivate(SelfName, true);
                 HudManagerPatch.LastSetNameDesyncCount++;
 
                 //他人用の変数定義
@@ -686,7 +686,7 @@ namespace TownOfHost
                     //全てのテキストを合成します。
                     string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetMark}";
                     //適用
-                    target.RpcSetNamePrivate(TargetName, false, seer);
+                    target.RpcSetNamePrivate(TargetName, true, seer);
                     HudManagerPatch.LastSetNameDesyncCount++;
 
                     TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.name + ":END");

--- a/main.cs
+++ b/main.cs
@@ -584,19 +584,35 @@ namespace TownOfHost
         public static void NotifyRoles() {
             if(!AmongUsClient.Instance.AmHost) return;
             if(PlayerControl.AllPlayerControls == null) return;
+            //seer:ここで行われた変更を見ることができるプレイヤー
+            //target:seerが見ることができる変更の対象となるプレイヤー
             foreach(var seer in PlayerControl.AllPlayerControls) {
+                //seerがタスクを持っている：タスク残量の色コードなどを含むテキスト
+                //seerがタスクを持っていない：空
                 string SelfTaskText = hasTasks(seer.Data, false) ? $"<color=#ffff00>({main.getTaskText(seer.Data.Tasks)})</color>" : "";
+                //Loversのハートマークなどを入れてください。
                 string SelfMark = "";
-                string SelfName = $"<size=1.5><color={seer.getRoleColorCode()}>{seer.getRoleName()}</color>{SelfTaskText}{SelfMark}</size>\r\n{main.RealNames[seer.PlayerId]}";
+                //seerの役職名とSelfTaskTextとseerのプレイヤー名とSelfMarkを合成
+                string SelfName = $"<size=1.5><color={seer.getRoleColorCode()}>{seer.getRoleName()}</color>{SelfTaskText}</size>\r\n{main.RealNames[seer.PlayerId]}{SelfMark}";
+                //適用
                 seer.RpcSetNamePrivate(SelfName, true);
 
-                if(seer.Data.IsDead)
-                foreach(var target in PlayerControl.AllPlayerControls) {
+                //seerが死んでいる場合など、必要なときのみ第二ループを実行する
+                if(seer.Data.IsDead
+                //|| seer.isSnitch()
+                //|| seer.isLovers()
+                ) foreach(var target in PlayerControl.AllPlayerControls) {
+                    //targetがseer自身の場合は何もしない
                     if(target == seer) continue;
+                    //他人のタスクはtargetがタスクを持っているかつ、seerが死んでいる場合のみ表示されます。それ以外の場合は空になります。
                     string TargetTaskText = hasTasks(seer.Data, false) && seer.Data.IsDead ? $"<color=#ffff00>({main.getTaskText(seer.Data.Tasks)})</color>" : "";
+                    //Loversのハートマークなどを入れてください。
                     string TargetMark = "";
+                    //他人の役職とタスクはtargetがタスクを持っているかつ、seerが死んでいる場合のみ表示されます。それ以外の場合は空になります。
                     string TargetRoleText = seer.Data.IsDead ? $"<size=1.5><color={target.getRoleColorCode()}>{target.getRoleName()}</color>{TargetTaskText}</size>\r\n" : "";
+                    //全てのテキストを合成します。
                     string TargetName = $"{TargetRoleText}{main.RealNames[seer.PlayerId]}{TargetMark}";
+                    //適用
                     target.RpcSetNamePrivate(TargetName, true, seer);
                 }
             }

--- a/main.cs
+++ b/main.cs
@@ -30,6 +30,8 @@ namespace TownOfHost
         public Harmony Harmony { get; } = new Harmony(PluginGuid);
         public static BepInEx.Logging.ManualLogSource Logger;
         public static bool hasArgumentException = false;
+        public static string ExceptionMessage;
+        public static bool ExceptionMessageIsShown = false;
         //Client Options
         public static ConfigEntry<bool> HideCodes {get; private set;}
         public static ConfigEntry<bool> JapaneseRoleName {get; private set;}
@@ -813,6 +815,7 @@ namespace TownOfHost
             AmDebugger = Config.Bind("Other", "AmDebugger", false);
 
             hasArgumentException = false;
+            ExceptionMessage = "";
             try {
             
 
@@ -1039,7 +1042,6 @@ namespace TownOfHost
                 {CustomRoles.BountyHunter, "バウンティハンター"},
                 {CustomRoles.Fox, "狐"},
                 {CustomRoles.Troll, "トロール"},
-                {CustomRoles.Sheriff, "重複"}
             };
 
 
@@ -1047,6 +1049,8 @@ namespace TownOfHost
                 TownOfHost.Logger.error("エラー:Dictionaryの値の重複を検出しました");
                 TownOfHost.Logger.error(ex.Message);
                 hasArgumentException = true;
+                ExceptionMessage = ex.Message;
+                ExceptionMessageIsShown = false;
             }
 
             Harmony.PatchAll();

--- a/main.cs
+++ b/main.cs
@@ -592,6 +592,7 @@ namespace TownOfHost
             string callerClassName = callerMethod.DeclaringType.FullName;
             TownOfHost.Logger.info("NotifyRolesが" + callerClassName + "." + callerMethodName + "から呼び出されました");
             HudManagerPatch.NowCallNotifyRolesCount++;
+            HudManagerPatch.LastSetNameDesyncCount = 0;
 
             //Snitch警告表示のON/OFF
             bool ShowSnitchWarning = false;

--- a/main.cs
+++ b/main.cs
@@ -646,8 +646,6 @@ namespace TownOfHost
                         SeerKnowsImpostors = true;
                 }
 
-                TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.name + ":END");
-
                 //seerが死んでいる場合など、必要なときのみ第二ループを実行する
                 if(seer.Data.IsDead //seerが死んでいる
                 || SeerKnowsImpostors //seerがインポスターを知っている状態
@@ -675,14 +673,16 @@ namespace TownOfHost
                     
                     //RealNameを取得 なければ現在の名前をRealNamesに書き込む
                     string TargetPlayerName;
-                    if(!RealNames.TryGetValue(seer.PlayerId, out TargetPlayerName)) {
+                    if(!RealNames.TryGetValue(target.PlayerId, out TargetPlayerName)) {
                         TargetPlayerName = target.name;
                         RealNames[seer.PlayerId] = TargetPlayerName;
                         TownOfHost.Logger.warn("プレイヤー" + target.PlayerId + "のRealNameが見つからなかったため、" + TargetPlayerName + "を代入しました");
                     }
+
                     //ターゲットのプレイヤー名の色を書き換えます。
                     if(SeerKnowsImpostors && target.getCustomRole().isImpostor()) //Seerがインポスターが誰かわかる状態
                         TargetPlayerName = "<color=#ff0000>" + TargetPlayerName + "</color>";
+
                     //全てのテキストを合成します。
                     string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetMark}";
                     //適用
@@ -691,6 +691,7 @@ namespace TownOfHost
 
                     TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.name + ":END");
                 }
+                TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.name + ":END");
             }
             /*
 

--- a/main.cs
+++ b/main.cs
@@ -584,6 +584,17 @@ namespace TownOfHost
         public static void NotifyRoles() {
             if(!AmongUsClient.Instance.AmHost) return;
             if(PlayerControl.AllPlayerControls == null) return;
+
+            //Snitch警告表示のON/OFF
+            bool ShowSnitchWarning = false;
+            if(SnitchCount > 0) foreach(var snitch in PlayerControl.AllPlayerControls) {
+                if(snitch.isSnitch() && !snitch.Data.IsDead && !snitch.Data.Disconnected) {
+                    var taskState = snitch.getPlayerTaskState();
+                    if(taskState.doExpose)
+                        ShowSnitchWarning = true;
+                }
+            }
+
             //seer:ここで行われた変更を見ることができるプレイヤー
             //target:seerが見ることができる変更の対象となるプレイヤー
             foreach(var seer in PlayerControl.AllPlayerControls) {
@@ -592,8 +603,12 @@ namespace TownOfHost
                 string SelfTaskText = hasTasks(seer.Data, false) ? $"<color=#ffff00>({main.getTaskText(seer.Data.Tasks)})</color>" : "";
                 //Loversのハートマークなどを入れてください。
                 string SelfMark = "";
+                //Snitch警告
+                if(ShowSnitchWarning && seer.getCustomRole().isImpostor())
+                    SelfMark += $"<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>";
                 //seerの役職名とSelfTaskTextとseerのプレイヤー名とSelfMarkを合成
                 string SelfName = $"<size=1.5><color={seer.getRoleColorCode()}>{seer.getRoleName()}</color>{SelfTaskText}</size>\r\n{main.RealNames[seer.PlayerId]}{SelfMark}";
+                
                 //適用
                 seer.RpcSetNamePrivate(SelfName, true);
 
@@ -608,7 +623,6 @@ namespace TownOfHost
                     }
                     if(AllTaskCount - CompletedTaskCount <= 0)
                         SeerKnowsImpostors = true;
-
                 }
 
                 //seerが死んでいる場合など、必要なときのみ第二ループを実行する

--- a/main.cs
+++ b/main.cs
@@ -625,6 +625,20 @@ namespace TownOfHost
                 if(ShowSnitchWarning && seer.getCustomRole().isImpostor())
                     SelfMark += $"<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>";
                 
+                //Markとは違い、改行してから追記されます。
+                string SelfSuffix = "";
+
+                if(seer.isBountyHunter() && main.b_target != null) {
+                    string targetName;
+                    if(!RealNames.TryGetValue(main.b_target.PlayerId, out targetName)) {
+                        if(main.b_target.AmOwner) targetName = SaveManager.PlayerName;
+                        else targetName = seer.name;
+                        RealNames[main.b_target.PlayerId] = targetName;
+                        TownOfHost.Logger.warn("プレイヤー" + main.b_target.PlayerId + "のRealNameが見つからなかったため、" + targetName + "を代入しました");
+                    }
+                    SelfSuffix = $"<size=1.5>Target:{targetName}</size>";
+                }
+                
                 //RealNameを取得 なければ現在の名前をRealNamesに書き込む
                 string SeerRealName;
                 if(!RealNames.TryGetValue(seer.PlayerId, out SeerRealName)) {
@@ -636,7 +650,8 @@ namespace TownOfHost
 
                 //seerの役職名とSelfTaskTextとseerのプレイヤー名とSelfMarkを合成
                 string SelfName = $"<size=1.5><color={seer.getRoleColorCode()}>{seer.getRoleName()}</color>{SelfTaskText}</size>\r\n{SeerRealName}{SelfMark}";
-                
+                SelfName += SelfSuffix == "" ? "" : "\r\n" + SelfSuffix;
+
                 //適用
                 seer.RpcSetNamePrivate(SelfName, true);
                 HudManagerPatch.LastSetNameDesyncCount++;

--- a/main.cs
+++ b/main.cs
@@ -584,6 +584,24 @@ namespace TownOfHost
         public static void NotifyRoles() {
             if(!AmongUsClient.Instance.AmHost) return;
             if(PlayerControl.AllPlayerControls == null) return;
+            foreach(var seer in PlayerControl.AllPlayerControls) {
+                string SelfTaskText = hasTasks(seer.Data, false) ? $"<color=#ffff00>({main.getTaskText(seer.Data.Tasks)})</color>" : "";
+                string SelfMark = "";
+                string SelfName = $"<size=1.5><color={seer.getRoleColorCode()}>{seer.getRoleName()}</color>{SelfTaskText}{SelfMark}</size>\r\n{main.RealNames[seer.PlayerId]}";
+                seer.RpcSetNamePrivate(SelfName, true);
+
+                if(seer.Data.IsDead)
+                foreach(var target in PlayerControl.AllPlayerControls) {
+                    if(target == seer) continue;
+                    string TargetTaskText = hasTasks(seer.Data, false) && seer.Data.IsDead ? $"<color=#ffff00>({main.getTaskText(seer.Data.Tasks)})</color>" : "";
+                    string TargetMark = "";
+                    string TargetRoleText = seer.Data.IsDead ? $"<size=1.5><color={target.getRoleColorCode()}>{target.getRoleName()}</color>{TargetTaskText}</size>\r\n" : "";
+                    string TargetName = $"{TargetRoleText}{main.RealNames[seer.PlayerId]}{TargetMark}";
+                    target.RpcSetNamePrivate(TargetName, true, seer);
+                }
+            }
+            /*
+
             foreach(PlayerControl p in PlayerControl.AllPlayerControls)
             {
                 string taskText = main.getTaskText(p.Data.Tasks);
@@ -623,7 +641,7 @@ namespace TownOfHost
                     if(p.isBountyHunter()) tmp += $"\r\n<size=1.5>{main.RealNames[main.b_target.PlayerId]}</size>";
                     if(!p.AmOwner) p.RpcSetNamePrivate(tmp,false);
                 }
-            }
+            }//*/
         }
         public static void CustomSyncAllSettings() {
             foreach(var pc in PlayerControl.AllPlayerControls) {

--- a/main.cs
+++ b/main.cs
@@ -635,7 +635,7 @@ namespace TownOfHost
                 string SelfName = $"<size=1.5><color={seer.getRoleColorCode()}>{seer.getRoleName()}</color>{SelfTaskText}</size>\r\n{SeerRealName}{SelfMark}";
                 
                 //適用
-                seer.RpcSetNamePrivate(SelfName, true);
+                seer.RpcSetNamePrivate(SelfName, false);
                 HudManagerPatch.LastSetNameDesyncCount++;
 
                 //他人用の変数定義
@@ -686,7 +686,7 @@ namespace TownOfHost
                     //全てのテキストを合成します。
                     string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetMark}";
                     //適用
-                    target.RpcSetNamePrivate(TargetName, true, seer);
+                    target.RpcSetNamePrivate(TargetName, false, seer);
                     HudManagerPatch.LastSetNameDesyncCount++;
 
                     TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.name + ":END");

--- a/main.cs
+++ b/main.cs
@@ -663,7 +663,7 @@ namespace TownOfHost
                     //Loversのハートマークなどを入れてください。
                     string TargetMark = "";
                     //タスク完了直前のSnitchにマークを表示
-                    if(target == target.isSnitch()) {
+                    if(target.isSnitch()) {
                         var taskState = target.getPlayerTaskState();
                         if(taskState.doExpose)
                             TargetMark += $"<color={main.getRoleColorCode(CustomRoles.Snitch)}>★</color>";

--- a/main.cs
+++ b/main.cs
@@ -597,6 +597,20 @@ namespace TownOfHost
                 //適用
                 seer.RpcSetNamePrivate(SelfName, true);
 
+                //他人用の変数定義
+                bool SeerKnowsImpostors = false;
+                if(seer.isSnitch()) {
+                    int CompletedTaskCount = 0;
+                    int AllTaskCount = 0;
+                    foreach(var task in seer.Data.Tasks) {
+                        AllTaskCount++;
+                        if(task.Complete) CompletedTaskCount++;
+                    }
+                    if(AllTaskCount - CompletedTaskCount <= 0)
+                        SeerKnowsImpostors = true;
+
+                }
+
                 //seerが死んでいる場合など、必要なときのみ第二ループを実行する
                 if(seer.Data.IsDead
                 //|| seer.isSnitch()


### PR DESCRIPTION
# 変更内容
- NotifyRolesをできるだけ読みやすくなるように書き直した
- ホストの名前はホストがRPCを介さずに管理します
- mod入りのホスト以外のプレイヤーの名前はプレイヤー自身がRPCを介さずに管理します
- modを持たないプレイヤーの名前はホストがRPCを介して管理します
- Lang系Dictionaryで例外が発生したときにmodのロードをキャンセルしないように変更
- また、例外が発生しているときはタイトル画面の中央に赤文字で警告が表示されます。