### PR TITLE
Fix/hide and seek winner v1.4

### DIFF
--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -198,7 +198,7 @@ namespace TownOfHost
                             else {
                                 //HideAndSeek中
                                 if(role == CustomRoles.Default) numTotalAlive++;
-                                if(role == CustomRoles.Impostor) numTotalAlive++;
+                                if(role.isImpostor()) numTotalAlive++;
                             }
 
                             if (playerInfo.Role.TeamType == RoleTeamTypes.Impostor && 

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -198,6 +198,7 @@ namespace TownOfHost
                             else {
                                 //HideAndSeek中
                                 if(role == CustomRoles.Default) numTotalAlive++;
+                                if(role == CustomRoles.Impostor) numTotalAlive++;
                             }
 
                             if (playerInfo.Role.TeamType == RoleTeamTypes.Impostor && 

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -11,10 +11,13 @@ namespace TownOfHost
         {
             Logger.info("ゲームが終了","Phase");
             //winnerListリセット
-            TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
-            main.additionalwinners = new HashSet<AdditionalWinners>();
-            var winner = new List<PlayerControl>();
-            //勝者リスト作成
+            TempData.winners = new();
+            main.winnerList = new();
+            main.additionalwinners = new();
+
+            //作業用勝者リストの作成
+            List<PlayerControl> winner = new();
+
             if (TempData.DidHumansWin(endGameResult.GameOverReason))
             {
                 if (main.currentWinner == CustomWinner.Default) {
@@ -47,39 +50,32 @@ namespace TownOfHost
             endGameResult.GameOverReason == GameOverReason.ImpostorDisconnect ||
             main.currentWinner == CustomWinner.Draw)
             {
-                winner = new List<PlayerControl>();
+                winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
                     winner.Add(p);
                 }
             }
-            foreach (var p in winner)
-            {
-                TempData.winners.Add(new WinningPlayerData(p.Data));
-            }
 
             //単独勝利
             if (main.currentWinner == CustomWinner.Jester && main.JesterCount > 0)
             { //Jester単独勝利
-                TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
+                winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
-                    if (p.PlayerId == main.ExiledJesterID) {
-                        TempData.winners.Add(new WinningPlayerData(p.Data));
-                        winner = new();
+                    if (p.PlayerId == main.ExiledJesterID)
+                    {
                         winner.Add(p);
                     }
                 }
             }
             if (main.currentWinner == CustomWinner.Terrorist && main.TerroristCount> 0)
             { //Terrorist単独勝利
-                TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
+                winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
                     if (p.PlayerId == main.WonTerroristID)
                     {
-                        TempData.winners.Add(new WinningPlayerData(p.Data));
-                        winner = new();
                         winner.Add(p);
                     }
                 }
@@ -88,7 +84,6 @@ namespace TownOfHost
             foreach(var pc in PlayerControl.AllPlayerControls) {
                 if(pc.isOpportunist() && !pc.Data.IsDead && main.currentWinner != CustomWinner.Draw && main.currentWinner != CustomWinner.Terrorist)
                 {
-                    TempData.winners.Add(new WinningPlayerData(pc.Data));
                     winner.Add(pc);
                     main.additionalwinners.Add(AdditionalWinners.Opportunist);
                 }
@@ -96,35 +91,33 @@ namespace TownOfHost
             
             //HideAndSeek専用
             if(main.IsHideAndSeek && main.currentWinner != CustomWinner.Draw) {
-                var winners = new List<PlayerControl>();
+                winner = new();
                 foreach(var pc in PlayerControl.AllPlayerControls) {
                     var hasRole = main.AllPlayerCustomRoles.TryGetValue(pc.PlayerId, out var role);
                     if(!hasRole) continue;
                     if(role == CustomRoles.Default) {
                         if(pc.Data.Role.IsImpostor && TempData.DidImpostorsWin(endGameResult.GameOverReason))
-                            winners.Add(pc);
+                            winner.Add(pc);
                         if(!pc.Data.Role.IsImpostor && TempData.DidHumansWin(endGameResult.GameOverReason))
-                            winners.Add(pc);
+                            winner.Add(pc);
                     }
                     if(role == CustomRoles.Fox && !pc.Data.IsDead) {
-                        winners.Add(pc);
+                        winner.Add(pc);
                         main.additionalwinners.Add(AdditionalWinners.Fox);
                     }
                     if(role == CustomRoles.Troll && pc.Data.IsDead) {
                         main.currentWinner = CustomWinner.Troll;
-                        winners = new List<PlayerControl>();
-                        winners.Add(pc);
+                        winner = new();
+                        winner.Add(pc);
                         break;
                     }
                 }
-                TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
-                foreach(var pc in winners) {
-                    TempData.winners.Add(new WinningPlayerData(pc.Data));
-                }
             }
-            main.winnerList = new();
+
+            //勝者リスト登録
             foreach (var pc in winner)
             {
+                TempData.winners.Add(new WinningPlayerData(pc.Data));
                 main.winnerList.Add(pc.PlayerId);
             }
         }

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -95,15 +95,16 @@ namespace TownOfHost
                 foreach(var pc in PlayerControl.AllPlayerControls) {
                     var hasRole = main.AllPlayerCustomRoles.TryGetValue(pc.PlayerId, out var role);
                     if(!hasRole) continue;
-                    if (role == CustomRoles.Impostor)
+                    if (pc.Data.Role.IsImpostor && TempData.DidImpostorsWin(endGameResult.GameOverReason))
                     {
-                        if (pc.Data.Role.IsImpostor && TempData.DidImpostorsWin(endGameResult.GameOverReason))
-                            winner.Add(pc);
+                        winner.Add(pc);
                     }
                     if (role == CustomRoles.Default)
                     {
-                            if (!pc.Data.Role.IsImpostor && TempData.DidHumansWin(endGameResult.GameOverReason))
+                        if (!pc.Data.Role.IsImpostor && TempData.DidHumansWin(endGameResult.GameOverReason))
+                        {
                             winner.Add(pc);
+                        }
                     }
                     if(role == CustomRoles.Fox && !pc.Data.IsDead) {
                         winner.Add(pc);

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -95,10 +95,14 @@ namespace TownOfHost
                 foreach(var pc in PlayerControl.AllPlayerControls) {
                     var hasRole = main.AllPlayerCustomRoles.TryGetValue(pc.PlayerId, out var role);
                     if(!hasRole) continue;
-                    if(role == CustomRoles.Default) {
-                        if(pc.Data.Role.IsImpostor && TempData.DidImpostorsWin(endGameResult.GameOverReason))
+                    if (role == CustomRoles.Impostor)
+                    {
+                        if (pc.Data.Role.IsImpostor && TempData.DidImpostorsWin(endGameResult.GameOverReason))
                             winner.Add(pc);
-                        if(!pc.Data.Role.IsImpostor && TempData.DidHumansWin(endGameResult.GameOverReason))
+                    }
+                    if (role == CustomRoles.Default)
+                    {
+                            if (!pc.Data.Role.IsImpostor && TempData.DidHumansWin(endGameResult.GameOverReason))
                             winner.Add(pc);
                     }
                     if(role == CustomRoles.Fox && !pc.Data.IsDead) {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -145,7 +145,17 @@ namespace TownOfHost
                 }
                 //通常クルー・インポスター用RPC
                 foreach(var pc in Crewmates) pc.RpcSetCustomRole(CustomRoles.Default);
-                foreach(var pc in Impostors) pc.RpcSetCustomRole(CustomRoles.Impostor);
+                foreach (var pc in Impostors)
+                {
+                    if (pc.Data.Role.Role == RoleTypes.Impostor)
+                    {
+                        pc.RpcSetCustomRole(CustomRoles.Impostor);
+                    }
+                    else
+                    {
+                        pc.RpcSetCustomRole(CustomRoles.Shapeshifter);
+                    }
+                }
             } else {
                 List<PlayerControl> Crewmates = new List<PlayerControl>();
                 List<PlayerControl> Impostors = new List<PlayerControl>();

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -104,7 +104,9 @@ namespace TownOfHost
                 List<PlayerControl> Impostors = new List<PlayerControl>();
                 List<PlayerControl> Crewmates = new List<PlayerControl>();
                 //リスト作成兼色設定処理
+                main.AllPlayerNames = new();
                 foreach(var pc in PlayerControl.AllPlayerControls) {
+                    main.AllPlayerNames.Add(pc.PlayerId,pc.name);
                     main.AllPlayerCustomRoles.Add(pc.PlayerId,CustomRoles.Default);
                     if(pc.Data.Role.IsImpostor) {
                         Impostors.Add(pc);

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -107,11 +107,12 @@ namespace TownOfHost
                 main.AllPlayerNames = new();
                 foreach(var pc in PlayerControl.AllPlayerControls) {
                     main.AllPlayerNames.Add(pc.PlayerId,pc.name);
-                    main.AllPlayerCustomRoles.Add(pc.PlayerId,CustomRoles.Default);
                     if(pc.Data.Role.IsImpostor) {
+                        main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Impostor);
                         Impostors.Add(pc);
                         pc.RpcSetColor(0);
                     } else {
+                        main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Default);
                         Crewmates.Add(pc);
                         pc.RpcSetColor(1);
                     }
@@ -144,7 +145,7 @@ namespace TownOfHost
                 }
                 //通常クルー・インポスター用RPC
                 foreach(var pc in Crewmates) pc.RpcSetCustomRole(CustomRoles.Default);
-                foreach(var pc in Impostors) pc.RpcSetCustomRole(CustomRoles.Default);
+                foreach(var pc in Impostors) pc.RpcSetCustomRole(CustomRoles.Impostor);
             } else {
                 List<PlayerControl> Crewmates = new List<PlayerControl>();
                 List<PlayerControl> Impostors = new List<PlayerControl>();


### PR DESCRIPTION
HideAndSeak時
・名前の登録が出来ていなかったため例外発生して試合結果表示が出来なかった
・勝利者登録で通常モードの勝者リストと二重登録になる可能性があったため整理して修正
・インポスターがイントロでクルーメイトと表示され、結果でもクルーメイト扱いになっていた点の修正

インポスター1 クルーメイト2
インポスター1 クルーメイト1 狐1
インポスター1 クルーメイト1 トロル1
の組み合わせで正常に勝敗が出ることを確認しました