### PR TITLE
ShapeshiftPatchをホスト以外が実行したときに何もしないよう変更

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -54,6 +54,7 @@ namespace TownOfHost
     {
         public static void Prefix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
         {
+            if (!AmongUsClient.Instance.AmHost) return;
             if (__instance.isWarlock())
             {
                 if (main.FirstCursedCheck[__instance.PlayerId])//呪われた人がいるか確認


### PR DESCRIPTION
ShapeshiftPatchをホスト以外が実行したときに何もしないように変更
以前の状態ではホスト以外のプレイヤーがMurderPlayerRPCなどを送ってBANされる可能性がありました。