### PR TITLE
fix/TaskCountCustomize

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -264,6 +264,16 @@ namespace TownOfHost {
                 AllTasksCount++;
                 if(task.Complete) CompletedTaskCount++;
             }
+            switch (player.getCustomRole())
+            {
+                case CustomRoles.MadSnitch:
+                    AllTasksCount = main.MadSnitchTasks;
+                    break;
+                default:
+                    break;
+            }
+            //調整後のタスク量までしか表示しない
+            CompletedTaskCount = Math.Min(AllTasksCount, CompletedTaskCount);
             Logger.info(player.name + ": " + AllTasksCount + ", " + CompletedTaskCount);
             return new TaskState(AllTasksCount, CompletedTaskCount);
         }

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -264,14 +264,18 @@ namespace TownOfHost {
                 AllTasksCount++;
                 if(task.Complete) CompletedTaskCount++;
             }
+            //役職ごとにタスク量の調整を行う
+            var adjustedTasksCount = AllTasksCount;
             switch (player.getCustomRole())
             {
                 case CustomRoles.MadSnitch:
-                    AllTasksCount = main.MadSnitchTasks;
+                    adjustedTasksCount = main.MadSnitchTasks;
                     break;
                 default:
                     break;
             }
+            //タスク数が通常タスクより多い場合は再設定が必要
+            AllTasksCount = Math.Min(adjustedTasksCount, AllTasksCount);
             //調整後のタスク量までしか表示しない
             CompletedTaskCount = Math.Min(AllTasksCount, CompletedTaskCount);
             Logger.info(player.name + ": " + AllTasksCount + ", " + CompletedTaskCount);

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -196,7 +196,7 @@ namespace TownOfHost
 
                     var RoleTextData = main.GetRoleText(pc);
                     RoleTextMeeting.text = RoleTextData.Item1;
-                    if (main.VisibleTasksCount && main.hasTasks(pc.Data, false)) RoleTextMeeting.text += " <color=#e6b422>(" + main.getTaskText(pc.Data) + ")</color>";
+                    if (main.VisibleTasksCount && main.hasTasks(pc.Data, false)) RoleTextMeeting.text += " <color=#e6b422>(" + main.getTaskText(pc) + ")</color>";
                     RoleTextMeeting.color = RoleTextData.Item2;
                     if (pva.TargetPlayerId == PlayerControl.LocalPlayer.PlayerId) RoleTextMeeting.enabled = true;
                     else if (main.VisibleTasksCount && PlayerControl.LocalPlayer.Data.IsDead) RoleTextMeeting.enabled = true;

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -140,14 +140,8 @@ namespace TownOfHost
                 }
             }
             if(target.isMadGuardian()) {
-                var isTaskFinished = true;
-                foreach(var task in target.Data.Tasks) {
-                    if(!task.Complete) {
-                        isTaskFinished = false;
-                        break;
-                    }
-                }
-                if(isTaskFinished) {
+                var taskState = target.getPlayerTaskState();
+                if(taskState.isTaskFinished) {
                     __instance.RpcGuardAndKill(target);
                     if(main.MadGuardianCanSeeBarrier) {
                         //MadGuardian視点用
@@ -365,7 +359,7 @@ namespace TownOfHost
                     if(!__instance.AmOwner) __instance.nameText.text = __instance.name;
                 }
                 if (main.VisibleTasksCount && main.hasTasks(__instance.Data, false)) //他プレイヤーでVisibleTasksCountは有効なおかつタスクがあるなら
-                    RoleText.text += $" <color=#e6b422>({main.getTaskText(__instance.Data)})</color>"; //ロールの横にタスク表示
+                    RoleText.text += $" <color=#e6b422>({main.getTaskText(__instance)})</color>"; //ロールの横にタスク表示
                 
 
                 //変数定義

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -373,7 +373,7 @@ namespace TownOfHost
                 //タスクを終わらせたMadSnitchがインポスターを確認できる
                 if(PlayerControl.LocalPlayer.isMadSnitch() && //LocalPlayerがMadSnitch
                     __instance.getCustomRole().isImpostor() && //__instanceがインポスター
-                    PlayerControl.LocalPlayer.getPlayerTaskState().CompletedTasksCount == main.MadSnitchTasks) //LocalPlayerのタスクが終わっている
+                    PlayerControl.LocalPlayer.getPlayerTaskState().isTaskFinished) //LocalPlayerのタスクが終わっている
                 {
                     RealName = $"<color={main.getRoleColorCode(CustomRoles.Impostor)}>{RealName}</color>"; //__instanceの名前を赤色で表示
                 }

--- a/main.cs
+++ b/main.cs
@@ -757,7 +757,7 @@ namespace TownOfHost
                 }
                 if(seer.isMadSnitch()) {
                     var TaskState = seer.getPlayerTaskState();
-                    if(TaskState.CompletedTasksCount == MadSnitchTasks)
+                    if(TaskState.isTaskFinished)
                         SeerKnowsImpostors = true;
                 }
 


### PR DESCRIPTION
タスクの計算はgetPlayerTaskState()を使うように修正
通常のタスク数より制限タスク数のほうが多かった時の処理を追加

タスクのカウント処理が複数個所存在したのでgetPlayerTaskState()に統一するよう修正しました。
クルー、テロリスト、マッドガーディアン、マッドスニッチで動作確認しました。