### PR TITLE
Feature/last roles to result view

### DIFF
--- a/Modules/OptionController.cs
+++ b/Modules/OptionController.cs
@@ -134,6 +134,8 @@ namespace TownOfHost
             });
             Suffix.amVisible = () => AmongUsClient.Instance.AmHost;
             var forceJapanese = new PageObject(basePage, () => main.getLang(lang.ForceJapanese) + ": " + main.getOnOff(main.forceJapanese), false, () => main.forceJapanese = !main.forceJapanese);
+            var autoPrintLastRoles = new PageObject(basePage, () => main.getLang(lang.AutoDisplayLastRoles) + ": " + main.getOnOff(main.autoDisplayLastRoles), false, () => main.autoDisplayLastRoles = !main.autoDisplayLastRoles);
+            autoPrintLastRoles.amVisible = () => AmongUsClient.Instance.AmHost;
         }
         public static void SetPage(PageObject page)
         {

--- a/Modules/OptionController.cs
+++ b/Modules/OptionController.cs
@@ -134,7 +134,7 @@ namespace TownOfHost
             });
             Suffix.amVisible = () => AmongUsClient.Instance.AmHost;
             var forceJapanese = new PageObject(basePage, () => main.getLang(lang.ForceJapanese) + ": " + main.getOnOff(main.forceJapanese), false, () => main.forceJapanese = !main.forceJapanese);
-            var autoPrintLastRoles = new PageObject(basePage, () => main.getLang(lang.AutoDisplayLastRoles) + ": " + main.getOnOff(main.autoDisplayLastRoles), false, () => main.autoDisplayLastRoles = !main.autoDisplayLastRoles);
+            var autoPrintLastRoles = new PageObject(basePage, () => main.getLang(lang.AutoDisplayLastResult) + ": " + main.getOnOff(main.autoDisplayLastRoles), false, () => main.autoDisplayLastRoles = !main.autoDisplayLastRoles);
             autoPrintLastRoles.amVisible = () => AmongUsClient.Instance.AmHost;
         }
         public static void SetPage(PageObject page)

--- a/Patches/ChatBubblePatch.cs
+++ b/Patches/ChatBubblePatch.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using HarmonyLib;
+
+namespace TownOfHost.Patches
+{
+    [HarmonyPatch(typeof(ChatBubble), nameof(ChatBubble.SetRight))]
+    class ChatBubblePatch
+    {
+        public static void Postfix(ChatBubble __instance)
+        {
+           if(main.isChatCommand) __instance.SetLeft();
+        }
+    }
+}

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -11,6 +11,7 @@ using UnhollowerBaseLib;
 using TownOfHost;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Linq;
 
 namespace TownOfHost
 {
@@ -30,7 +31,7 @@ namespace TownOfHost
                     case "/win":
                     case "/winner":
                         canceled = true;
-                        main.SendToAll(main.winnerList);
+                        main.SendToAll("Winner: "+string.Join(",",main.winnerList.Select(b=> main.AllPlayerNames[b])));
                         break;
 
                     case "/l":

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -26,7 +26,8 @@ namespace TownOfHost
             var cancelVal = "";
             if (AmongUsClient.Instance.AmHost)
             {
-                switch(args[0])
+                main.isChatCommand = true;
+                switch (args[0])
                 {
                     case "/win":
                     case "/winner":
@@ -134,6 +135,7 @@ namespace TownOfHost
                             break;
 
                     default:
+                        main.isChatCommand = false;
                         break;
                 }
             }

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -40,6 +40,7 @@ namespace TownOfHost
             main.SpelledPlayer.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);
             foreach(var p in main.SpelledPlayer)
             {
+                main.ps.setDeathReason(p.PlayerId, PlayerState.DeathReason.Kill);
                 p.RpcMurderPlayer(p);
             }
             if (exiled != null)

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -45,6 +45,15 @@ namespace TownOfHost
                     __instance.MakePublicButton.color = Palette.DisabledClear;
                     __instance.privatePublicText.color = Palette.DisabledClear;
                 }
