### PR TITLE
[v1.5]エアシップで発生していた問題を修正

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -220,7 +220,7 @@ namespace TownOfHost
                         if (main.isCursed) opt.RoleOptions.ShapeshifterCooldown = 1f;
                         opt.KillCooldown = Options.BHDefaultKillCooldown.GetFloat() * 2;
                     }
-                    if (main.AirshipMeetingCheck)
+                    else
                     {
                         opt.RoleOptions.ShapeshifterCooldown = Options.BHDefaultKillCooldown.GetFloat() - 10f;
                         opt.KillCooldown = (Options.BHDefaultKillCooldown.GetFloat() - 10f) * 2;
@@ -232,7 +232,7 @@ namespace TownOfHost
                         opt.RoleOptions.ShapeshifterCooldown = Options.SerialKillerLimit.GetFloat();
                         opt.KillCooldown = Options.SerialKillerCooldown.GetFloat() * 2;
                     }
-                    if (main.AirshipMeetingCheck)
+                    else
                     {
                         opt.RoleOptions.ShapeshifterCooldown = Options.SerialKillerLimit.GetFloat() - 10f;
                         opt.KillCooldown = (Options.SerialKillerCooldown.GetFloat() - 10f) * 2;
@@ -265,7 +265,7 @@ namespace TownOfHost
                             }
                         }
                     }
