### PR TITLE
会議後、呪われた人を殺した後リストから除去するように変更

### DIFF
--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -26,8 +26,6 @@ namespace TownOfHost
         {
             main.witchMeeting = false;
             if(!AmongUsClient.Instance.AmHost) return; //ホスト以外はこれ以降の処理を実行しません
-            main.CursedPlayerDie.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);//呪われた人が死んだ場合にリストから削除する
-            main.SpelledPlayer.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);
             foreach(var p in main.SpelledPlayer)
             {
                 PlayerState.setDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
@@ -40,6 +38,8 @@ namespace TownOfHost
                 main.IgnoreReportPlayers.Add(p.PlayerId);
                 p.RpcMurderPlayer(p);
             }
+            main.CursedPlayerDie.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);//呪われた人が死んだ場合にリストから削除する
+            main.SpelledPlayer.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);
             if (exiled != null)
             {
                 var role = exiled.getCustomRole();


### PR DESCRIPTION
会議後、呪われた人を殺した後リストから除去するように変更

呪われた場合次の会議後に死亡しますが、
　呪われて死んだ人をリストから除去→呪われた人を殺す
と言う手順だったためその次の会議でもう一度”†”マークが付けられていました。