+
+                if (AmongUsClient.Instance.AmHost && main.autoDisplayLastRoles && main.AllPlayerCustomRoles.Count != 0)
+                {
+                    new LateTask(() =>
+                    {
+                        main.ShowLastRoles();
+                    }
+                        , 5f, "DisplayLastRoles");
+                }
             }
         }
 

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -50,6 +50,7 @@ namespace TownOfHost
                 {
                     new LateTask(() =>
                     {
+                        main.isChatCommand = true;
                         main.ShowLastRoles();
                     }
                         , 5f, "DisplayLastRoles");

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -121,11 +121,10 @@ namespace TownOfHost
                     TempData.winners.Add(new WinningPlayerData(pc.Data));
                 }
             }
-            main.winnerList = "winner:";
-            foreach (var wpd in TempData.winners)
+            main.winnerList = new();
+            foreach (var pc in winner)
             {
-                main.winnerList += wpd.PlayerName;
-                if(wpd != TempData.winners[TempData.winners.Count - 1]) main.winnerList += ", ";
+                main.winnerList.Add(pc.PlayerId);
             }
         }
     }

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -96,6 +96,7 @@ namespace TownOfHost
                 if(pc.isOpportunist() && !pc.Data.IsDead && main.currentWinner != CustomWinner.Draw && main.currentWinner != CustomWinner.Terrorist)
                 {
                     TempData.winners.Add(new WinningPlayerData(pc.Data));
+                    winner.Add(pc);
                     main.additionalwinners.Add(AdditionalWinners.Opportunist);
                 }
             }

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -71,8 +71,11 @@ namespace TownOfHost
                 TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
-                    if (p.PlayerId == main.ExiledJesterID)
+                    if (p.PlayerId == main.ExiledJesterID) {
                         TempData.winners.Add(new WinningPlayerData(p.Data));
+                        winner = new();
+                        winner.Add(p);
+                    }
                 }
             }
             if (main.currentWinner == CustomWinner.Terrorist && main.TerroristCount> 0)
@@ -81,7 +84,11 @@ namespace TownOfHost
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
                     if (p.PlayerId == main.WonTerroristID)
+                    {
                         TempData.winners.Add(new WinningPlayerData(p.Data));
+                        winner = new();
+                        winner.Add(p);
+                    }
                 }
             }
             //Opportunist

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -23,6 +23,14 @@ namespace TownOfHost
             if (!target.Data.IsDead || !AmongUsClient.Instance.AmHost)
                 return;
             Logger.SendToFile("MurderPlayer発生: " + __instance.name + "=>" + target.name);
+            if(__instance == target && __instance.getCustomRole() == CustomRoles.Sheriff)
+            {
+                main.ps.setDeathReason(__instance.PlayerId, PlayerState.DeathReason.Suicide);
+            }
+            else
+            {
+                main.ps.setDeathReason(target.PlayerId, PlayerState.DeathReason.Kill);
+            }
             //When Bait is killed
             if (target.getCustomRole() == CustomRoles.Bait && __instance.PlayerId != target.PlayerId)
             {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -214,11 +214,11 @@ namespace TownOfHost
                     ExtendedPlayerControl.RpcSetCustomRole(pair.Key, pair.Value);
                 }
 
-                //名前、役職の記録
-                main.lastAllPlayerCustomRoles = new ();
+                //名前の記録
+                main.AllPlayerNames = new ();
                 foreach (var pair in main.AllPlayerCustomRoles)
                 {
-                    main.lastAllPlayerCustomRoles.Add(main.RealNames[pair.Key], pair.Value);
+                    main.AllPlayerNames.Add(pair.Key,main.RealNames[pair.Key]);
                 }
 
                 HudManager.Instance.SetHudActive(true);

--- a/main.cs
+++ b/main.cs
@@ -438,7 +438,7 @@ namespace TownOfHost
             foreach (var kvp in cloneRoles)
             {
                 var id = kvp.Key;
-                text += $"\n　 {AllPlayerNames[id]} : {main.getRoleName(id)}";
+                text += $"\n　 {AllPlayerNames[id]} : {main.getRoleName(AllPlayerCustomRoles[id])}";
                 text += $" {main.getDeathReason(ps.deathReasons[id])}";
             }
             main.SendToAll(text);

--- a/main.cs
+++ b/main.cs
@@ -93,7 +93,7 @@ namespace TownOfHost
         public static bool canTerroristSuicideWin = false;
         public static List<byte> winnerList;
         public static List<(string, byte)> MessagesToSend;
