### PR TITLE
lastrolesが正しく表示されないバグの修正

### DIFF
--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -212,7 +212,11 @@ namespace TownOfHost
                 foreach(var pair in main.AllPlayerCustomRoles) {
                     ExtendedPlayerControl.RpcSetCustomRole(pair.Key, pair.Value);
                 }
-                main.lastAllPlayerCustomRoles = main.AllPlayerCustomRoles;
+                main.lastAllPlayerCustomRoles = new ();
+                foreach (var pair in main.AllPlayerCustomRoles)
+                {
+                    main.lastAllPlayerCustomRoles.Add(PlayerControl.AllPlayerControls[pair.Key].name, pair.Value);
+                }
 
                 HudManager.Instance.SetHudActive(true);
                 main.KillOrSpell = new Dictionary<byte, bool>();

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -212,10 +212,12 @@ namespace TownOfHost
                 foreach(var pair in main.AllPlayerCustomRoles) {
                     ExtendedPlayerControl.RpcSetCustomRole(pair.Key, pair.Value);
                 }
+
+                //名前、役職の記録
                 main.lastAllPlayerCustomRoles = new ();
                 foreach (var pair in main.AllPlayerCustomRoles)
                 {
-                    main.lastAllPlayerCustomRoles.Add(PlayerControl.AllPlayerControls[pair.Key].name, pair.Value);
+                    main.lastAllPlayerCustomRoles.Add(main.RealNames[pair.Key], pair.Value);
                 }
 
                 HudManager.Instance.SetHudActive(true);

--- a/main.cs
+++ b/main.cs
@@ -59,7 +59,7 @@ namespace TownOfHost
         public static float HideAndSeekImpVisionMin;
 
         public static Dictionary<byte, CustomRoles> AllPlayerCustomRoles;
-        public static Dictionary<byte, CustomRoles> lastAllPlayerCustomRoles;
+        public static Dictionary<string, CustomRoles> lastAllPlayerCustomRoles;
         public static bool SyncButtonMode;
         public static int SyncedButtonCount;
         public static int UsedButtonCount;
@@ -416,9 +416,9 @@ namespace TownOfHost
         public static void ShowLastRoles()
         {
             var text = "ロール割り当て:";
-            foreach(KeyValuePair<byte, CustomRoles> kvp in lastAllPlayerCustomRoles)
+            foreach(KeyValuePair<string, CustomRoles> kvp in lastAllPlayerCustomRoles)
             {
-                text += $"\n{RealNames[kvp.Key]}:{main.getRoleName(kvp.Value)}";
+                text += $"\n{kvp.Key}:{main.getRoleName(kvp.Value)}";
             }
             main.SendToAll(text);
         }


### PR DESCRIPTION
ゲーム終了後、ロビーに戻った時に前回のPlayerIdを参照しているため
lastrolesが正しく表示されません。
名前と役職を保存する形に修正しました。