### PR TITLE
Fix/death reason

### DIFF
--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -25,6 +25,7 @@ namespace TownOfHost {
             Vote,
             Suicide,
             Spell,
+            Bite,
             etc = -1
         }
     }

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -5,12 +5,23 @@ namespace TownOfHost {
         
         static PlayerState()
         {
-            foreach(var p in PlayerControl.AllPlayerControls)
+            Init();
+        }
+
+        public static void Init()
+        {
+            players = new();
+            isDead = new();
+            deathReasons = new();
+            isDead = new();
+
+            foreach (var p in PlayerControl.AllPlayerControls)
             {
                 players.Add(p.PlayerId);
                 isDead.Add(p.PlayerId,false);
                 deathReasons.Add(p.PlayerId,DeathReason.etc);
             }
+
         }
         public static List<byte> players = new List<byte>();
         public static Dictionary<byte,bool> isDead = new Dictionary<byte, bool>();

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -15,12 +15,9 @@ namespace TownOfHost
             if (!target.Data.IsDead || !AmongUsClient.Instance.AmHost)
                 return;
             Logger.SendToFile("MurderPlayer発生: " + __instance.name + "=>" + target.name);
-            if(__instance == target && __instance.getCustomRole() == CustomRoles.Sheriff)
+            if (PlayerState.getDeathReason(target.PlayerId)==PlayerState.DeathReason.etc)
             {
-                PlayerState.setDeathReason(__instance.PlayerId, PlayerState.DeathReason.Suicide);
-            }
-            else
-            {
+                //死因が設定されていない場合は死亡判定
                 PlayerState.setDeathReason(target.PlayerId, PlayerState.DeathReason.Kill);
             }
             //When Bait is killed
@@ -161,6 +158,7 @@ namespace TownOfHost
                 }
 
                 if(!target.canBeKilledBySheriff()) {
+                    PlayerState.setDeathReason(__instance.PlayerId, PlayerState.DeathReason.Suicide);
                     __instance.RpcMurderPlayer(__instance);
                     return false;
                 }
@@ -264,6 +262,7 @@ namespace TownOfHost
                 {
                     if (bp.Key == pc.PlayerId && !pc.Data.IsDead)
                     {
+                        PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Bite);
                         pc.RpcMurderPlayer(pc);
                         RPC.PlaySoundRPC(bp.Value.Item1, Sounds.KillSound);
                         Logger.SendToFile("Vampireに噛まれている" + pc.name + "を自爆させました。");
@@ -322,6 +321,7 @@ namespace TownOfHost
                         byte vampireID = main.BitPlayers[__instance.PlayerId].Item1;
                         if (!__instance.Data.IsDead)
                         {
+                            PlayerState.setDeathReason(__instance.PlayerId, PlayerState.DeathReason.Bite);
                             __instance.RpcMurderPlayer(__instance);
                             RPC.PlaySoundRPC(vampireID, Sounds.KillSound);
                             Logger.SendToFile("Vampireに噛まれている" + __instance.name + "を自爆させました。");
@@ -342,6 +342,7 @@ namespace TownOfHost
                     {
                         if(!__instance.Data.IsDead)
                         {
+                            PlayerState.setDeathReason(__instance.PlayerId, PlayerState.DeathReason.Suicide);
                             __instance.RpcMurderPlayer(__instance);
                             RPC.PlaySoundRPC(__instance.PlayerId, Sounds.KillSound);
                         }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -9,6 +9,8 @@ namespace TownOfHost
     {
         public static void Postfix(AmongUsClient __instance)
         {//注:この時点では役職は設定されていません。
+            PlayerState.Init();
+
             main.currentWinner = CustomWinner.Default;
             main.CustomWinTrigger = false;
             main.OptionControllerIsEnable = false;

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -146,6 +146,7 @@ DeathReason.Kill,Kill,死亡
 DeathReason.Vote,Vote,追放
 DeathReason.Suicide,Suicide,自爆
 DeathReason.Spell,Spelled,呪殺
+DeathReason.Bite,Bited,噛殺
 DeathReason.etc,Living,生存
 Win,Wins,勝利
 CanTerroristSuicideWin,Can Terrorist Suicide Win,テロリストの自殺勝ち


### PR DESCRIPTION
SheriffがVampireに殺されたときなどで自爆判定になってしまう不具合の修正

Sheriffでinstanceとtargetが同じとき自爆判定としていましたが、SheriffがVampireに
キルされると同じ条件になります。
Vampireキルを死因に追加し、特殊死因判定をRpcMurderPlayerを呼ぶ前に移動しました。
またPlayerStateがゲームごとに初期化されず以前の情報を保持し続けるため初期化を追加しました。

Vampire、Sheriff、Crewmateの組み合わせで正常に結果が出ることを確認しました。