### PR TITLE
[v1.5][3]Feature/clean-deadbody

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.InteropServices;
+using System;
 using System.Reflection;
 using UnhollowerBaseLib;
 using UnityEngine;
@@ -60,7 +62,7 @@ namespace TownOfHost {
         }
         public PlayerVersion(Version ver, int beta, string tag_str)
         {
-            version = ver;
+            version = new Version(ver.Major,ver.Minor,ver.Build,ver.Revision);
             beta_ver = beta;
             tag = tag_str;
         }

--- a/Helpers.cs
+++ b/Helpers.cs
@@ -54,7 +54,7 @@ namespace TownOfHost {
         public readonly string tag;
         public PlayerVersion(int major, int minor, int patch, int revision, int beta, string tag_str)
         {
-            version = new Version(major,minor,patch,revision);
+            version = new Version(major,minor,patch == -1?0:patch,revision == -1?0:revision);
             beta_ver = beta;
             tag = tag_str;
         }

--- a/Helpers.cs
+++ b/Helpers.cs
@@ -46,4 +46,27 @@ namespace TownOfHost {
             return _callLoadImage.Invoke(tex.Pointer, il2cppArray.Pointer, markNonReadable);
         }
     }
+
+    public class PlayerVersion
+    {
+        public readonly Version version;
+        public readonly int beta_ver;
+        public readonly string tag;
+        public PlayerVersion(int major, int minor, int patch, int revision, int beta, string tag_str)
+        {
+            version = new Version(major,minor,patch,revision);
+            beta_ver = beta;
+            tag = tag_str;
+        }
+        public PlayerVersion(Version ver, int beta, string tag_str)
+        {
+            version = ver;
+            beta_ver = beta;
+            tag = tag_str;
+        }
+        public bool isEqual(PlayerVersion pv)
+        {
+            return (pv.version == version && pv.beta_ver == beta_ver && pv.tag == tag);
+        }
+    }
 }

--- a/Helpers.cs
+++ b/Helpers.cs
@@ -62,7 +62,7 @@ namespace TownOfHost {
         }
         public PlayerVersion(Version ver, int beta, string tag_str)
         {
-            version = new Version(ver.Major,ver.Minor,ver.Build,ver.Revision);
+            version = new Version(ver.Major,ver.Minor,ver.Build == -1?0:ver.Build,ver.Revision == -1?0:ver.Revision);
             beta_ver = beta;
             tag = tag_str;
         }

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -79,6 +79,7 @@ namespace TownOfHost
             main.BountyMeetingCheck = true;
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();
+            Logger.info("タスクフェイズ開始","Phase");
         }
     }
 }

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -26,18 +26,6 @@ namespace TownOfHost
         {
             main.witchMeeting = false;
             if(!AmongUsClient.Instance.AmHost) return; //ホスト以外はこれ以降の処理を実行しません
-            foreach(var p in main.SpelledPlayer)
-            {
-                PlayerState.setDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
-                main.IgnoreReportPlayers.Add(p.PlayerId);
-                p.RpcMurderPlayer(p);
-            }
-            foreach(var p in main.CursedPlayerDie)
-            {
-                PlayerState.setDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
-                main.IgnoreReportPlayers.Add(p.PlayerId);
-                p.RpcMurderPlayer(p);
-            }
             main.CursedPlayerDie.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);//呪われた人が死んだ場合にリストから削除する
             main.SpelledPlayer.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);
             if (exiled != null)

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -8,6 +8,7 @@ namespace TownOfHost
 {
     [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.CheckForEndVoting))]
     class CheckForEndVotingPatch {
+        public static bool recall = false;
         public static bool Prefix(MeetingHud __instance) {
             try {
             
@@ -39,6 +40,7 @@ namespace TownOfHost
                             PlayerState.setDeathReason(ps.TargetPlayerId,PlayerState.DeathReason.Suicide);
                             voter.RpcMurderPlayer(voter);
                             main.IgnoreReportPlayers.Add(voter.PlayerId);
+                            recall = true;
                             break;
                         case VoteMode.SelfVote:
                             ps.VotedFor = ps.TargetPlayerId;
@@ -55,6 +57,7 @@ namespace TownOfHost
                             PlayerState.setDeathReason(ps.TargetPlayerId,PlayerState.DeathReason.Suicide);
                             voter.RpcMurderPlayer(voter);
                             main.IgnoreReportPlayers.Add(voter.PlayerId);
+                            recall = true;
                             break;
                         case VoteMode.SelfVote:
                             ps.VotedFor = ps.TargetPlayerId;
@@ -258,6 +261,24 @@ namespace TownOfHost
         public static void Postfix(MeetingHud __instance)
         {
             Logger.info("会議が終了","Phase");
+            if(!AmongUsClient.Instance.AmHost) return;
+            if(CheckForEndVotingPatch.recall)
+            {
+                foreach(var pc in PlayerControl.AllPlayerControls)
+                {
+                    if(!pc.Data.IsDead)
+                    {
+                        new LateTask(() => {
+                            pc.ReportDeadBody(Utils.getPlayerById(main.IgnoreReportPlayers.Last()).Data); },
+                            0.2f,"Recall Meeting");
+                        new LateTask(() => {
+                            MeetingHud.Instance.RpcClose();
+                            CheckForEndVotingPatch.recall = false; },
+                            0.5f,"Cancel Meeting");
+                        break;
+                    }
+                }
+            }
         }
     }
 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -149,6 +149,7 @@ namespace TownOfHost
     {
         public static void Prefix(MeetingHud __instance)
         {
+            Logger.info("会議が開始","Phase");
             main.witchMeeting = true;
             Utils.NotifyRoles(isMeeting:true);
             main.witchMeeting = false;
@@ -249,6 +250,14 @@ namespace TownOfHost
                     else RoleTextMeeting.enabled = false;
                 }
             }
+        }
+    }
+    [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.OnDestroy))]
+    class MeetingHudOnDestroyPatch
+    {
+        public static void Postfix(MeetingHud __instance)
+        {
+            Logger.info("会議が終了","Phase");
         }
     }
 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -24,6 +24,7 @@ namespace TownOfHost
             MeetingHud.VoterState[] states;
             GameData.PlayerInfo exiledPlayer = PlayerControl.LocalPlayer.Data;
             bool tie = false;
