### PR TITLE
Fix/option tab

### DIFF
--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -268,19 +268,19 @@ namespace TownOfHost
                 .SetGameMode(CustomGameMode.Standard);
 
             // タスク無効化
-            DisableTasks = CustomOption.Create(100300, Color.white, "DisableSwipeCardTask", false, null, true)
+            DisableTasks = CustomOption.Create(100300, Color.white, "DisableTasks", false, null, true)
                 .SetGameMode(CustomGameMode.All);
-            DisableSwipeCard = CustomOption.Create(100300, Color.white, "DisableSwipeCardTask", false, DisableTasks)
+            DisableSwipeCard = CustomOption.Create(100301, Color.white, "DisableSwipeCardTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
-            DisableSubmitScan = CustomOption.Create(100301, Color.white, "DisableSubmitScanTask", false, DisableTasks)
+            DisableSubmitScan = CustomOption.Create(100302, Color.white, "DisableSubmitScanTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
-            DisableUnlockSafe = CustomOption.Create(100302, Color.white, "DisableUnlockSafeTask", false, DisableTasks)
+            DisableUnlockSafe = CustomOption.Create(100303, Color.white, "DisableUnlockSafeTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
-            DisableUploadData = CustomOption.Create(100303, Color.white, "DisableUploadDataTask", false, DisableTasks)
+            DisableUploadData = CustomOption.Create(100304, Color.white, "DisableUploadDataTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
-            DisableStartReactor = CustomOption.Create(100304, Color.white, "DisableStartReactorTask", false, DisableTasks)
+            DisableStartReactor = CustomOption.Create(100305, Color.white, "DisableStartReactorTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
-            DisableResetBreaker = CustomOption.Create(100305, Color.white, "DisableResetBreakerTask", false, DisableTasks)
+            DisableResetBreaker = CustomOption.Create(100306, Color.white, "DisableResetBreakerTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
 
             // ランダムマップ

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -209,9 +209,10 @@ namespace TownOfHost
             SetupRoleOptions(1300, CustomRoles.Vampire);
             VampireKillDelay = CustomOption.Create(1310, Color.white, "VampireKillDelay", 10, 1, 1000, 1, CustomRoleSpawnChances[CustomRoles.Vampire]);
             SetupRoleOptions(1400, CustomRoles.Warlock);
-            CanMakeMadmateCount = CustomOption.Create(1410, Color.white, "CanMakeMadmateCount", 1, 1, 15, 1, CustomRoleSpawnChances[CustomRoles.Warlock]);
             SetupRoleOptions(1500, CustomRoles.Witch);
             SetupRoleOptions(1600, CustomRoles.Mafia);
+
+            CanMakeMadmateCount = CustomOption.Create(5000, Color.white, "CanMakeMadmateCount", 1, 1, 15, 1, null, true);
             // Madmate
             SetupRoleOptions(10000, CustomRoles.Madmate);
             SetupRoleOptions(10100, CustomRoles.MadGuardian);

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -92,6 +92,7 @@ namespace TownOfHost
         public static int UsedButtonCount = 0;
 
         // タスク無効化
+        public static CustomOption DisableTasks;
         public static CustomOption DisableSwipeCard;
         public static CustomOption DisableSubmitScan;
         public static CustomOption DisableUnlockSafe;
@@ -264,17 +265,19 @@ namespace TownOfHost
                 .SetGameMode(CustomGameMode.Standard);
 
             // タスク無効化
-            DisableSwipeCard = CustomOption.Create(100300, Color.white, "DisableSwipeCardTask", false, null, true)
+            DisableTasks = CustomOption.Create(100300, Color.white, "DisableSwipeCardTask", false, null, true)
                 .SetGameMode(CustomGameMode.All);
-            DisableSubmitScan = CustomOption.Create(100301, Color.white, "DisableSubmitScanTask", false)
+            DisableSwipeCard = CustomOption.Create(100300, Color.white, "DisableSwipeCardTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
-            DisableUnlockSafe = CustomOption.Create(100302, Color.white, "DisableUnlockSafeTask", false)
+            DisableSubmitScan = CustomOption.Create(100301, Color.white, "DisableSubmitScanTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
-            DisableUploadData = CustomOption.Create(100303, Color.white, "DisableUploadDataTask", false)
+            DisableUnlockSafe = CustomOption.Create(100302, Color.white, "DisableUnlockSafeTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
-            DisableStartReactor = CustomOption.Create(100304, Color.white, "DisableStartReactorTask", false)
+            DisableUploadData = CustomOption.Create(100303, Color.white, "DisableUploadDataTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
-            DisableResetBreaker = CustomOption.Create(100305, Color.white, "DisableResetBreakerTask", false)
+            DisableStartReactor = CustomOption.Create(100304, Color.white, "DisableStartReactorTask", false, DisableTasks)
+                .SetGameMode(CustomGameMode.All);
+            DisableResetBreaker = CustomOption.Create(100305, Color.white, "DisableResetBreakerTask", false, DisableTasks)
                 .SetGameMode(CustomGameMode.All);
 
             // ランダムマップ

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -212,13 +212,14 @@ namespace TownOfHost
             SetupRoleOptions(1600, CustomRoles.Mafia);
             // Madmate
             SetupRoleOptions(10000, CustomRoles.Madmate);
-            MadmateCanFixLightsOut = CustomOption.Create(10010, Color.white, "MadmateCanFixLightsOut", false, CustomRoleSpawnChances[CustomRoles.Madmate]);
-            MadmateCanFixComms = CustomOption.Create(10011, Color.white, "MadmateCanFixComms", false, CustomRoleSpawnChances[CustomRoles.Madmate]);
-            MadmateHasImpostorVision = CustomOption.Create(10012, Color.white, "MadmateHasImpostorVision", false, CustomRoleSpawnChances[CustomRoles.Madmate]);
             SetupRoleOptions(10100, CustomRoles.MadGuardian);
             MadGuardianCanSeeWhoTriedToKill = CustomOption.Create(10110, Color.white, "MadGuardianCanSeeWhoTriedToKill", false, CustomRoleSpawnChances[CustomRoles.MadGuardian]);
             SetupRoleOptions(10200, CustomRoles.MadSnitch);
             MadSnitchTasks = CustomOption.Create(10210, Color.white, "MadSnitchTasks", 4, 1, 20, 1, CustomRoleSpawnChances[CustomRoles.MadSnitch]);
+            // Madmate Common Options
+            MadmateCanFixLightsOut = CustomOption.Create(11000, Color.white, "MadmateCanFixLightsOut", false, null, true);
+            MadmateCanFixComms = CustomOption.Create(11001, Color.white, "MadmateCanFixComms", false);
+            MadmateHasImpostorVision = CustomOption.Create(11002, Color.white, "MadmateHasImpostorVision", false);
             // Crewmate
             SetupRoleOptions(20000, CustomRoles.Bait);
             SetupRoleOptions(20100, CustomRoles.Lighter);

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -77,6 +77,7 @@ namespace TownOfHost
         public static CustomOption SheriffCanKillJester;
         public static CustomOption SheriffCanKillTerrorist;
         public static CustomOption SheriffCanKillOpportunist;
+        public static CustomOption CanTerroristSuicideWin;
 
         // HideAndSeek
         public static CustomOption AllowCloseDoors;
@@ -109,9 +110,9 @@ namespace TownOfHost
         public static CustomOption AddedDleks;
 
         // 投票モード
+        public static CustomOption VoteMode;
         public static CustomOption WhenSkipVote;
         public static CustomOption WhenNonVote;
-        public static CustomOption CanTerroristSuicideWin;
         public static readonly string[] voteModes =
         {
             "Default", "Suicide", "SelfVote", "Skip"
@@ -244,6 +245,8 @@ namespace TownOfHost
             SetupRoleOptions(50000, CustomRoles.Jester);
             SetupRoleOptions(50100, CustomRoles.Opportunist);
             SetupRoleOptions(50200, CustomRoles.Terrorist);
+            CanTerroristSuicideWin = CustomOption.Create(100201, Color.white, "CanTerroristSuicideWin", false, CustomRoleSpawnChances[CustomRoles.Terrorist], false)
+                .SetGameMode(CustomGameMode.Standard);
             #endregion
 
             // HideAndSeek
@@ -295,15 +298,15 @@ namespace TownOfHost
             //     .SetGameMode(CustomGameMode.All);
 
             // 投票モード
-            WhenSkipVote = CustomOption.Create(100500, Color.white, "WhenSkipVote", voteModes[0..3], voteModes[0], null, true)
+            VoteMode = CustomOption.Create(100500, Color.white, "VoteMode", false, null, true)
                 .SetGameMode(CustomGameMode.Standard);
-            WhenNonVote = CustomOption.Create(100501, Color.white, "WhenNonVote", voteModes, voteModes[0], null, false)
+            WhenSkipVote = CustomOption.Create(100501, Color.white, "WhenSkipVote", voteModes[0..3], voteModes[0], VoteMode)
                 .SetGameMode(CustomGameMode.Standard);
-            CanTerroristSuicideWin = CustomOption.Create(100502, Color.white, "CanTerroristSuicideWin", false, null, false)
+            WhenNonVote = CustomOption.Create(100502, Color.white, "WhenNonVote", voteModes, voteModes[0], VoteMode)
                 .SetGameMode(CustomGameMode.Standard);
 
             // その他
-            NoGameEnd = CustomOption.Create(100600, Color.white, "NoGameEnd", false, null, false)
+            NoGameEnd = CustomOption.Create(100600, Color.white, "NoGameEnd", false, null, true)
                 .SetGameMode(CustomGameMode.All);
             AutoDisplayLastResult = CustomOption.Create(100601, Color.white, "AutoDisplayLastResult", false)
                 .SetGameMode(CustomGameMode.All);

--- a/Modules/OptionShower.cs
+++ b/Modules/OptionShower.cs
@@ -50,6 +50,10 @@ namespace TownOfHost
                     text += $"\t{Options.MadmateCanFixComms.GetName()}: {Options.MadmateCanFixComms.GetString()}\n";
                     text += $"\t{Options.MadmateHasImpostorVision.GetName()}: {Options.MadmateHasImpostorVision.GetString()}\n";
                 }
+                if (kvp.Key == CustomRoles.Shapeshifter || kvp.Key == CustomRoles.ShapeMaster || kvp.Key == CustomRoles.Mafia || kvp.Key == CustomRoles.BountyHunter || kvp.Key == CustomRoles.SerialKiller) //シェイプシフター役職の時に追加する詳細設定
+                {
+                    text += $"\t{Options.CanMakeMadmateCount.GetName()}: {Options.CanMakeMadmateCount.GetString()}\n";
+                }
                 text += "\n";
             }
             //Onの時に子要素まで表示するメソッド

--- a/Modules/OptionShower.cs
+++ b/Modules/OptionShower.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using static TownOfHost.Translator;
+
+namespace TownOfHost
+{
+    public static class OptionShower
+    {
+        public static int currentPage = 0;
+        public static List<string> pages = new();
+        static OptionShower()
+        {
+
+        }
+        public static string getText()
+        {
+            //初期化
+            string text = "";
+            pages = new();
+            //1ページに基本ゲーム設定を格納
+            pages.Add(PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10) + "\n\n");
+            //ゲームモードの表示
+            text += $"{Options.GameMode.GetName()}: {Options.GameMode.GetString()}\n\n";
+            //Standardの時のみ実行
+            if (Options.CurrentGameMode == CustomGameMode.Standard)
+            {
+                //役職一覧
+                foreach (var kvp in Options.CustomRoleSpawnChances)
+                    if (kvp.Value.GameMode == CustomGameMode.Standard || kvp.Value.GameMode == CustomGameMode.All) //スタンダードか全てのゲームモードで表示する役職
+                        text += $"<color={Utils.getRoleColorCode(kvp.Key)}>{kvp.Value.GetName()}:</color> {kvp.Value.GetString()}×{kvp.Key.getCount()}\n";
+                pages.Add(text + "\n\n");
+                text = "";
+            }
+            //有効な役職と詳細設定一覧
+            pages.Add("");
+            foreach (var kvp in Options.CustomRoleSpawnChances)
+            {
+                if (!kvp.Key.isEnable()) continue;
+                if (!(kvp.Value.GameMode == Options.CurrentGameMode || kvp.Value.GameMode == CustomGameMode.All)) continue; //現在のゲームモードでも全てのゲームモードでも表示しない役職なら飛ばす
+                text += $"<color={Utils.getRoleColorCode(kvp.Key)}>{kvp.Value.GetName()}:</color> {kvp.Value.GetString()}×{kvp.Key.getCount()}\n";
+                foreach (var c in kvp.Value.Children) //詳細設定をループする
+                {
+                    if (c.Name == "Maximum") continue; //Maximumの項目は飛ばす
+                    text += $"\t{c.GetName()}: {c.GetString()}\n";
+                }
+                if (kvp.Key.isMadmate()) //マッドメイトの時に追加する詳細設定
+                {
+                    text += $"\t{Options.MadmateCanFixLightsOut.GetName()}: {Options.MadmateCanFixLightsOut.GetString()}\n";
+                    text += $"\t{Options.MadmateCanFixComms.GetName()}: {Options.MadmateCanFixComms.GetString()}\n";
+                    text += $"\t{Options.MadmateHasImpostorVision.GetName()}: {Options.MadmateHasImpostorVision.GetString()}\n";
+                }
+                text += "\n";
+            }
+            //Onの時に子要素まで表示するメソッド
+            Action<CustomOption> listUp = (o) =>
+            {
+                if (o.GetBool())
+                {
+                    text += $"{o.GetName()}: {o.GetString()}\n";
+                    foreach (var c in o.Children)
+                        text += $"\t{c.getName()}: {c.GetString()}\n";
+                    text += "\n";
+                }
+            };
+            Action<CustomOption> nameAndValue = (o) => text += $"{o.GetName()}: {o.GetString()}\n";
+            if (Options.CurrentGameMode == CustomGameMode.Standard)
+            {
+                listUp(Options.SyncButtonMode);
+                listUp(Options.VoteMode);
+            }
+            else if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
+            {
+                nameAndValue(Options.AllowCloseDoors);
+                nameAndValue(Options.KillDelay);
+                nameAndValue(Options.IgnoreCosmetics);
+                nameAndValue(Options.IgnoreVent);
+            }
+            text += "\n";
+            listUp(Options.DisableTasks);
+            listUp(Options.RandomMapsMode);
+            nameAndValue(Options.NoGameEnd);
+            //1ページにつき35行までにする処理
+            List<string> tmp = new(text.Split("\n\n"));
+            for (var i = 0; i < tmp.Count; i++)
+            {
+                if (pages[pages.Count - 1].Count(c => c == '\n') + 1 + tmp[i].Count(c => c == '\n') + 1 > 35)
+                {
+                    pages.Add(tmp[i] + "\n\n");
+                }
+                else
+                {
+                    pages[pages.Count - 1] += tmp[i] + "\n\n";
+                }
+            }
+            if (currentPage >= pages.Count) currentPage = pages.Count - 1; //現在のページが最大ページ数を超えていれば最後のページに修正
+            return $"{pages[currentPage]}{getString("PressTabToNextPage")}({currentPage + 1}/{pages.Count})";
+        }
+        public static void next()
+        {
+            currentPage++;
+            if (currentPage >= pages.Count) currentPage = 0; //現在のページが最大ページを超えていれば最初のページに
+        }
+    }
+}

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -50,8 +50,11 @@ namespace TownOfHost
             switch (packetID)
             {
                 case (byte)CustomRPC.SyncCustomSettings:
-                    foreach (CustomRoles r in Enum.GetValues(typeof(CustomRoles))) r.setCount(reader.ReadInt32());
-
+                    foreach (var kvp in Options.CustomRoleSpawnChances)
+                    {
+                        kvp.Value.Selection = reader.ReadInt32();
+                        kvp.Key.setCount(reader.ReadInt32());
+                    }
                     int CurrentGameMode = reader.ReadInt32();
                     bool NoGameEnd = reader.ReadBoolean();
                     bool SwipeCardDisabled = reader.ReadBoolean();
@@ -325,7 +328,7 @@ namespace TownOfHost
             Options.MadSnitchTasks.UpdateSelection(MadSnitchTasks);
 
             Options.MayorAdditionalVote.UpdateSelection(MayorAdditionalVote);
-            
+
             Options.AutoDisplayLastResult.UpdateSelection(AutoDisplayLastResult);
         }
         //SyncCustomSettingsRPC Sender
@@ -333,7 +336,11 @@ namespace TownOfHost
         {
             if (!AmongUsClient.Instance.AmHost) return;
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, 80, Hazel.SendOption.Reliable, -1);
-            foreach (CustomRoles r in Enum.GetValues(typeof(CustomRoles))) writer.Write(r.getCount());
+            foreach (var kvp in Options.CustomRoleSpawnChances)
+            {
+                writer.Write(kvp.Value.GetSelection());
+                writer.Write(kvp.Key.getCount());
+            }
 
             writer.Write(Options.GameMode.Selection);
             writer.Write(Options.NoGameEnd.GetBool());

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -165,9 +165,7 @@ namespace TownOfHost
             if (Input.GetKeyDown(KeyCode.Tab) && AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Joined)
             {
                 //Logger.SendInGame("tabキーが押されました");
-                main.OptionControllerIsEnable = !main.OptionControllerIsEnable;
-                CustomOptionController.currentPage = CustomOptionController.basePage;
-                CustomOptionController.currentCursor = 0;
+                OptionShower.next();
             }
             if (main.OptionControllerIsEnable)
             {

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -157,18 +157,9 @@ namespace TownOfHost
 
             if (!__instance.TaskText.text.Contains(TaskTextPrefix)) __instance.TaskText.text = TaskTextPrefix + "\r\n" + __instance.TaskText.text;
 
-            if (main.OptionControllerIsEnable)
-            {
-                __instance.GameSettings.text = CustomOptionController.GetOptionText();
-                __instance.GameSettings.fontSizeMin = 2f;
-                __instance.GameSettings.fontSizeMax = 2f;
-                __instance.GameSettings.m_maxHeight = 0.5f;
-            }
-            else
-            {
-                __instance.GameSettings.fontSizeMin = 1.3f;
-                __instance.GameSettings.fontSizeMax = 1.3f;
-            }
+            __instance.GameSettings.text = OptionShower.getText();
+            __instance.GameSettings.fontSizeMin =
+            __instance.GameSettings.fontSizeMax = (TranslationController.Instance.CurrentLanguage.languageID == SupportedLangs.Japanese || Options.ForceJapanese.GetBool()) ? 1.05f : 1.2f;
 
             if (Input.GetKeyDown(KeyCode.Y) && AmongUsClient.Instance.GameMode == GameModes.FreePlay)
             {

--- a/Patches/TaskAssignPatch.cs
+++ b/Patches/TaskAssignPatch.cs
@@ -9,6 +9,7 @@ namespace TownOfHost
         public static void Prefix(ShipStatus __instance,
             [HarmonyArgument(4)] Il2CppSystem.Collections.Generic.List<NormalPlayerTask> unusedTasks)
         {
+            if (!Options.DisableTasks.GetBool()) return;
             List<NormalPlayerTask> disabledTasks = new List<NormalPlayerTask>();
             for (var i = 0; i < unusedTasks.Count; i++)
             {

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -190,5 +190,6 @@ Preset_4,Preset 4,プリセット4
 Preset_5,Preset 5,プリセット5
 Standard,Standard,スタンダード
 GameMode,GameMode,ゲームモード
+PressTabToNextPage,Press Tab To Next Page...,Tabキーを押して次のページへ...
 On,On,オン
 Off,Off,オフ


### PR DESCRIPTION
- マッドメイトの共通設定をマッドメイト系の役職の下に移動
- CanMakeMadmateCountをマフィアの下に移動
- VoteModeをグループ化
- タスクの無効化設定をグループ化
- 割り当て確率をRPCで同期するように変更
- TABキーで表示されるメニューをTOR式に変更