### PR TITLE
Feature/TeroristWinRenew

### DIFF
--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -39,6 +39,7 @@ namespace TownOfHost
             Suicide,
             Spell,
             Bite,
+            Bombed,
             Misfire,
             Disconnected,
             etc = -1

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -259,6 +259,22 @@ namespace TownOfHost
             var taskState = getPlayerById(Terrorist.PlayerId).getPlayerTaskState();
             if (taskState.isTaskFinished && (!PlayerState.isSuicide(Terrorist.PlayerId) || Options.canTerroristSuicideWin)) //タスクが完了で（自殺じゃない OR 自殺勝ちが許可）されていれば
             {
+                foreach (var pc in PlayerControl.AllPlayerControls)
+                {
+                    if (!pc.Data.IsDead)
+                    {
+                        //生存者は爆死
+                        pc.MurderPlayer(pc);
+                        PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Bombed);
+                        PlayerState.isDead[pc.PlayerId] = true;
+                    }
+                    if (pc.isTerrorist() && PlayerState.getDeathReason(pc.PlayerId) == PlayerState.DeathReason.Kill)
+                    {
+                        //キルされた場合は自爆扱い
+                        PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Suicide);
+
+                    }
+                }
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TerroristWin, Hazel.SendOption.Reliable, -1);
                 writer.Write(Terrorist.PlayerId);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -268,11 +268,10 @@ namespace TownOfHost
                         PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Bombed);
                         PlayerState.isDead[pc.PlayerId] = true;
                     }
-                    if (pc.isTerrorist() && PlayerState.getDeathReason(pc.PlayerId) == PlayerState.DeathReason.Kill)
+                    if (pc.isTerrorist() && pc.Data.IsDead)
                     {
                         //キルされた場合は自爆扱い
                         PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Suicide);
-
                     }
                 }
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TerroristWin, Hazel.SendOption.Reliable, -1);

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -152,6 +152,7 @@ DeathReason.Vote,Exiled,追放
 DeathReason.Suicide,Suicide,自爆
 DeathReason.Spell,Spelled,呪殺
 DeathReason.Bite,Bited,噛殺
+DeathReason.Bombed,Bombed,爆死
 DeathReason.Misfire,Misfire,誤爆
 DeathReason.Disconnected,Disconnected,回線切断
 DeathReason.etc,etc,その他


### PR DESCRIPTION
テロリスト勝利時に生存者を爆死されるように変更

Ticket-0113の要望より。
テロリスト勝利時に非Modでも敗北表示になるためわかりやすいかと思います。