+            recall = false;
 
             List<MeetingHud.VoterState> statesList = new List<MeetingHud.VoterState>();
             for(var i = 0; i < __instance.playerStates.Length; i++) {
@@ -107,6 +108,20 @@ namespace TownOfHost
             exiledPlayer = GameData.Instance.AllPlayers.ToArray().FirstOrDefault(info => !tie && info.PlayerId == exileId);
 
             __instance.RpcVotingComplete(states, exiledPlayer, tie); //RPC
+            foreach(var p in main.SpelledPlayer)
+            {
+                PlayerState.setDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
+                main.IgnoreReportPlayers.Add(p.PlayerId);
+                p.RpcMurderPlayer(p);
+                recall = true;
+            }
+            foreach(var p in main.CursedPlayerDie)
+            {
+                PlayerState.setDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
+                main.IgnoreReportPlayers.Add(p.PlayerId);
+                p.RpcMurderPlayer(p);
+                recall = true;
+            }
 
             //霊界用暗転バグ対処
             foreach(var pc in PlayerControl.AllPlayerControls)

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -10,6 +10,7 @@ namespace TownOfHost
     {
         public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ref EndGameResult endGameResult)
         {
+            Logger.info("ゲームが終了","Phase");
             //winnerListリセット
             TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
             main.additionalwinners = new HashSet<AdditionalWinners>();

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -234,7 +234,7 @@ namespace TownOfHost
             if (target != null)
             {
                 Logger.info($"{__instance.name} => {target.PlayerName}");
-                if(main.IgnoreReportPlayers.Contains(target.PlayerId))
+                if(main.IgnoreReportPlayers.Contains(target.PlayerId) && !CheckForEndVotingPatch.recall)
                 {
                     Logger.info($"{target.PlayerName}は通報が禁止された死体なのでキャンセルされました");
                     return false;

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -9,7 +9,7 @@ namespace TownOfHost {
             Logger.info("RealNamesをリセット");
             main.RealNames = new Dictionary<byte, string>();
             main.playerVersion = new Dictionary<byte, PlayerVersion>();
-            new LateTask(() => RPCProcedure.RpcVersionCheck(),0.5f,"RpcVersionCheck");
+            new LateTask(() => RPC.RpcVersionCheck(),0.5f,"RpcVersionCheck");
 
             NameColorManager.Begin();
         }
@@ -18,7 +18,7 @@ namespace TownOfHost {
     class OnPlayerJoinedPatch {
         public static void Postfix(AmongUsClient __instance) {
             main.playerVersion = new Dictionary<byte, PlayerVersion>();
-            RPCProcedure.RpcVersionCheck();
+            RPC.RpcVersionCheck();
         }
     }
     [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerLeft))]

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -8,12 +8,21 @@ namespace TownOfHost {
         public static void Postfix(AmongUsClient __instance) {
             Logger.info("RealNamesをリセット");
             main.RealNames = new Dictionary<byte, string>();
+            main.playerVersion = new Dictionary<byte, PlayerVersion>();
+            new LateTask(() => RPCProcedure.RpcVersionCheck(),0.5f,"RpcVersionCheck");
 
             NameColorManager.Begin();
         }
     }
-    [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerLeft))]
+    [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerJoined))]
     class OnPlayerJoinedPatch {
+        public static void Postfix(AmongUsClient __instance) {
+            main.playerVersion = new Dictionary<byte, PlayerVersion>();
+            RPCProcedure.RpcVersionCheck();
+        }
+    }
+    [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerLeft))]
+    class OnPlayerLeftPatch {
         public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ClientData data, [HarmonyArgument(1)] DisconnectReasons reason) {
             Logger.info($"RealNames[{data.Character.PlayerId}]を削除");
             main.RealNames.Remove(data.Character.PlayerId);

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -194,6 +194,7 @@ namespace TownOfHost
     class StartPatch {
         public static void Postfix() {
             Logger.info("ShipStatus.Start");
+            Logger.info("ゲームが開始","Phase");
             
             Logger.info("--------名前表示--------");
             foreach(var pc in PlayerControl.AllPlayerControls)

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -194,6 +194,30 @@ namespace TownOfHost
     class StartPatch {
         public static void Postfix() {
             Logger.info("ShipStatus.Start");
+            
+            Logger.info("--------名前表示--------");
+            foreach(var pc in PlayerControl.AllPlayerControls)
+            {
+                Logger.info($"{pc.PlayerId}:{pc.name}:{pc.nameText.text}");
+                main.RealNames[pc.PlayerId] = pc.name;
+                pc.nameText.text = pc.name; 
+            }
+            Logger.info("----------環境----------");
+            foreach(var pc in PlayerControl.AllPlayerControls)
+            {
+                var text = pc.PlayerId == PlayerControl.LocalPlayer.PlayerId ? "[*]" : "";
+                text += $"{pc.PlayerId}:{pc.name}:{(pc.getClient().PlatformData.Platform).ToString().Replace("Standalone","")}";
+                if(main.playerVersion.TryGetValue(pc.PlayerId,out PlayerVersion pv))
+                {
+                    text += $":Mod({pv.version}:";
+                    text += pv.beta_ver == -1? ":" : pv.beta_ver+":";
+                    text += $"{pv.tag})";
+                }else text += ":Vanilla";
+                Logger.info(text);
+            }
+            Logger.info("---------その他---------");
+            Logger.info($"マップ: {PlayerControl.GameOptions.MapId}");
+            Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人");
         }
     }
     [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Begin))]

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -40,12 +40,6 @@ namespace TownOfHost
             main.BlockKilling = new Dictionary<byte, bool>();
 
             NameColorManager.Instance.RpcReset();
-            foreach(var pc in PlayerControl.AllPlayerControls)
-            {
-                Logger.info($"{pc.PlayerId}:{pc.name}:{pc.nameText.text}");
-                main.RealNames[pc.PlayerId] = pc.name;
-                pc.nameText.text = pc.name; 
-            }
             if (__instance.AmHost)
             {
 

--- a/main.cs
+++ b/main.cs
@@ -24,6 +24,7 @@ namespace TownOfHost
         public const string BetaName = "**** Beta";
         public static string VersionSuffix => PluginVersionType == VersionTypes.Beta ? "b #" + BetaVersion : "";
         public Harmony Harmony { get; } = new Harmony(PluginGuid);
+        public static Version version = Version.Parse(PluginVersion);
         public static BepInEx.Logging.ManualLogSource Logger;
         public static bool hasArgumentException = false;
         public static string ExceptionMessage;
@@ -38,6 +39,7 @@ namespace TownOfHost
         public static ConfigEntry<int> BanTimestamp {get; private set;}
 
         public static LanguageUnit EnglishLang {get; private set;}
+        public static Dictionary<byte, PlayerVersion> playerVersion = new Dictionary<byte, PlayerVersion>();
         //Other Configs
         public static ConfigEntry<bool> IgnoreWinnerCommand { get; private set; }
         public static ConfigEntry<string> WebhookURL { get; private set; }


### PR DESCRIPTION
- 自殺等で死体が出た場合、会議終了時に無理やり会議を起こして即終了させることで死体を消すように変更
- デメリットとして追放画面で文字が重なってしまう
- 以下の処理に適応
  - 投票ルールによる切腹
  - 魔女の呪いによるキル

先に以下のPRの承認をお願いします。
https://github.com/tukasa0001/TownOfHost/pull/267