-                    if (main.AirshipMeetingCheck)
+                    else
                     {
                         opt.KillCooldown = (Options.BHDefaultKillCooldown.GetFloat() - 10f) * 2;
                         opt.RoleOptions.ShapeshifterCooldown = Options.BountyTargetChangeTime.GetFloat() + Options.BountyFailureKillCooldown.GetFloat() - 10f;

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -214,37 +214,61 @@ namespace TownOfHost
                     if (!main.BountyMeetingCheck) opt.KillCooldown = Options.BHDefaultKillCooldown.GetFloat() * 2;
                     break;
                 case CustomRoles.Warlock:
-                    if (!main.isCursed) opt.RoleOptions.ShapeshifterCooldown = Options.BHDefaultKillCooldown.GetFloat();
-                    if (main.isCursed) opt.RoleOptions.ShapeshifterCooldown = 1f;
-                    opt.KillCooldown = Options.BHDefaultKillCooldown.GetFloat() * 2;
-                    break;
-                case CustomRoles.SerialKiller:
-                    opt.RoleOptions.ShapeshifterCooldown = Options.SerialKillerLimit.GetFloat();
-                    opt.KillCooldown = Options.SerialKillerCooldown.GetFloat() * 2;
-                    break;
-                case CustomRoles.BountyHunter:
-                    opt.RoleOptions.ShapeshifterCooldown = Options.BountyTargetChangeTime.GetFloat() + Options.BountyFailureKillCooldown.GetFloat();
-                    if (main.BountyMeetingCheck)
-                    {//会議後のキルクール
+                    if (!main.AirshipMeetingCheck)
+                    {
+                        if (!main.isCursed) opt.RoleOptions.ShapeshifterCooldown = Options.BHDefaultKillCooldown.GetFloat();
+                        if (main.isCursed) opt.RoleOptions.ShapeshifterCooldown = 1f;
                         opt.KillCooldown = Options.BHDefaultKillCooldown.GetFloat() * 2;
                     }
-                    else
+                    if (main.AirshipMeetingCheck)
                     {
-                        if (!main.isBountyKillSuccess)
-                        {//ターゲット以外をキルした時の処理
-                            opt.KillCooldown = Options.BountyFailureKillCooldown.GetFloat() * 2;
-                            Logger.info("ターゲット以外をキル");
+                        opt.RoleOptions.ShapeshifterCooldown = Options.BHDefaultKillCooldown.GetFloat() - 10f;
+                        opt.KillCooldown = (Options.BHDefaultKillCooldown.GetFloat() - 10f) * 2;
+                    }
+                    break;
+                case CustomRoles.SerialKiller:
+                    if (!main.AirshipMeetingCheck)
+                    {
+                        opt.RoleOptions.ShapeshifterCooldown = Options.SerialKillerLimit.GetFloat();
+                        opt.KillCooldown = Options.SerialKillerCooldown.GetFloat() * 2;
+                    }
+                    if (main.AirshipMeetingCheck)
+                    {
+                        opt.RoleOptions.ShapeshifterCooldown = Options.SerialKillerLimit.GetFloat() - 10f;
+                        opt.KillCooldown = (Options.SerialKillerCooldown.GetFloat() - 10f) * 2;
+                    }
+                    break;
+                case CustomRoles.BountyHunter:
+                    if (!main.AirshipMeetingCheck)
+                    {
+                        opt.RoleOptions.ShapeshifterCooldown = Options.BountyTargetChangeTime.GetFloat() + Options.BountyFailureKillCooldown.GetFloat();
+                        if (main.BountyMeetingCheck)
+                        {//会議後のキルクール
+                            opt.KillCooldown = Options.BHDefaultKillCooldown.GetFloat() * 2;
                         }
-                        if (!main.BountyTimerCheck)
-                        {//ゼロって書いてあるけど実際はキルクールはそのまま維持されるので大丈夫
-                            opt.KillCooldown = 10;
-                            Logger.info("ターゲットリセット");
+                        else
+                        {
+                            if (!main.isBountyKillSuccess)
+                            {//ターゲット以外をキルした時の処理
+                                opt.KillCooldown = Options.BountyFailureKillCooldown.GetFloat() * 2;
+                                Logger.info("ターゲット以外をキル");
+                            }
+                            if (!main.BountyTimerCheck)
+                            {//ゼロって書いてあるけど実際はキルクールはそのまま維持されるので大丈夫
+                                opt.KillCooldown = 10;
+                                Logger.info("ターゲットリセット");
+                            }
+                            if (main.isBountyKillSuccess)
+                            {//ターゲットをキルした時の処理
+                                opt.KillCooldown = Options.BountySuccessKillCooldown.GetFloat() * 2;
+                                Logger.info("ターゲットをキル");
+                            }
                         }
-                        if (main.isBountyKillSuccess)
-                        {//ターゲットをキルした時の処理
-                            opt.KillCooldown = Options.BountySuccessKillCooldown.GetFloat() * 2;
-                            Logger.info("ターゲットをキル");
-                        }
+                    }
+                    if (main.AirshipMeetingCheck)
+                    {
+                        opt.KillCooldown = (Options.BHDefaultKillCooldown.GetFloat() - 10f) * 2;
+                        opt.RoleOptions.ShapeshifterCooldown = Options.BountyTargetChangeTime.GetFloat() + Options.BountyFailureKillCooldown.GetFloat() - 10f;
                     }
                     break;
                 case CustomRoles.Shapeshifter:

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -210,7 +210,7 @@ namespace TownOfHost
             SetupRoleOptions(1400, CustomRoles.Warlock);
             SetupRoleOptions(1500, CustomRoles.Witch);
             SetupRoleOptions(1600, CustomRoles.Mafia);
-            BHDefaultKillCooldown = CustomOption.Create(1013, Color.white, "BHDefaultKillCooldown", 30, 1, 999, 1, null, true);
+            BHDefaultKillCooldown = CustomOption.Create(1013, Color.white, "BHDefaultKillCooldown", 30, 10, 999, 1, null, true);
             DefaultShapeshiftCooldown = CustomOption.Create(1013, Color.white, "DefaultShapeshiftCooldown", 15, 5, 999, 5, null, true);
 
             CanMakeMadmateCount = CustomOption.Create(5000, Color.white, "CanMakeMadmateCount", 1, 0, 15, 1, null, true);

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -100,7 +100,6 @@ namespace TownOfHost
                         main.isCurseAndKill[pc.PlayerId] = false;
                     }
                 }
-                main.AirshipMeetingCheck = true;
             }
             main.ArsonistKillCooldownCheck = true;
             main.BountyMeetingCheck = true;

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -68,27 +68,27 @@ namespace TownOfHost
             main.SpelledPlayer.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);
             if (PlayerControl.GameOptions.MapId != 4)
             {
-                foreach (var wr in PlayerControl.AllPlayerControls)
+                foreach (var pc in PlayerControl.AllPlayerControls)
                 {
-                    if (wr.isSerialKiller())
+                    if (pc.isSerialKiller())
                     {
-                        wr.RpcGuardAndKill(wr);
-                        main.SerialKillerTimer.Add(wr.PlayerId, 0f);
+                        pc.RpcGuardAndKill(pc);
+                        main.SerialKillerTimer.Add(pc.PlayerId, 0f);
                     }
-                    if (wr.isBountyHunter())
+                    if (pc.isBountyHunter())
                     {
-                        wr.RpcGuardAndKill(wr);
-                        main.BountyTimer.Add(wr.PlayerId, 0f);
+                        pc.RpcGuardAndKill(pc);
+                        main.BountyTimer.Add(pc.PlayerId, 0f);
                     }
-                    if (wr.isWarlock())
+                    if (pc.isWarlock())
                     {
-                        wr.RpcGuardAndKill(wr);
-                        main.CursedPlayers[wr.PlayerId] = (null);
-                        main.isCurseAndKill[wr.PlayerId] = false;
+                        pc.RpcGuardAndKill(pc);
+                        main.CursedPlayers[pc.PlayerId] = (null);
+                        main.isCurseAndKill[pc.PlayerId] = false;
                     }
                 }
             }
