### PR TITLE
Fix/SKMadmateのサイドキック判定修正

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -44,7 +44,7 @@ namespace TownOfHost
         public static void Prefix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
         {
             //シェイプシフト解除時にはサイドキック判定しない
-            if (target.getCustomRole() == CustomRoles.Shapeshifter) return;
+            if (target == __instance) return;
             if(main.CanMakeMadmateCount > main.SKMadmateNowCount)//Warlockとserialkillerを除く処理を追加する。
             {//変身したとき一番近い人をマッドメイトにする処理
                 Vector2 __instancepos = __instance.transform.position;//変身者の位置

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -43,6 +43,8 @@ namespace TownOfHost
     {
         public static void Prefix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
         {
+            //シェイプシフト解除時にはサイドキック判定しない
+            if (target.getCustomRole() == CustomRoles.Shapeshifter) return;
             if(main.CanMakeMadmateCount > main.SKMadmateNowCount)//Warlockとserialkillerを除く処理を追加する。
             {//変身したとき一番近い人をマッドメイトにする処理
                 Vector2 __instancepos = __instance.transform.position;//変身者の位置

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -58,6 +58,8 @@ namespace TownOfHost
                         mpdistance.Add(p,dis);
                     }
                 }
+                //対象がいないときは処理しない
+                if (mpdistance.Count() == 0) return;
                 var min = mpdistance.OrderBy(c => c.Value).FirstOrDefault();//一番値が小さい
                 PlayerControl targetm = min.Key;
                 targetm.SetCustomRole(CustomRoles.SKMadmate);


### PR DESCRIPTION
シェイプシフト解除時にはサイドキック判定をしないよう修正
サイドキック対象がいない場合、例外が発生してシェイプシフトできないバグの修正