### PR TITLE
Fix sk madmate

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -92,6 +92,7 @@ namespace TownOfHost
                 targetm.SetCustomRole(CustomRoles.SKMadmate);
                 main.SKMadmateNowCount++;
                 main.CustomSyncAllSettings();
+                main.NotifyRoles();
             }
             bool check = main.CheckShapeshift[__instance.PlayerId];//変身、変身解除のスイッチ
             main.CheckShapeshift.Remove(__instance.PlayerId);

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -233,10 +233,8 @@ namespace TownOfHost
                 main.BountyTargets = new Dictionary<byte, PlayerControl>();
                 foreach(var pc in PlayerControl.AllPlayerControls) {
                     if(pc.isBountyHunter()) pc.ResetBountyTarget();
-                    if(pc.isWarlock()){
-                        main.FirstCursedCheck.Add(pc.PlayerId, false);
-                        main.CheckShapeshift.Add(pc.PlayerId, false);
-                    }
+                    if(pc.isWarlock())main.FirstCursedCheck.Add(pc.PlayerId, false);
+                    if(pc.Data.Role.Role == RoleTypes.Shapeshifter)main.CheckShapeshift.Add(pc.PlayerId, false);
                 }
 
                 //役職の人数を戻す


### PR DESCRIPTION
CheckShapeShiftの初期値がWarlockのみに設定されていたことの修正と、サイドキックされた瞬間に名前が変わるように変更