### PR TITLE
fix/CustomTaskCountsPatch

### DIFF
--- a/Patches/RecomputeTaskPatch.cs
+++ b/Patches/RecomputeTaskPatch.cs
@@ -25,10 +25,10 @@ namespace TownOfHost
                 var hasTasks = main.hasTasks(p);
                 if (hasTasks)
                 {
-//                    if(p.Tasks == null) {
-//                        Logger.warn("警告:" + p.PlayerName + "のタスクがnullです");
-//                        continue;//これより下を実行しない
-//                    }
+                    if(p.Tasks == null) {
+                        Logger.warn("警告:" + p.PlayerName + "のタスクがnullです");
+                        continue;//これより下を実行しない
+                    }
                     foreach (var task in p.Tasks)
                     {
                         __instance.TotalTasks++;


### PR DESCRIPTION
NullReferenceException対策の復活

初回RecomputeTaskCountsのコール時は役職決定前のためhasTasksがTrueで返ってきてしまいますが
PlayerInfo.taskはnullであるためNullReferenceExceptionが発生します。
役職設定後に再計算されるようなのでそのままでもログが残る以外問題ないようですが、
念のためnull検出したほうが良いかと思います。