### PR TITLE
ロビーでシリアルキラーが死ぬバグを修正

### DIFF
--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -157,6 +157,7 @@ namespace TownOfHost
                 }
             }
             main.BitPlayers = new Dictionary<byte, (byte, float)>();
+            main.SerialKillerTimer = new Dictionary<byte, float>();
             main.VisibleTasksCount = false;
             if(AmongUsClient.Instance.AmHost) {
                 PlayerControl.LocalPlayer.RpcSyncSettings(main.RealOptionsData);


### PR DESCRIPTION
outropatchにシリアルキラーが死ぬ時間をリセットする処理を追加