### PR TITLE
SKMadmate作成時にRPCで通知するように修正

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -369,6 +369,13 @@ namespace TownOfHost
             writer.Write((byte)role);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
+        public static void RpcSetCustomRole(PlayerControl targetPlayer, CustomRoles role)
+        {
+            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(targetPlayer.NetId, (byte)CustomRPC.SetCustomRole, Hazel.SendOption.Reliable, -1);
+            writer.Write((byte)targetPlayer.PlayerId);
+            writer.Write((byte)role);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+        }
         public static void ExileAsync(PlayerControl player)
         {
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.Exiled, Hazel.SendOption.Reliable, -1);
@@ -448,6 +455,10 @@ namespace TownOfHost
         }
         public static void SetCustomRole(byte targetId, CustomRoles role)
         {
+            if (role == CustomRoles.SKMadmate)
+            {
+                main.SKMadmateNowCount++;
+            }
             main.AllPlayerCustomRoles[targetId] = role;
             HudManager.Instance.SetHudActive(true);
         }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -369,13 +369,6 @@ namespace TownOfHost
             writer.Write((byte)role);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
-        public static void RpcSetCustomRole(PlayerControl targetPlayer, CustomRoles role)
-        {
-            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(targetPlayer.NetId, (byte)CustomRPC.SetCustomRole, Hazel.SendOption.Reliable, -1);
-            writer.Write((byte)targetPlayer.PlayerId);
-            writer.Write((byte)role);
-            AmongUsClient.Instance.FinishRpcImmediately(writer);
-        }
         public static void ExileAsync(PlayerControl player)
         {
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.Exiled, Hazel.SendOption.Reliable, -1);

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -101,7 +101,6 @@ namespace TownOfHost
                 {
                     var min = mpdistance.OrderBy(c => c.Value).FirstOrDefault();//一番値が小さい
                     PlayerControl targetm = min.Key;
-                    targetm.SetCustomRole(CustomRoles.SKMadmate);
                     targetm.RpcSetCustomRole(CustomRoles.SKMadmate);
                     main.SKMadmateNowCount++;
                     Utils.CustomSyncAllSettings();

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -102,8 +102,8 @@ namespace TownOfHost
                     var min = mpdistance.OrderBy(c => c.Value).FirstOrDefault();//一番値が小さい
                     PlayerControl targetm = min.Key;
                     targetm.SetCustomRole(CustomRoles.SKMadmate);
+                    targetm.RpcSetCustomRole(CustomRoles.SKMadmate);
                     main.SKMadmateNowCount++;
-                    RPC.RpcSetCustomRole(targetm, CustomRoles.SKMadmate);
                     Utils.CustomSyncAllSettings();
                     Utils.NotifyRoles();
                 }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -103,6 +103,7 @@ namespace TownOfHost
                     PlayerControl targetm = min.Key;
                     targetm.SetCustomRole(CustomRoles.SKMadmate);
                     main.SKMadmateNowCount++;
+                    RPC.RpcSetCustomRole(targetm, CustomRoles.SKMadmate);
                     Utils.CustomSyncAllSettings();
                     Utils.NotifyRoles();
                 }


### PR DESCRIPTION
バグ ＃0067-skmadmateの対応

非ホストMODの時、SKMadmate作成の通知を受け取っていないため
自身がSKMadmateにされても表示されず、勝利陣営にも入れなかった。
RPC通知することで対応しました。