### PR TITLE
[v1.5]Fix/spelld kill

### DIFF
--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -50,15 +50,6 @@ namespace TownOfHost
                 }
                 PlayerState.isDead[exiled.PlayerId] = true;
             }
-            if (exiled == null && main.SpelledPlayer != null)
-            {
-                foreach (var p in main.SpelledPlayer)
-                {
-                    PlayerState.setDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
-                    main.IgnoreReportPlayers.Add(p.PlayerId);
-                    p.RpcMurderPlayer(p);
-                }
-            }
             if (AmongUsClient.Instance.AmHost && main.isFixedCooldown)
                 main.RefixCooldownDelay = main.RealOptionsData.KillCooldown - 3f;
             main.SpelledPlayer.RemoveAll(pc => pc == null || pc.Data == null || pc.Data.IsDead || pc.Data.Disconnected);

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -314,6 +314,10 @@ namespace TownOfHost
         {
             Logger.info("会議が終了", "Phase");
             if (!AmongUsClient.Instance.AmHost) return;
+
+            //エアシップの場合スポーン位置選択が発生するため死体消し用の会議を5秒遅らせる。
+            var additional = PlayerControl.GameOptions.MapId == 4 ? 5f : 0f;
+
             if (CheckForEndVotingPatch.recall)
             {
                 foreach (var pc in PlayerControl.AllPlayerControls)
@@ -324,13 +328,13 @@ namespace TownOfHost
                         {
                             pc.ReportDeadBody(Utils.getPlayerById(main.IgnoreReportPlayers.Last()).Data);
                         },
-                            0.2f, "Recall Meeting");
+                            0.2f + additional, "Recall Meeting");
                         new LateTask(() =>
                         {
                             MeetingHud.Instance.RpcClose();
                             CheckForEndVotingPatch.recall = false;
                         },
-                            0.5f, "Cancel Meeting");
+                            0.5f + additional, "Cancel Meeting");
                         break;
                     }
                 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -117,12 +117,15 @@ namespace TownOfHost
                 exiledPlayer = GameData.Instance.AllPlayers.ToArray().FirstOrDefault(info => !tie && info.PlayerId == exileId);
 
                 __instance.RpcVotingComplete(states, exiledPlayer, tie); //RPC
-                foreach (var p in main.SpelledPlayer)
+                if (!Utils.getPlayerById(exileId).isWitch())
                 {
-                    PlayerState.setDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
-                    main.IgnoreReportPlayers.Add(p.PlayerId);
-                    p.RpcMurderPlayer(p);
-                    recall = true;
+                    foreach (var p in main.SpelledPlayer)
+                    {
+                        PlayerState.setDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
+                        main.IgnoreReportPlayers.Add(p.PlayerId);
+                        p.RpcMurderPlayer(p);
+                        recall = true;
+                    }
                 }
                 main.SpelledPlayer.Clear();
 

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -124,6 +124,7 @@ namespace TownOfHost
                     p.RpcMurderPlayer(p);
                     recall = true;
                 }
+                main.SpelledPlayer.Clear();
 
                 //霊界用暗転バグ対処
                 foreach (var pc in PlayerControl.AllPlayerControls)


### PR DESCRIPTION
Witchに呪われた人が会議後に死ぬ際、以下の問題が発生。
・投票直後にキルされるが、死体消しの再会議時にもう一度キルされ死体が残る
=>投票直後のキル後にSpelledPlayerが初期化されていないため追加。
　会議後にキルするコードが残っていたため削除

・Airshipでは会議後にスポーン位置選択が発生するが死体消し再会議のため2重に発生する
=>AirShipに限り再会議を5秒遅延させ初回と2回目のスポーン位置選択のタイミングをずらした。
5秒間は2重に見える問題は発生しますが
・初回分を選択してもスポーンは発生せず2回目分での決定になる。
・初回分がタイムアウトしても5秒の猶予がある。
という点で利点があると思います。