### PR TITLE
フリープレイ中にNullReferenceExceptionが出る問題を解消

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -1000,6 +1000,10 @@ namespace TownOfHost
 
             hasArgumentException = false;
             ExceptionMessage = "";
+
+            main.ps = new PlayerState();
+            main.IgnoreReportPlayers = new List<byte>();
+            
             try {
 
             roleColors = new Dictionary<CustomRoles, string>(){


### PR DESCRIPTION
modをロードした際にmain.psとmain.IgnoreReportPlayersの初期化処理を実行するように変更しました。