### PR TITLE
フリープレイ中にNullReferenceExceptionが出る問題を解消-v1.5

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -147,6 +147,8 @@ namespace TownOfHost
 
             hasArgumentException = false;
             ExceptionMessage = "";
+
+            main.IgnoreReportPlayers = new List<byte>();
             try
             {
 


### PR DESCRIPTION
modをロードした際にmain.IgnoreReportPlayersの初期化処理を実行するように変更しました。