### PR TITLE
Feature/DisableResetBreakerTask

### DIFF
--- a/Modules/OptionController.cs
+++ b/Modules/OptionController.cs
@@ -104,6 +104,7 @@ namespace TownOfHost
             var dUnlockSafe = new PageObject(DisableTasks, () => main.getLang(lang.DisableUnlockSafeTask) + ": " + main.getOnOff(main.DisableUnlockSafe), true, () => {main.DisableUnlockSafe = !main.DisableUnlockSafe;});
             var dUploadData = new PageObject(DisableTasks, () => main.getLang(lang.DisableUploadDataTask) + ": " + main.getOnOff(main.DisableUploadData), true, () => {main.DisableUploadData = !main.DisableUploadData;});
             var dStartReactor = new PageObject(DisableTasks, () => main.getLang(lang.DisableStartReactorTask) + ": " + main.getOnOff(main.DisableStartReactor), true, () => {main.DisableStartReactor = !main.DisableStartReactor;});
+            var dResetBreaker = new PageObject(DisableTasks, () => main.getLang(lang.DisableResetBreakerTask) + ": " + main.getOnOff(main.DisableResetBreaker), true, () => {main.DisableResetBreaker = !main.DisableResetBreaker;});
 
             var RandomMapsMode = new PageObject(ModeOptions, lang.RandomMapsMode);
             var RandomMapsModeEnabled = new PageObject(RandomMapsMode, () => main.getLang(lang.RandomMapsMode) + ": " + main.getOnOff(main.RandomMapsMode), true, () => main.RandomMapsMode = !main.RandomMapsMode);

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -79,6 +79,7 @@ namespace TownOfHost
                     bool UnlockSafeDisabled = reader.ReadBoolean();
                     bool UploadDataDisabled = reader.ReadBoolean();
                     bool StartReactorDisabled = reader.ReadBoolean();
+                    bool ResetBreakerDisabled = reader.ReadBoolean();
                     int VampireKillDelay = reader.ReadInt32();
                     int SabotageMasterSkillLimit = reader.ReadInt32();
                     bool SabotageMasterFixesDoors = reader.ReadBoolean();
@@ -129,6 +130,7 @@ namespace TownOfHost
                         UnlockSafeDisabled,
                         UploadDataDisabled,
                         StartReactorDisabled,
+                        ResetBreakerDisabled,
                         VampireKillDelay,
                         SabotageMasterSkillLimit,
                         SabotageMasterFixesDoors,
@@ -217,6 +219,7 @@ namespace TownOfHost
                 bool UnlockSafeDisabled,
                 bool UploadDataDisabled,
                 bool StartReactorDisabled,
+                bool ResetBreakerDisabled,
                 int VampireKillDelay,
                 int SabotageMasterSkillLimit,
                 bool SabotageMasterFixesDoors,
@@ -269,6 +272,7 @@ namespace TownOfHost
             main.DisableUnlockSafe = UnlockSafeDisabled;
             main.DisableUploadData = UploadDataDisabled;
             main.DisableStartReactor = StartReactorDisabled;
+            main.DisableResetBreaker = ResetBreakerDisabled;
 
             main.currentWinner = CustomWinner.Default;
             main.CustomWinTrigger = false;

--- a/Patches/TaskAssignPatch.cs
+++ b/Patches/TaskAssignPatch.cs
@@ -28,6 +28,7 @@ namespace TownOfHost
                 if (task.TaskType == TaskTypes.UnlockSafe && main.DisableUnlockSafe) disabledTasks.Add(task);//金庫タスク
                 if (task.TaskType == TaskTypes.UploadData && main.DisableUploadData) disabledTasks.Add(task);//アップロードタスク
                 if (task.TaskType == TaskTypes.StartReactor && main.DisableStartReactor) disabledTasks.Add(task);//リアクターの3x3タスク
+                if (task.TaskType == TaskTypes.ResetBreakers && main.DisableResetBreaker) disabledTasks.Add(task);//レバータスク
             }
             foreach (var task in disabledTasks)
             {

--- a/main.cs
+++ b/main.cs
@@ -72,6 +72,7 @@ namespace TownOfHost
         public static bool DisableUnlockSafe;
         public static bool DisableUploadData;
         public static bool DisableStartReactor;
+        public static bool DisableResetBreaker;
         //ランダムマップ
         public static bool AddedTheSkeld;
         public static bool AddedMIRAHQ;
@@ -540,6 +541,7 @@ namespace TownOfHost
             writer.Write(DisableUnlockSafe);
             writer.Write(DisableUploadData);
             writer.Write(DisableStartReactor);
+            writer.Write(DisableResetBreaker);
             writer.Write(VampireKillDelay);
             writer.Write(SabotageMasterSkillLimit);
             writer.Write(SabotageMasterFixesDoors);
@@ -832,6 +834,7 @@ namespace TownOfHost
             DisableUnlockSafe = false;
             DisableUploadData = false;
             DisableStartReactor = false;
+            DisableResetBreaker = false;
 
             VampireKillDelay = 10;
             SerialKillerCooldownDiscount = 50;
@@ -975,6 +978,7 @@ namespace TownOfHost
                 {lang.DisableUnlockSafeTask, "金庫タスクを無効化する"},
                 {lang.DisableUploadDataTask, "ダウンロードタスクを無効化する"},
                 {lang.DisableStartReactorTask, "原子炉起動タスクを無効化する"},
+                {lang.DisableResetBreakerTask, "ブレーカーリセットタスクを無効化する"},
                 {lang.AddedTheSkeld, "TheSkeldを追加"},
                 {lang.AddedMIRAHQ, "MIRAHQを追加"},
                 {lang.AddedPolus, "Polusを追加"},
@@ -1082,6 +1086,7 @@ namespace TownOfHost
                 {lang.DisableUnlockSafeTask, "Disable UnlockSafe Tasks"},
                 {lang.DisableUploadDataTask, "Disable UploadData Tasks"},
                 {lang.DisableStartReactorTask, "Disable StartReactor Tasks"},
+                {lang.DisableResetBreakerTask, "Disable ResetBreaker Tasks"},
                 {lang.AddedTheSkeld, "Added TheSkeld"},
                 {lang.AddedMIRAHQ, "Added MIRAHQ"},
                 {lang.AddedPolus, "Added Polus"},
@@ -1271,6 +1276,7 @@ namespace TownOfHost
         DisableUnlockSafeTask,
         DisableUploadDataTask,
         DisableStartReactorTask,
+        DisableResetBreakerTask,
         SuffixMode,
         WhenSkipVote,
         WhenNonVote,


### PR DESCRIPTION
0084-レバータスク削除の要望です。
テスト内容
・エアシップでリセットブレーカータスク無効化設定を有効、無効にした時、ロングタスク99にした時の動作を10回づつ

有効時
10回全部レバータスクは出現しなかった。

無効時
10回全部レバータスクが出現した。

動作確認済みで、問題ないと判断しております。
先ほどベースとmain.にしてプルリク送ってしまいましたので、クローズしてベースをv1.5にして再度送っております。