### PR TITLE
Fix/NotifyRolesLag

### DIFF
--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -29,9 +29,10 @@ namespace TownOfHost
             return data;
         }
         public void Add(byte seerId, byte targetId, string color) {
-            NameColors.Add(new NameColorData(seerId, targetId, color));
+            Add(new NameColorData(seerId, targetId, color));
         }
         public void Add(NameColorData data) {
+            Remove(data.seerId, data.targetId);
             NameColors.Add(data);
         }
         public void Remove(byte seerId, byte targetId) {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -95,12 +95,15 @@ namespace TownOfHost
                     }
                 }
                 if(isTaskFinished) {
+                    int dataCountBefore = NameColorManager.Instance.NameColors.Count;
+
                     NameColorManager.Instance.RpcAdd(__instance.PlayerId, target.PlayerId, "#ff0000");
                     if(main.MadGuardianCanSeeWhoTriedToKill)
                         NameColorManager.Instance.RpcAdd(target.PlayerId, __instance.PlayerId, "#ff0000");
                     
                     main.BlockKilling[__instance.PlayerId] = false;
-                    main.NotifyRoles();
+                    if(dataCountBefore != NameColorManager.Instance.NameColors.Count)
+                        main.NotifyRoles();
                     return false;
                 }
             }

--- a/main.cs
+++ b/main.cs
@@ -730,14 +730,46 @@ namespace TownOfHost
                         SeerKnowsImpostors = true;
                 }
 
+                //二週目のループを実行するかどうかを決める処理
+                //このリストに入ってあるいずれかのFuncがtrueを返したとき、そのプレイヤーをtargetとしたループを実行する
+                //このリストの中身が空の時、foreach自体が実行されなくなる
+                List<Func<PlayerControl, bool>> conditions = new List<Func<PlayerControl, bool>>();
+                
+                //seerが死んでいる
+                if(seer.Data.IsDead) 
+                    //常時
+                    conditions.Add(target => true);
+                
+                //seerがインポスターを知っている
+                if(SeerKnowsImpostors) 
+                    //targetがインポスター
+                    conditions.Add(target => target.getCustomRole().isImpostor());
+
+                //seerがインポスターで、タスクが終わりそうなSnitchがいる
+                if(seer.getCustomRole().isImpostor() && ShowSnitchWarning) 
+                    //targetがSnitch
+                    conditions.Add(target => target.isSnitch());
+
+                //seer視点用の名前色データが一つ以上ある
+                if(NameColorManager.Instance.GetDatasBySeer(seer.PlayerId).Count > 0) 
+                    //seer視点用のtargetに対する名前色データが存在する
+                    conditions.Add(target => NameColorManager.Instance.GetData(seer.PlayerId, target.PlayerId).color != null);
+                
                 //seerが死んでいる場合など、必要なときのみ第二ループを実行する
-                if(seer.Data.IsDead //seerが死んでいる
-                || SeerKnowsImpostors //seerがインポスターを知っている状態
-                || (seer.getCustomRole().isImpostor() && ShowSnitchWarning) //seerがインポスターで、タスクが終わりそうなSnitchがいる
-                || NameColorManager.Instance.GetDatasBySeer(seer.PlayerId).Count > 0 //seer視点用の名前色データが一つ以上ある
-                ) foreach(var target in PlayerControl.AllPlayerControls) {
+                if(conditions.Count > 0) foreach(var target in PlayerControl.AllPlayerControls) {
                     //targetがseer自身の場合は何もしない
                     if(target == seer) continue;
+
+                    //conditions内のデータによる判定
+                    bool doCancel = true;
+                    foreach(var func in conditions) {
+                        if(func(target)) {
+                            doCancel = false;
+                            break;
+                        }
+                    }
+                    if(doCancel) continue;
+                    
                     TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.name + ":START","NotifyRoles");
 
                     //他人のタスクはtargetがタスクを持っているかつ、seerが死んでいる場合のみ表示されます。それ以外の場合は空になります。


### PR DESCRIPTION
NotifyRolesを最適化しまし、キルボタン連打などでNotifyRolesを連続して実行した場合にネットワークエラーが発生しないようにしました。
# 修正内容の詳細
- 第二ループの処理を必要なプレイヤーがtargetの時にのみ実行するよう変更
- MadGuardianが斬られたとき、NameColorManagerのデータ数に変化がなければNotifyRolesを実行しないよう変更