### PR TITLE
シェイプシフト中に会議が始まると名前が戻らなくなるバグ修正

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -282,10 +282,13 @@ namespace TownOfHost {
             }, 0.4f + delay, "Fix Desync Reactor 2");
         }
 
-        public static string getRealName(this PlayerControl player) {
+        public static string getRealName(this PlayerControl player, bool isMeeting = false) {
+
             string RealName;
-            if(player.CurrentOutfitType == PlayerOutfitType.Shapeshifted)
+            if(player.CurrentOutfitType == PlayerOutfitType.Shapeshifted && isMeeting == false) {
                 return player.Data.Outfits[PlayerOutfitType.Shapeshifted].PlayerName;
+            }
+
             if(!main.RealNames.TryGetValue(player.PlayerId, out RealName)) {
                 RealName = player.name;
                 if(RealName == "Player(Clone)") return RealName;

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -175,13 +175,13 @@ namespace TownOfHost
                 Logger.SendToFile("緊急会議ボタンはあと" + (main.SyncedButtonCount - main.UsedButtonCount) + "回使用可能です。", LogLevel.Message);
             }
 
-            if(AmongUsClient.Instance.AmHost)
-            new LateTask(() => {
-                foreach(var pc in PlayerControl.AllPlayerControls) {
-                    pc.RpcSetName(pc.getRealName());
+            if (AmongUsClient.Instance.AmHost)
+            {
+                foreach (var pc in PlayerControl.AllPlayerControls)
+                {
+                    pc.RpcSetNamePrivate(pc.getRealName(isMeeting:true));
                 }
-            }, 3f, "SetName To Chat");
-
+            }
 
             foreach(var pva in __instance.playerStates) {
                 if(pva == null) continue;

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -153,7 +153,7 @@ namespace TownOfHost
         public static void Prefix(MeetingHud __instance)
         {
             main.witchMeeting = true;
-            main.NotifyRoles();
+            main.NotifyRoles(isMeeting:true);
             main.witchMeeting = false;
         }
         public static void Postfix(MeetingHud __instance)
@@ -177,10 +177,13 @@ namespace TownOfHost
 
             if (AmongUsClient.Instance.AmHost)
             {
-                foreach (var pc in PlayerControl.AllPlayerControls)
+                _ = new LateTask(() =>
                 {
-                    pc.RpcSetNamePrivate(pc.getRealName(isMeeting:true));
-                }
+                    foreach (var pc in PlayerControl.AllPlayerControls)
+                    {
+                        pc.RpcSetNamePrivate(pc.getRealName(isMeeting: true));
+                    }
+                }, 3f, "SetName To Chat");
             }
 
             foreach(var pva in __instance.playerStates) {

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -181,7 +181,7 @@ namespace TownOfHost
                 {
                     foreach (var pc in PlayerControl.AllPlayerControls)
                     {
-                        pc.RpcSetNamePrivate(pc.getRealName(isMeeting: true));
+                        pc.RpcSetName(pc.getRealName(isMeeting: true));
                     }
                 }, 3f, "SetName To Chat");
             }

--- a/main.cs
+++ b/main.cs
@@ -623,7 +623,7 @@ namespace TownOfHost
         public static PlayerControl getPlayerById(int PlayerId) {
             return PlayerControl.AllPlayerControls.ToArray().Where(pc => pc.PlayerId == PlayerId).FirstOrDefault();
         }
-        public static void NotifyRoles() {
+        public static void NotifyRoles(bool isMeeting = false) {
             if(!AmongUsClient.Instance.AmHost) return;
             if(PlayerControl.AllPlayerControls == null) return;
 
@@ -667,7 +667,7 @@ namespace TownOfHost
                 string SelfSuffix = "";
 
                 if(seer.isBountyHunter() && seer.getBountyTarget() != null) {
-                    string BountyTargetName = seer.getBountyTarget().getRealName();
+                    string BountyTargetName = seer.getBountyTarget().getRealName(isMeeting);
                     SelfSuffix = $"<size=1.5>Target:{BountyTargetName}</size>";
                 }
                 if(seer.isWitch()) {
@@ -676,7 +676,7 @@ namespace TownOfHost
                 }
                 
                 //RealNameを取得 なければ現在の名前をRealNamesに書き込む
-                string SeerRealName = seer.getRealName();
+                string SeerRealName = seer.getRealName(isMeeting);
 
                 //seerの役職名とSelfTaskTextとseerのプレイヤー名とSelfMarkを合成
                 string SelfName = $"<size=1.5><color={seer.getRoleColorCode()}>{seer.getRoleName()}</color>{SelfTaskText}</size>\r\n{SeerRealName}{SelfMark}";
@@ -720,7 +720,7 @@ namespace TownOfHost
                     string TargetRoleText = seer.Data.IsDead ? $"<size=1.5><color={target.getRoleColorCode()}>{target.getRoleName()}</color>{TargetTaskText}</size>\r\n" : "";
                     
                     //RealNameを取得 なければ現在の名前をRealNamesに書き込む
-                    string TargetPlayerName = target.getRealName();
+                    string TargetPlayerName = target.getRealName(isMeeting);
 
                     //ターゲットのプレイヤー名の色を書き換えます。
                     if(SeerKnowsImpostors && target.getCustomRole().isImpostor()) //Seerがインポスターが誰かわかる状態


### PR DESCRIPTION
[#ticket-0047](https://discord.com/channels/931559416413687848/947141630392172564/947165562881060904)

``LateTask``で遅延実行や``RpcSetName``だと名前変更が反映されないので、遅延の削除と``RpcSetNamePrivate``に変更しています。


・テストシナリオ
シェイプシフト中に会議を行い、会議中～会議終了後に全視点で名前が戻っていることを確認する

| シェイプシフト実行者 | 結果 |
| --- | --- | 
| ホスト | OK |
| 非ホストのMOD PC | OK |
| 非MOD | OK | 