### PR TITLE
[v1.4]Feature/better-logs-v1.4

### DIFF
--- a/Modules/LateTask.cs
+++ b/Modules/LateTask.cs
@@ -19,13 +19,13 @@ namespace TownOfHost {
             this.timer = time;
             this.name = name;
             Tasks.Add(this);
-            Logger.info("New LateTask \"" + name + "\" is created","LateTask");
+            Logger.info($"\"{name}\" is created","LateTask");
         }
         public static void Update(float deltaTime) {
             var TasksToRemove = new List<LateTask>();
             Tasks.ForEach((task) => {
                 if(task.run(deltaTime)) {
-                    Logger.info("LateTask \"" + task.name + "\" is finished","LateTask");
+                    Logger.info($"\"{task.name}\" is finished","LateTask");
                     TasksToRemove.Add(task);
                 }
             });

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -28,7 +28,7 @@ namespace TownOfHost
             for(var i = 0; i < __instance.playerStates.Length; i++) {
                 PlayerVoteArea ps = __instance.playerStates[i];
                 if(ps == null) continue;
-                Logger.info($"{ps.TargetPlayerId}:{ps.VotedFor}","Vote");
+                Logger.info($"{ps.TargetPlayerId}({main.getVoteName(ps.TargetPlayerId)})\t=> {ps.VotedFor}({main.getVoteName(ps.VotedFor)})","Vote");
                 var voter = main.getPlayerById(ps.TargetPlayerId);
                 if(voter == null || voter.Data == null || voter.Data.Disconnected) continue;
                 if(ps.VotedFor == 253 && !voter.Data.IsDead)//スキップ
@@ -82,22 +82,22 @@ namespace TownOfHost
             int max = 0;
             Logger.info("===追放者確認処理開始===","Vote");
             foreach(var data in VotingData) {
-                Logger.info(data.Key + ": " + data.Value,"Vote");
+                Logger.info($"{data.Key}({main.getVoteName(data.Key)}): {main.getVoteName(data.Value)}票","Vote");
                 if(data.Value > max)
                 {
-                    Logger.info(data.Key + "番が最高値を更新(" + data.Value + ")","Vote");
+                    Logger.info($"{data.Key}({main.getVoteName(data.Key)})が最高値を更新({data.Value})","Vote");
                     exileId = data.Key;
                     max = data.Value;
                     tie = false;
                 } else if(data.Value == max) {
-                    Logger.info(data.Key + "番が" + exileId + "番と同数(" + data.Value + ")","Vote");
+                    Logger.info($"{data.Key}({main.getVoteName(data.Key)})が{exileId}({main.getVoteName(exileId)})と同数({data.Value})","Vote");
                     exileId = byte.MaxValue;
                     tie = true;
                 }
-                Logger.info("exileId: " + exileId + ", max: " + max,"Vote");
+                Logger.info($"exileId: {exileId}, max: {max}","Vote");
             }
 
-            Logger.info("追放者決定: " + exileId,"Vote");
+            Logger.info($"追放者決定: {exileId}({main.getVoteName(exileId)}:{main.getPlayerById(exileId).getCustomRole()})","Vote");
             exiledPlayer = GameData.Instance.AllPlayers.ToArray().FirstOrDefault(info => !tie && info.PlayerId == exileId);
 
             __instance.RpcVotingComplete(states, exiledPlayer, tie); //RPC

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -13,7 +13,7 @@ namespace TownOfHost
         {
             if (!target.Data.IsDead || !AmongUsClient.Instance.AmHost)
                 return;
-            Logger.SendToFile("MurderPlayer発生: " + __instance.name + "=>" + target.name);
+            Logger.info($"発生: {__instance.name}({__instance.getCustomRole()}) => {target.name}({target.getCustomRole()})","MurderPlayer");
             if(__instance == target && __instance.getCustomRole() == CustomRoles.Sheriff)
             {
                 main.ps.setDeathReason(__instance.PlayerId, PlayerState.DeathReason.Suicide);
@@ -43,7 +43,7 @@ namespace TownOfHost
         public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
         {
             if (!AmongUsClient.Instance.AmHost) return false;
-            Logger.SendToFile("CheckMurder発生: " + __instance.name + "=>" + target.name);
+            Logger.info($"発生: {__instance.name}({__instance.getCustomRole()}) => {target.name}({target.getCustomRole()})","CheckMerder");
             if(main.IsHideAndSeek && main.HideAndSeekKillDelayTimer > 0) {
                 Logger.info("HideAndSeekの待機時間中だったため、キルをキャンセルしました。");
                 return false;

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -57,7 +57,7 @@ namespace TownOfHost
             [HarmonyArgument(2)] byte amount) {
             Logger.msg("SystemType: " + systemType.ToString() + ", PlayerName: " + player.name + ", amount: " + amount);
             if(RepairSender.enabled && AmongUsClient.Instance.GameMode != GameModes.OnlineGame)
-            Logger.SendInGame("SystemType: " + systemType.ToString() + ", PlayerName: " + player.name + ", amount: " + amount);
+                Logger.SendInGame("SystemType: " + systemType.ToString() + ", PlayerName: " + player.name + ", amount: " + amount);
 
             if(!AmongUsClient.Instance.AmHost) return true;
             if(main.IsHideAndSeek && systemType == SystemTypes.Sabotage) return false;

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -195,30 +195,6 @@ namespace TownOfHost
         public static void Postfix() {
             Logger.info("ShipStatus.Start");
             Logger.info("ゲームが開始","Phase");
-            
-            Logger.info("--------名前表示--------");
-            foreach(var pc in PlayerControl.AllPlayerControls)
-            {
-                Logger.info($"{pc.PlayerId}:{pc.name}:{pc.nameText.text}");
-                main.RealNames[pc.PlayerId] = pc.name;
-                pc.nameText.text = pc.name; 
-            }
-            Logger.info("----------環境----------");
-            foreach(var pc in PlayerControl.AllPlayerControls)
-            {
-                var text = pc.PlayerId == PlayerControl.LocalPlayer.PlayerId ? "[*]" : "";
-                text += $"{pc.PlayerId}:{pc.name}:{(pc.getClient().PlatformData.Platform).ToString().Replace("Standalone","")}";
-                if(main.playerVersion.TryGetValue(pc.PlayerId,out PlayerVersion pv))
-                {
-                    text += $":Mod({pv.version}:";
-                    text += pv.beta_ver == -1? ":" : pv.beta_ver+":";
-                    text += $"{pv.tag})";
-                }else text += ":Vanilla";
-                Logger.info(text);
-            }
-            Logger.info("---------その他---------");
-            Logger.info($"マップ: {PlayerControl.GameOptions.MapId}");
-            Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人");
         }
     }
     [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Begin))]

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -282,6 +282,8 @@ namespace TownOfHost
                 }else text += ":Vanilla";
                 Logger.info(text);
             }
+            Logger.info("--------基本設定--------");
+            Logger.info(PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10));
             Logger.info("---------その他---------");
             Logger.info($"マップ: {PlayerControl.GameOptions.MapId}");
             Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人");

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -264,6 +264,11 @@ namespace TownOfHost
                 main.RealNames[pc.PlayerId] = pc.name;
                 pc.nameText.text = pc.name; 
             }