-            if (PlayerControl.GameOptions.MapId == 4)
+            if (PlayerControl.GameOptions.MapId == 4)//Airship用
             {
                 foreach (var pc in PlayerControl.AllPlayerControls)
                 {

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -66,26 +66,43 @@ namespace TownOfHost
                 if (CustomRoles.BountyHunter.getCount() == 0) main.RefixCooldownDelay = main.RealOptionsData.KillCooldown - 3f;
             }
             main.SpelledPlayer.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);
-            foreach (var wr in PlayerControl.AllPlayerControls)
+            if (PlayerControl.GameOptions.MapId != 4)
             {
-                if (wr.isSerialKiller())
+                foreach (var wr in PlayerControl.AllPlayerControls)
                 {
-                    wr.RpcGuardAndKill(wr);
-                    main.SerialKillerTimer.Add(wr.PlayerId, 0f);
+                    if (wr.isSerialKiller())
+                    {
+                        wr.RpcGuardAndKill(wr);
+                        main.SerialKillerTimer.Add(wr.PlayerId, 0f);
+                    }
+                    if (wr.isBountyHunter())
+                    {
+                        wr.RpcGuardAndKill(wr);
+                        main.BountyTimer.Add(wr.PlayerId, 0f);
+                    }
+                    if (wr.isWarlock())
+                    {
+                        wr.RpcGuardAndKill(wr);
+                        main.CursedPlayers[wr.PlayerId] = (null);
+                        main.isCurseAndKill[wr.PlayerId] = false;
+                    }
                 }
-                if (wr.isBountyHunter())
-                {
-                    wr.RpcGuardAndKill(wr);
-                    main.BountyTimer.Add(wr.PlayerId, 0f);
-                }
-                if (wr.isWarlock())
-                {
-                    wr.RpcGuardAndKill(wr);
-                    main.CursedPlayers[wr.PlayerId] = (null);
-                    main.isCurseAndKill[wr.PlayerId] = false;
-                }
-                if (wr.isArsonist()) wr.RpcGuardAndKill(wr);
             }