-
+        public static bool autoDisplayLastRoles = false;
 
         public static int SetRoleCountToggle(int currentCount)
         {
@@ -984,6 +984,7 @@ namespace TownOfHost
                 {lang.RoleOptions, "役職設定"},
                 {lang.ModeOptions, "モード設定"},
                 {lang.ForceJapanese, "日本語に強制"},
+                {lang.AutoDisplayLastRoles,"最終役職の自動表示"},
                 {lang.VoteMode, "投票モード"},
                 {lang.Default, "デフォルト"},
                 {lang.Suicide, "切腹"},
@@ -1089,6 +1090,7 @@ namespace TownOfHost
                 {lang.RoleOptions, "Role Options"},
                 {lang.ModeOptions, "Mode Options"},
                 {lang.ForceJapanese, "Force Japanese"},
+                {lang.AutoDisplayLastRoles,"Auto Display Last Roles"},
                 {lang.VoteMode, "VoteMode"},
                 {lang.Default, "Default"},
                 {lang.Suicide, "Suicide"},
@@ -1285,6 +1287,7 @@ namespace TownOfHost
         RoleOptions,
         ModeOptions,
         ForceJapanese,
+        AutoDisplayLastRoles,
         VoteMode,
         Default,
         Suicide,

--- a/main.cs
+++ b/main.cs
@@ -429,7 +429,7 @@ namespace TownOfHost
 
         public static void ShowLastRoles()
         {
-            var text = "ロール割り当て:";
+            var text = getLang(lang.LastResult);
             Dictionary<byte,CustomRoles> cloneRoles = new(AllPlayerCustomRoles);
             foreach(var id in winnerList)
             {
@@ -986,7 +986,8 @@ namespace TownOfHost
                 {lang.RoleOptions, "役職設定"},
                 {lang.ModeOptions, "モード設定"},
                 {lang.ForceJapanese, "日本語に強制"},
-                {lang.AutoDisplayLastRoles,"最終役職の自動表示"},
+                {lang.AutoDisplayLastResult,"ゲーム結果の自動表示"},
+                {lang.LastResult,"ゲーム結果:"},
                 {lang.VoteMode, "投票モード"},
                 {lang.Default, "デフォルト"},
                 {lang.Suicide, "切腹"},
@@ -1092,7 +1093,8 @@ namespace TownOfHost
                 {lang.RoleOptions, "Role Options"},
                 {lang.ModeOptions, "Mode Options"},
                 {lang.ForceJapanese, "Force Japanese"},
-                {lang.AutoDisplayLastRoles,"Auto Display Last Roles"},
+                {lang.AutoDisplayLastResult,"Auto Display Last Result"},
+                {lang.LastResult,"Game Result:"},
                 {lang.VoteMode, "VoteMode"},
                 {lang.Default, "Default"},
                 {lang.Suicide, "Suicide"},
@@ -1289,7 +1291,8 @@ namespace TownOfHost
         RoleOptions,
         ModeOptions,
         ForceJapanese,
-        AutoDisplayLastRoles,
+        AutoDisplayLastResult,
+        LastResult,
         VoteMode,
         Default,
         Suicide,

--- a/main.cs
+++ b/main.cs
@@ -95,6 +95,8 @@ namespace TownOfHost
         public static List<(string, byte)> MessagesToSend;
         public static bool autoDisplayLastRoles = false;
 
+        public static bool isChatCommand = false;
+
         public static int SetRoleCountToggle(int currentCount)
         {
             if(currentCount > 0) return 0;


### PR DESCRIPTION
LastRolesをリザルト風に描き替えてみました。
・勝者から順に表示
・勝者には★マークを記載
・生存・死因を表示
・ホストがロビーに戻って5秒後に自動的に発言する機能の追加
・ホストでもコマンド結果は左寄せで他と同様に表示する

※#140ではPlayerIdの取り扱いかと思ったのですがRealNamesが
破壊されることが原因のようなので、別途名前とIdを保存しています。
※役職はAllPlayerCustomRolesを参照するように差し戻しました
※扱いやすいようにwinnerListの型を変更しています。
※PlayerStateがあまり使われていなかったので死因を拾うようにしています。
※ロビーに戻った直後にLastRolesを発言すると他者に届かない場合があるので5秒待ちました。
※ON・OFF設定はルートに追加しましたがモード設定内のほうがよいでしょうか？