+            Logger.info("------役職割り当て------");
+            foreach(var pc in PlayerControl.AllPlayerControls)
+            {
+                Logger.info($"{pc.name}({pc.PlayerId}):{pc.getRoleName()}");
+            }
             Logger.info("----------環境----------");
             foreach(var pc in PlayerControl.AllPlayerControls)
             {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -256,6 +256,30 @@ namespace TownOfHost
             }
             main.CustomSyncAllSettings();
             SetColorPatch.IsAntiGlitchDisabled = false;
+            
+            Logger.info("--------名前表示--------");
+            foreach(var pc in PlayerControl.AllPlayerControls)
+            {
+                Logger.info($"{pc.PlayerId}:{pc.name}:{pc.nameText.text}");
+                main.RealNames[pc.PlayerId] = pc.name;
+                pc.nameText.text = pc.name; 
+            }
+            Logger.info("----------環境----------");
+            foreach(var pc in PlayerControl.AllPlayerControls)
+            {
+                var text = pc.PlayerId == PlayerControl.LocalPlayer.PlayerId ? "[*]" : "";
+                text += $"{pc.PlayerId}:{pc.name}:{(pc.getClient().PlatformData.Platform).ToString().Replace("Standalone","")}";
+                if(main.playerVersion.TryGetValue(pc.PlayerId,out PlayerVersion pv))
+                {
+                    text += $":Mod({pv.version}:";
+                    text += pv.beta_ver == -1? ":" : pv.beta_ver+":";
+                    text += $"{pv.tag})";
+                }else text += ":Vanilla";
+                Logger.info(text);
+            }
+            Logger.info("---------その他---------");
+            Logger.info($"マップ: {PlayerControl.GameOptions.MapId}");
+            Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人");
 
             Logger.msg("SelectRolesPatch.Postfix.End");
         }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -285,7 +285,6 @@ namespace TownOfHost
             Logger.info("--------基本設定--------");
             Logger.info(PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10));
             Logger.info("---------その他---------");
