### PR TITLE
SKMadmate作成時にRPCで通知するように修正

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -101,7 +101,7 @@ namespace TownOfHost
                 {
                     var min = mpdistance.OrderBy(c => c.Value).FirstOrDefault();//一番値が小さい
                     PlayerControl targetm = min.Key;
-                    targetm.SetCustomRole(CustomRoles.SKMadmate);
+                    targetm.RpcSetCustomRole(CustomRoles.SKMadmate);
                     main.SKMadmateNowCount++;
                     Utils.CustomSyncAllSettings();
                     Utils.NotifyRoles();


### PR DESCRIPTION
バグ ＃0067-skmadmateの対応

非ホストMODの時、SKMadmate作成の通知を受け取っていないため
自身がSKMadmateにされても表示されず、勝利陣営にも入れなかった。
RPC通知することで対応しました。
※PR作り直しました