### PR TITLE
会議後に死なないように変更

### DIFF
--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -124,13 +124,6 @@ namespace TownOfHost
                     p.RpcMurderPlayer(p);
                     recall = true;
                 }
-                foreach (var p in main.CursedPlayers.Values)
-                {
-                    PlayerState.setDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
-                    main.IgnoreReportPlayers.Add(p.PlayerId);
-                    p.RpcMurderPlayer(p);
-                    recall = true;
-                }
 
                 //霊界用暗転バグ対処
                 foreach (var pc in PlayerControl.AllPlayerControls)


### PR DESCRIPTION
守護天使バグが直り、会議後に呪った人を殺す必要がなくなったので殺している部分を削除しました