### PR TITLE
Rename/RPC

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -159,7 +159,7 @@ namespace TownOfHost {
             writer.Write(KilledById);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
 
-            RPCProcedure.BeKilled(player.PlayerId, KilledById);
+            RPC.BeKilled(player.PlayerId, KilledById);
         }*/
         public static void CustomSyncSettings(this PlayerControl player) {
             if(player == null || !AmongUsClient.Instance.AmHost) return;

--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -49,7 +49,7 @@ namespace TownOfHost
 
             AmongUsClient.Instance.FinishRpcImmediately(writer);
 
-            RPCProcedure.AddNameColorData(seerId, targetId, color);
+            RPC.AddNameColorData(seerId, targetId, color);
         }
         public void RpcRemove(byte seerId, byte targetId) {
             if(!AmongUsClient.Instance.AmHost) return;
@@ -59,7 +59,7 @@ namespace TownOfHost
             writer.Write(targetId);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
 
-            RPCProcedure.RemoveNameColorData(seerId, targetId);
+            RPC.RemoveNameColorData(seerId, targetId);
         }
         public void RpcReset() {
             if(!AmongUsClient.Instance.AmHost) return;
@@ -67,7 +67,7 @@ namespace TownOfHost
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.ResetNameColorData, SendOption.Reliable, -1);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
 
-            RPCProcedure.ResetNameColorData();
+            RPC.ResetNameColorData();
         }
 
         public NameColorManager() {

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -91,7 +91,7 @@ namespace TownOfHost
                     int BountyFailureKillCooldown = reader.ReadInt32();
                     int BHDefaultKillCooldown = reader.ReadInt32();
                     int ShapeMasterShapeshiftDuration = reader.ReadInt32();
-                    RPCProcedure.SyncCustomSettings(
+                    RPC.SyncCustomSettings(
                         Options.roleCounts,
                         IsHideAndSeek,
                         NoGameEnd,
@@ -140,24 +140,24 @@ namespace TownOfHost
                     break;
                 case (byte)CustomRPC.JesterExiled:
                     byte exiledJester = reader.ReadByte();
-                    RPCProcedure.JesterExiled(exiledJester);
+                    RPC.JesterExiled(exiledJester);
                     break;
                 case (byte)CustomRPC.TerroristWin:
                     byte wonTerrorist = reader.ReadByte();
-                    RPCProcedure.TerroristWin(wonTerrorist);
+                    RPC.TerroristWin(wonTerrorist);
                     break;
                 case (byte)CustomRPC.EndGame:
-                    RPCProcedure.EndGame();
+                    RPC.EndGame();
                     break;
                 case (byte)CustomRPC.PlaySound:
                     byte playerID = reader.ReadByte();
                     Sounds sound = (Sounds)reader.ReadByte();
-                    RPCProcedure.PlaySound(playerID, sound);
+                    RPC.PlaySound(playerID, sound);
                     break;
                 case (byte)CustomRPC.SetCustomRole:
                     byte CustomRoleTargetId = reader.ReadByte();
                     CustomRoles role = (CustomRoles)reader.ReadByte();
-                    RPCProcedure.SetCustomRole(CustomRoleTargetId, role);
+                    RPC.SetCustomRole(CustomRoleTargetId, role);
                     break;
                 case (byte)CustomRPC.SetBountyTarget:
                     byte HunterId = reader.ReadByte();
@@ -174,20 +174,20 @@ namespace TownOfHost
                     byte addSeerId = reader.ReadByte();
                     byte addTargetId = reader.ReadByte();
                     string color = reader.ReadString();
-                    RPCProcedure.AddNameColorData(addSeerId, addTargetId, color);
+                    RPC.AddNameColorData(addSeerId, addTargetId, color);
                     break;
                 case (byte)CustomRPC.RemoveNameColorData:
                     byte removeSeerId = reader.ReadByte();
                     byte removeTargetId = reader.ReadByte();
-                    RPCProcedure.RemoveNameColorData(removeSeerId, removeTargetId);
+                    RPC.RemoveNameColorData(removeSeerId, removeTargetId);
                     break;
                 case (byte)CustomRPC.ResetNameColorData:
-                    RPCProcedure.ResetNameColorData();
+                    RPC.ResetNameColorData();
                     break;
             }
         }
     }
-    static class RPCProcedure {
+    static class RPC {
         public static void SyncCustomSettings(
                 Dictionary<CustomRoles,int> roleCounts,
                 bool isHideAndSeek,

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -239,7 +239,7 @@ namespace TownOfHost
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TerroristWin, Hazel.SendOption.Reliable, -1);
                 writer.Write(Terrorist.PlayerId);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
-                RPCProcedure.TerroristWin(Terrorist.PlayerId);
+                RPC.TerroristWin(Terrorist.PlayerId);
             }
         }
         public static void SendMessage(string text, byte sendTo = byte.MaxValue)

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -18,7 +18,7 @@ namespace TownOfHost
             {
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
-                RPCProcedure.EndGame();
+                RPC.EndGame();
             }
             if (Input.GetKeyDown(KeyCode.LeftShift) && GameStartManager._instance && AmongUsClient.Instance.AmHost)
             {

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -48,7 +48,7 @@ namespace TownOfHost
                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.JesterExiled, Hazel.SendOption.Reliable, -1);
                     writer.Write(exiled.PlayerId);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
-                    RPCProcedure.JesterExiled(exiled.PlayerId);
+                    RPC.JesterExiled(exiled.PlayerId);
                 }
                 if (role == CustomRoles.Terrorist && AmongUsClient.Instance.AmHost)
                 {

--- a/main.cs
+++ b/main.cs
@@ -140,7 +140,7 @@ namespace TownOfHost
         public static void PlaySoundRPC(byte PlayerID, Sounds sound)
         {
             if (AmongUsClient.Instance.AmHost)
-                RPCProcedure.PlaySound(PlayerID, sound);
+                RPC.PlaySound(PlayerID, sound);
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.PlaySound, Hazel.SendOption.Reliable, -1);
             writer.Write(PlayerID);
             writer.Write((byte)sound);


### PR DESCRIPTION
- RPCProcedureからRPCへクラス名変更
理由：『Remote Procedure Call Procedure』となり意味が重複するため