+            if (PlayerControl.GameOptions.MapId == 4)
+            {
+                foreach (var pc in PlayerControl.AllPlayerControls)
+                {
+                    if (pc.isSerialKiller() || pc.isBountyHunter()) main.AirshipMeetingTimer.Add(pc.PlayerId, 0f);
+                    if (pc.isWarlock())
+                    {
+                        main.AirshipMeetingTimer.Add(pc.PlayerId, 0f);
+                        main.CursedPlayers[pc.PlayerId] = (null);
+                        main.isCurseAndKill[pc.PlayerId] = false;
+                    }
+                }
+                main.AirshipMeetingCheck = true;
+            }
+            main.ArsonistKillCooldownCheck = true;
             main.BountyMeetingCheck = true;
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -453,6 +453,11 @@ namespace TownOfHost
                 //バウハンのキルクールの変換とターゲットのリセット
                 if (main.BountyTimer.ContainsKey(__instance.PlayerId))
                 {
+                    if (main.BountyTimer[__instance.PlayerId] >= Options.BountyTargetChangeTime.GetFloat() + Options.BountyFailureKillCooldown.GetFloat() - 1f && main.AirshipMeetingCheck)
+                    {
+                        main.AirshipMeetingCheck = false;
+                        Utils.CustomSyncAllSettings();
+                    }
                     if (main.BountyTimer[__instance.PlayerId] >= Options.BountyTargetChangeTime.GetFloat() + Options.BountyFailureKillCooldown.GetFloat())//時間経過でターゲットをリセットする処理
                     {
                         main.BountyMeetingCheck = false;
@@ -491,6 +496,11 @@ namespace TownOfHost
                 }
                 if (main.AirshipMeetingTimer.ContainsKey(__instance.PlayerId))
                 {
+                    if (main.AirshipMeetingTimer[__instance.PlayerId] >= 9f && !main.AirshipMeetingCheck)
+                    {
+                        main.AirshipMeetingCheck = true;
+                        Utils.CustomSyncAllSettings();
+                    }
                     if (main.AirshipMeetingTimer[__instance.PlayerId] >= 10f)
                     {
                         if (__instance.isSerialKiller())

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -135,6 +135,11 @@ namespace TownOfHost
         public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
         {
             if (!AmongUsClient.Instance.AmHost) return false;
+            if (main.AirshipMeetingCheck)
+            {
+                main.AirshipMeetingCheck = false;
+                Utils.CustomSyncAllSettings();
+            }
             Logger.SendToFile("CheckMurder発生: " + __instance.name + "=>" + target.name);
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek && Options.HideAndSeekKillDelayTimer > 0)
             {
@@ -482,6 +487,31 @@ namespace TownOfHost
                     {
                         main.BountyTimer[__instance.PlayerId] =
                         (main.BountyTimer[__instance.PlayerId] + Time.fixedDeltaTime);
+                    }
+                }
+                if (main.AirshipMeetingTimer.ContainsKey(__instance.PlayerId))
+                {
+                    if (main.AirshipMeetingTimer[__instance.PlayerId] >= 10f)
+                    {
+                        if (__instance.isSerialKiller())
+                        {
+                            __instance.RpcGuardAndKill(__instance);
+                            main.SerialKillerTimer.Add(__instance.PlayerId, 10f);
+                        }
+                        if (__instance.isBountyHunter())
+                        {
+                            __instance.RpcGuardAndKill(__instance);
+                            main.BountyTimer.Add(__instance.PlayerId, 10f);
+                        }
+                        if (__instance.isWarlock())
+                        {
+                            __instance.RpcGuardAndKill(__instance);
+                        }
+                        main.AirshipMeetingTimer.Remove(__instance.PlayerId);
+                    }
+                    else
+                    {
+                        main.AirshipMeetingTimer[__instance.PlayerId] = (main.AirshipMeetingTimer[__instance.PlayerId] + Time.fixedDeltaTime);
                     }
                 }
                 if (main.ArsonistTimer.ContainsKey(__instance.PlayerId))//アーソニストが誰かを塗っているとき

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -423,7 +423,7 @@ namespace TownOfHost
                 if (main.SerialKillerTimer.ContainsKey(__instance.PlayerId))
                 {
                     if (main.SerialKillerTimer[__instance.PlayerId] >= Options.SerialKillerLimit.GetFloat())
-                    {//時間が来たとき
+                    {//自滅時間が来たとき
                         if (!__instance.Data.IsDead)
                         {
                             PlayerState.setDeathReason(__instance.PlayerId, PlayerState.DeathReason.Suicide);//死因：自滅

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -26,6 +26,8 @@ namespace TownOfHost
             main.isTargetKilled = new Dictionary<byte, bool>();
             main.CursedPlayers = new Dictionary<byte, PlayerControl>();
             main.isCurseAndKill = new Dictionary<byte, bool>();
+            main.AirshipMeetingTimer = new Dictionary<byte, float>();
+            main.AirshipMeetingCheck = false;
             main.SKMadmateNowCount = 0;
             main.isCursed = false;
 

--- a/main.cs
+++ b/main.cs
@@ -77,6 +77,8 @@ namespace TownOfHost
         public static Dictionary<(byte, byte), bool> isDoused = new Dictionary<(byte, byte), bool>();
         public static Dictionary<byte, int> DousedPlayerCount = new Dictionary<byte, int>();
         public static Dictionary<byte, (PlayerControl, float)> ArsonistTimer = new Dictionary<byte, (PlayerControl, float)>();
+        public static Dictionary<byte, float> AirshipMeetingTimer = new Dictionary<byte, float>();
+        public static bool AirshipMeetingCheck;
         public static int SKMadmateNowCount;
         public static bool witchMeeting;
         public static bool isCursed;


### PR DESCRIPTION
エアシップで沸き位置変更によるGuardAndKillが実行されないバグを修正
具体的には、会議終了後１０秒でGuardandkillが起きるように変更。