### PR TITLE
Refact/player state

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -376,10 +376,10 @@ namespace TownOfHost {
                 return player.Data.Outfits[PlayerOutfitType.Shapeshifted].PlayerName;
             }
 
-            if(!PlayerState.names.TryGetValue(player.PlayerId, out RealName)) {
+            if(!PlayerState.realNames.TryGetValue(player.PlayerId, out RealName)) {
                 RealName = player.name;
                 if(RealName == "Player(Clone)") return RealName;
-                PlayerState.names[player.PlayerId] = RealName;
+                PlayerState.realNames[player.PlayerId] = RealName;
                 TownOfHost.Logger.warn("プレイヤー" + player.PlayerId + "のRealNameが見つからなかったため、" + RealName + "を代入しました");
             }
             return RealName;

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -7,7 +7,7 @@ using InnerNet;
 namespace TownOfHost {
     static class ExtendedPlayerControl {
         public static void RpcSetCustomRole(this PlayerControl player, CustomRoles role) {
-            main.AllPlayerCustomRoles[player.PlayerId] = role;
+            PlayerState.customRoles[player.PlayerId] = role;
             if(AmongUsClient.Instance.AmHost) {
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetCustomRole, Hazel.SendOption.Reliable, -1);
                 writer.Write(player.PlayerId);
@@ -24,7 +24,7 @@ namespace TownOfHost {
             }
         }
         public static void SetCustomRole(this PlayerControl player, CustomRoles role) {
-            main.AllPlayerCustomRoles[player.PlayerId] = role;
+            PlayerState.customRoles[player.PlayerId] = role;
         }
 
         public static void RpcExile(this PlayerControl player) {
@@ -50,7 +50,7 @@ namespace TownOfHost {
                 Logger.warn("CustomRoleを取得しようとしましたが、対象がnullでした。");
                 return CustomRoles.Crewmate;
             }
-            var cRoleFound = main.AllPlayerCustomRoles.TryGetValue(player.PlayerId, out var cRole);
+            var cRoleFound = PlayerState.customRoles.TryGetValue(player.PlayerId, out var cRole);
             if(!cRoleFound)
             {
                 switch(player.Data.Role.Role)
@@ -376,10 +376,10 @@ namespace TownOfHost {
                 return player.Data.Outfits[PlayerOutfitType.Shapeshifted].PlayerName;
             }
 
-            if(!main.RealNames.TryGetValue(player.PlayerId, out RealName)) {
+            if(!PlayerState.names.TryGetValue(player.PlayerId, out RealName)) {
                 RealName = player.name;
                 if(RealName == "Player(Clone)") return RealName;
-                main.RealNames[player.PlayerId] = RealName;
+                PlayerState.names[player.PlayerId] = RealName;
                 TownOfHost.Logger.warn("プレイヤー" + player.PlayerId + "のRealNameが見つからなかったため、" + RealName + "を代入しました");
             }
             return RealName;

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -17,7 +17,7 @@ namespace TownOfHost {
             foreach (var p in PlayerControl.AllPlayerControls)
             {
                 realNames.Add(p.PlayerId, p.name);
-                deathReasons.Add(p.PlayerId,DeathReason.Living);
+                deathReasons.Add(p.PlayerId,DeathReason.NotDead);
             }
         }
 
@@ -28,11 +28,11 @@ namespace TownOfHost {
         public static void setDeathReason(byte p, DeathReason reason) { deathReasons[p] = reason; }
         public static DeathReason getDeathReason(byte p) { return deathReasons[p]; }
         public static bool isSuicide(byte p) { return deathReasons[p] == DeathReason.Suicide; }
-        public static bool isDead(byte p) { return deathReasons[p] != DeathReason.Living; }
+        public static bool isDead(byte p) { return deathReasons[p] != DeathReason.NotDead; }
 
         public enum DeathReason
         {
-            Living = 0,
+            NotDead,
             Kill,
             Vote,
             Suicide,

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -10,18 +10,18 @@ namespace TownOfHost {
 
         public static void Init()
         {
-            names = new();
+            realNames = new();
             customRoles = new();
             deathReasons = new();
 
             foreach (var p in PlayerControl.AllPlayerControls)
             {
-                names.Add(p.PlayerId, p.name);
+                realNames.Add(p.PlayerId, p.name);
                 deathReasons.Add(p.PlayerId,DeathReason.Living);
             }
         }
 
-        public static Dictionary<byte, string> names;
+        public static Dictionary<byte, string> realNames;
         public static Dictionary<byte, CustomRoles> customRoles;
         public static Dictionary<byte,DeathReason> deathReasons;
 

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -10,28 +10,29 @@ namespace TownOfHost {
 
         public static void Init()
         {
-            players = new();
-            isDead = new();
+            names = new();
+            customRoles = new();
             deathReasons = new();
-            isDead = new();
 
             foreach (var p in PlayerControl.AllPlayerControls)
             {
-                players.Add(p.PlayerId);
-                isDead.Add(p.PlayerId,false);
-                deathReasons.Add(p.PlayerId,DeathReason.etc);
+                names.Add(p.PlayerId, p.name);
+                deathReasons.Add(p.PlayerId,DeathReason.Living);
             }
-
         }
-        public static List<byte> players = new List<byte>();
-        public static Dictionary<byte,bool> isDead = new Dictionary<byte, bool>();
-        public static Dictionary<byte,DeathReason> deathReasons = new Dictionary<byte, DeathReason>();
+
+        public static Dictionary<byte, string> names;
+        public static Dictionary<byte, CustomRoles> customRoles;
+        public static Dictionary<byte,DeathReason> deathReasons;
+
         public static void setDeathReason(byte p, DeathReason reason) { deathReasons[p] = reason; }
         public static DeathReason getDeathReason(byte p) { return deathReasons[p]; }
         public static bool isSuicide(byte p) { return deathReasons[p] == DeathReason.Suicide; }
-        
+        public static bool isDead(byte p) { return deathReasons[p] != DeathReason.Living; }
+
         public enum DeathReason
         {
+            Living = 0,
             Kill,
             Vote,
             Suicide,

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -439,7 +439,7 @@ namespace TownOfHost
             }
         }
         public static void SetCustomRole(byte targetId, CustomRoles role) {
-            main.AllPlayerCustomRoles[targetId] = role;
+            PlayerState.customRoles[targetId] = role;
             HudManager.Instance.SetHudActive(true);
         }
 

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -94,13 +94,13 @@ namespace TownOfHost
             if (Options.IsHideAndSeek)
             {
                 if (p.IsDead) hasTasks = false;
-                var hasRole = main.AllPlayerCustomRoles.TryGetValue(p.PlayerId, out var role);
+                var hasRole = PlayerState.customRoles.TryGetValue(p.PlayerId, out var role);
                 if (hasRole)
                 {
                     if (role == CustomRoles.Fox || role == CustomRoles.Troll) hasTasks = false;
                 }
             } else {
-                var cRoleFound = main.AllPlayerCustomRoles.TryGetValue(p.PlayerId, out var cRole);
+                var cRoleFound = PlayerState.customRoles.TryGetValue(p.PlayerId, out var cRole);
                 if(cRoleFound) {
                     if (cRole == CustomRoles.Jester) hasTasks = false;
                     if (cRole == CustomRoles.MadGuardian && ForRecompute) hasTasks = false;
@@ -200,17 +200,17 @@ namespace TownOfHost
         public static void ShowLastRoles()
         {
             var text = getString("LastResult")+":";
-            Dictionary<byte,CustomRoles> cloneRoles = new(main.AllPlayerCustomRoles);
+            Dictionary<byte,CustomRoles> cloneRoles = new(PlayerState.customRoles);
             foreach(var id in main.winnerList)
             {
-                text += $"\n★ {main.AllPlayerNames[id]}:{getRoleName(main.AllPlayerCustomRoles[id])}";
+                text += $"\n★ {PlayerState.names[id]}:{getRoleName(PlayerState.customRoles[id])}";
                 text += $" {getDeathReason(PlayerState.deathReasons[id])}";
                 cloneRoles.Remove(id);
             }
             foreach (var kvp in cloneRoles)
             {
                 var id = kvp.Key;
-                text += $"\n　 {main.AllPlayerNames[id]} : {getRoleName(main.AllPlayerCustomRoles[id])}";
+                text += $"\n　 {PlayerState.names[id]} : {getRoleName(PlayerState.customRoles[id])}";
                 text += $" {getDeathReason(PlayerState.deathReasons[id])}";
             }
             SendMessage(text);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -203,14 +203,14 @@ namespace TownOfHost
             Dictionary<byte,CustomRoles> cloneRoles = new(PlayerState.customRoles);
             foreach(var id in main.winnerList)
             {
-                text += $"\n★ {PlayerState.names[id]}:{getRoleName(PlayerState.customRoles[id])}";
+                text += $"\n★ {PlayerState.realNames[id]}:{getRoleName(PlayerState.customRoles[id])}";
                 text += $" {getDeathReason(PlayerState.deathReasons[id])}";
                 cloneRoles.Remove(id);
             }
             foreach (var kvp in cloneRoles)
             {
                 var id = kvp.Key;
-                text += $"\n　 {PlayerState.names[id]} : {getRoleName(PlayerState.customRoles[id])}";
+                text += $"\n　 {PlayerState.realNames[id]} : {getRoleName(PlayerState.customRoles[id])}";
                 text += $" {getDeathReason(PlayerState.deathReasons[id])}";
             }
             SendMessage(text);

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -23,7 +23,7 @@ namespace TownOfHost
                     case "/win":
                     case "/winner":
                         canceled = true;
-                        Utils.SendMessage("Winner: "+string.Join(",",main.winnerList.Select(b=> PlayerState.names[b])));
+                        Utils.SendMessage("Winner: "+string.Join(",",main.winnerList.Select(b=> PlayerState.realNames[b])));
                         break;
 
                     case "/l":

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -23,7 +23,7 @@ namespace TownOfHost
                     case "/win":
                     case "/winner":
                         canceled = true;
-                        Utils.SendMessage("Winner: "+string.Join(",",main.winnerList.Select(b=> main.AllPlayerNames[b])));
+                        Utils.SendMessage("Winner: "+string.Join(",",main.winnerList.Select(b=> PlayerState.names[b])));
                         break;
 
                     case "/l":

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -123,7 +123,7 @@ namespace TownOfHost
 
         private static bool CheckAndEndGameForTroll(ShipStatus __instance) {
             foreach(var pc in PlayerControl.AllPlayerControls) {
-                var hasRole = main.AllPlayerCustomRoles.TryGetValue(pc.PlayerId, out var role);
+                var hasRole = PlayerState.customRoles.TryGetValue(pc.PlayerId, out var role);
                 if(!hasRole) return false;
                 if(role == CustomRoles.Troll && pc.Data.IsDead) {
                     __instance.enabled = false;
@@ -189,7 +189,7 @@ namespace TownOfHost
                 for (int i = 0; i < GameData.Instance.PlayerCount; i++)
                 {
                     GameData.PlayerInfo playerInfo = GameData.Instance.AllPlayers[i];
-                    var hasHideAndSeekRole = main.AllPlayerCustomRoles.TryGetValue((byte)i,out var role);
+                    var hasHideAndSeekRole = PlayerState.customRoles.TryGetValue((byte)i,out var role);
                     if (!playerInfo.Disconnected)
                     {
                         if (!playerInfo.IsDead)

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -31,7 +31,7 @@ namespace TownOfHost
                     __instance.privatePublicText.color = Palette.DisabledClear;
                 }
 
-                if (AmongUsClient.Instance.AmHost && Options.autoDisplayLastRoles && main.AllPlayerCustomRoles.Count != 0)
+                if (AmongUsClient.Instance.AmHost && Options.autoDisplayLastRoles && PlayerState.customRoles.Count != 0)
                 {
                     new LateTask(() =>
                     {

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -98,7 +98,7 @@ namespace TownOfHost
             if(Options.IsHideAndSeek && main.currentWinner != CustomWinner.Draw) {
                 var winners = new List<PlayerControl>();
                 foreach(var pc in PlayerControl.AllPlayerControls) {
-                    var hasRole = main.AllPlayerCustomRoles.TryGetValue(pc.PlayerId, out var role);
+                    var hasRole = PlayerState.customRoles.TryGetValue(pc.PlayerId, out var role);
                     if(!hasRole) continue;
                     if(role == CustomRoles.Crewmate) {
                         if(pc.Data.Role.IsImpostor && TempData.DidImpostorsWin(endGameResult.GameOverReason))
@@ -188,7 +188,7 @@ namespace TownOfHost
                 if(Options.IsHideAndSeek) {
                     foreach(var p in PlayerControl.AllPlayerControls) {
                         if(p.Data.IsDead) {
-                            var hasRole = main.AllPlayerCustomRoles.TryGetValue(p.PlayerId, out var role);
+                            var hasRole = PlayerState.customRoles.TryGetValue(p.PlayerId, out var role);
                             if(hasRole && role == CustomRoles.Troll) {
                                 __instance.BackgroundBar.material.color = Color.green;
                                 CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Troll)}";

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -542,7 +542,7 @@ namespace TownOfHost
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.SetName))]
     class SetNamePatch {
         public static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] string name) {
-            PlayerState.names[__instance.PlayerId] = name;
+            PlayerState.realNames[__instance.PlayerId] = name;
         }
     }
 }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -15,7 +15,7 @@ namespace TownOfHost
             if (!target.Data.IsDead || !AmongUsClient.Instance.AmHost)
                 return;
             Logger.SendToFile("MurderPlayer発生: " + __instance.name + "=>" + target.name);
-            if (PlayerState.getDeathReason(target.PlayerId)==PlayerState.DeathReason.etc)
+            if (!PlayerState.isDead(target.PlayerId))
             {
                 //死因が設定されていない場合は死亡判定
                 PlayerState.setDeathReason(target.PlayerId, PlayerState.DeathReason.Kill);
@@ -216,6 +216,7 @@ namespace TownOfHost
 
 
             //==キル処理==
+            PlayerState.setDeathReason(target.PlayerId, PlayerState.DeathReason.Kill);
             __instance.RpcMurderPlayer(target);
             //============
             return false;
@@ -403,7 +404,7 @@ namespace TownOfHost
             {
                 var RoleTextData = Utils.GetRoleText(__instance);
                 if(Options.IsHideAndSeek) {
-                    var hasRole = main.AllPlayerCustomRoles.TryGetValue(__instance.PlayerId, out var role);
+                    var hasRole = PlayerState.customRoles.TryGetValue(__instance.PlayerId, out var role);
                     if(hasRole) RoleTextData = Utils.GetRoleTextHideAndSeek(__instance.Data.Role.Role, role);
                 }
                 RoleText.text = RoleTextData.Item1;
@@ -541,7 +542,7 @@ namespace TownOfHost
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.SetName))]
     class SetNamePatch {
         public static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] string name) {
-            main.RealNames[__instance.PlayerId] = name;
+            PlayerState.names[__instance.PlayerId] = name;
         }
     }
 }

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -1,7 +1,7 @@
 using HarmonyLib;
 using System.Collections.Generic;
 using InnerNet;
-
+/*
 namespace TownOfHost {
     [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnGameJoined))]
     class OnGameJoinedPatch {
@@ -21,3 +21,4 @@ namespace TownOfHost {
         }
     }
 }
+*/

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -142,12 +142,13 @@ VoteMode,VoteMode,投票モード
 Default,Default,デフォルト
 Suicide,Suicide,切腹
 SelfVote,SelfVote,自投票
+DeathReason.Living,Living,生存
 DeathReason.Kill,Kill,死亡
 DeathReason.Vote,Vote,追放
 DeathReason.Suicide,Suicide,自爆
 DeathReason.Spell,Spelled,呪殺
 DeathReason.Bite,Bited,噛殺
-DeathReason.etc,Living,生存
+DeathReason.etc,Etc.,不明
 Win,Wins,勝利
 CanTerroristSuicideWin,Can Terrorist Suicide Win,テロリストの自殺勝ち
 commandError,Error:%1$,エラー:%1$

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -142,7 +142,7 @@ VoteMode,VoteMode,投票モード
 Default,Default,デフォルト
 Suicide,Suicide,切腹
 SelfVote,SelfVote,自投票
-DeathReason.Living,Living,生存
+DeathReason.NotDead,NotDead,生存
 DeathReason.Kill,Kill,死亡
 DeathReason.Vote,Vote,追放
 DeathReason.Suicide,Suicide,自爆

--- a/main.cs
+++ b/main.cs
@@ -44,9 +44,6 @@ namespace TownOfHost
         public static CustomWinner currentWinner;
         public static HashSet<AdditionalWinners> additionalwinners = new HashSet<AdditionalWinners>();
         public static GameOptionsData RealOptionsData;
-        public static Dictionary<byte, string> AllPlayerNames;
-        public static Dictionary<byte, CustomRoles> AllPlayerCustomRoles;
-        public static Dictionary<string, CustomRoles> lastAllPlayerCustomRoles;
         public static Dictionary<byte, bool> BlockKilling;
         public static bool OptionControllerIsEnable;
         public static Dictionary<CustomRoles,String> roleColors;
@@ -59,7 +56,6 @@ namespace TownOfHost
         public static List<byte> winnerList;
         public static List<(string, byte)> MessagesToSend;
         public static bool isChatCommand = false;
-        public static Dictionary<byte, string> RealNames;
         public static string TextCursor => TextCursorVisible ? "_" : "";
         public static bool TextCursorVisible;
         public static float TextCursorTimer;
@@ -104,9 +100,6 @@ namespace TownOfHost
             currentWinner = CustomWinner.Default;
             additionalwinners = new HashSet<AdditionalWinners>();
 
-            RealNames = new Dictionary<byte, string>();
-
-            AllPlayerCustomRoles = new Dictionary<byte, CustomRoles>();
             CustomWinTrigger = false;
             OptionControllerIsEnable = false;
             BitPlayers = new Dictionary<byte, (byte, float)>();


### PR DESCRIPTION
名前、役職をPlayerStateに集約。死因の整理をしました。

AllPlayerNamesとRealNamesはライフサイクルが若干違うだけで用途は同じため統合
AllPlayerCustomRoles、lastAllPlayerCustomRolesも統合
それぞれPlayerStateに取り込みました。
isDeadは機能しにくいため、関数に変更。
DeathReasonのetcはおそらく本来はその他死因だったと思われるため
生存状態として~Living~NotDeadを追加しました。

RealNamesのタイミング変更により Patches/PlayerJoinAndLeftPatch.cs　が不要となりましたが
念のためファイルは残しています。