-            Logger.info($"マップ: {PlayerControl.GameOptions.MapId}");
             Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人");
 
             Logger.msg("SelectRolesPatch.Postfix.End");

--- a/main.cs
+++ b/main.cs
@@ -938,6 +938,7 @@ namespace TownOfHost
             Logger = BepInEx.Logging.Logger.CreateLogSource("TownOfHost");
             TownOfHost.Logger.enable();
             TownOfHost.Logger.disable("NotifyRoles");
+            TownOfHost.Logger.disable("getPlayerTaskState");
 
             currentWinner = CustomWinner.Default;
             additionalwinners = new HashSet<AdditionalWinners>();

--- a/main.cs
+++ b/main.cs
@@ -482,6 +482,15 @@ namespace TownOfHost
                 );
 
         }
+        public static string getVoteName(int num)
+        {
+            string name = "invalid";
+            if(num < 15) name = getPlayerById(num).getRealName();
+            if(num == 253) name = "Skip";
+            if(num == 254) name = "None";
+            if(num == 255) name = "Dead";
+            return name;
+        }
         public static Dictionary<byte, string> RealNames;
         public static string getOnOff(bool value) => value ? "ON" : "OFF";
         public static string TextCursor => TextCursorVisible ? "_" : "";

--- a/main.cs
+++ b/main.cs
@@ -766,7 +766,7 @@ namespace TownOfHost
             var callerMethod = caller.GetMethod();
             string callerMethodName = callerMethod.Name;
             string callerClassName = callerMethod.DeclaringType.FullName;
-            TownOfHost.Logger.info("NotifyRolesが" + callerClassName + "." + callerMethodName + "から呼び出されました","NotifyRoles");
+            TownOfHost.Logger.info(callerClassName + "." + callerMethodName + "から呼び出されました","NotifyRoles");
             HudManagerPatch.NowCallNotifyRolesCount++;
             HudManagerPatch.LastSetNameDesyncCount = 0;
 
@@ -783,7 +783,7 @@ namespace TownOfHost
             //seer:ここで行われた変更を見ることができるプレイヤー
             //target:seerが見ることができる変更の対象となるプレイヤー
             foreach(var seer in PlayerControl.AllPlayerControls) {
-                TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.name + ":START","NotifyRoles");
+                TownOfHost.Logger.info("Loop1-" + seer.name + ":START","NotifyRoles");
                 //Loop1-bottleのSTART-END間でKeyNotFoundException
                 //seerが落ちているときに何もしない
                 if(seer.Data.Disconnected) continue;
@@ -878,7 +878,7 @@ namespace TownOfHost
                     }
                     if(doCancel) continue;
 
-                    TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.name + ":START","NotifyRoles");
+                    TownOfHost.Logger.info("Loop2-" + target.name + ":START","NotifyRoles");
 
                     //他人のタスクはtargetがタスクを持っているかつ、seerが死んでいる場合のみ表示されます。それ以外の場合は空になります。
                     string TargetTaskText = hasTasks(target.Data, false) && seer.Data.IsDead ? $"<color=#ffff00>({main.getTaskText(target.Data.Tasks)})</color>" : "";
@@ -915,9 +915,9 @@ namespace TownOfHost
                     target.RpcSetNamePrivate(TargetName, true, seer);
                     HudManagerPatch.LastSetNameDesyncCount++;
 
-                    TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.name + ":END","NotifyRoles");
+                    TownOfHost.Logger.info("Loop2-" + target.name + ":END","NotifyRoles");
                 }
-                TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.name + ":END","NotifyRoles");
+                TownOfHost.Logger.info("Loop1-" + seer.name + ":END","NotifyRoles");
             }
             main.witchMeeting = false;
         }
@@ -948,6 +948,7 @@ namespace TownOfHost
             TownOfHost.Logger.enable();
             TownOfHost.Logger.disable("NotifyRoles");
             TownOfHost.Logger.disable("getPlayerTaskState");
+            TownOfHost.Logger.disable("SetNameRPC");
 
             currentWinner = CustomWinner.Default;
             additionalwinners = new HashSet<AdditionalWinners>();


### PR DESCRIPTION
- ログを一部整理
- ゲーム開始時にログへ基本設定を出力するように
- 投票ログにプレイヤー名を付随表示させるように変更
- getPlayerTaskStateとSetNameRPCのログを非表示に
- 投票をプレイヤー名や種別に変換するメソッドを追加

テスト内容:
- 2試合行い想定通りのログ出力がなされるか