### PR TITLE
Fix/TerroristWin

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -245,17 +245,20 @@ namespace TownOfHost
             {
                 foreach (var pc in PlayerControl.AllPlayerControls)
                 {
-                    if (!pc.Data.IsDead)
+                    if (pc.isTerrorist())
+                    {
+                        if (PlayerState.getDeathReason(pc.PlayerId) != PlayerState.DeathReason.Vote)
+                        {
+                            //キルされた場合は自爆扱い
+                            PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Suicide);
+                        }
+                    }
+                    else if (!pc.Data.IsDead)
                     {
                         //生存者は爆死
                         pc.MurderPlayer(pc);
                         PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Bombed);
                         PlayerState.isDead[pc.PlayerId] = true;
-                    }
-                    if (pc.isTerrorist() && pc.Data.IsDead)
-                    {
-                        //キルされた場合は自爆扱い
-                        PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Suicide);
                     }
                 }
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TerroristWin, Hazel.SendOption.Reliable, -1);

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -28,6 +28,7 @@ namespace TownOfHost
             if (!AmongUsClient.Instance.AmHost) return; //ホスト以外はこれ以降の処理を実行しません
             if (exiled != null)
             {
+                PlayerState.setDeathReason(exiled.PlayerId, PlayerState.DeathReason.Vote);
                 var role = exiled.getCustomRole();
                 if (role == CustomRoles.Jester && AmongUsClient.Instance.AmHost)
                 {
@@ -49,7 +50,7 @@ namespace TownOfHost
                         p.RpcMurderPlayer(p);
                     }
                 }
-                PlayerState.setDeathReason(exiled.PlayerId, PlayerState.DeathReason.Vote);
+                PlayerState.isDead[exiled.PlayerId] = true;
             }
             if (exiled == null && main.SpelledPlayer != null)
             {


### PR DESCRIPTION
#275 テロリスト勝利時に生存者を爆死されるように変更 の修正。
・テロリストも爆死させていた点の修正
・追放死因の登録タイミング変更
・追放時の死亡判定追加