### PR TITLE
[v1.5]Fix/LateTaskAntiException_1.5

### DIFF
--- a/Modules/LateTask.cs
+++ b/Modules/LateTask.cs
@@ -31,9 +31,17 @@ namespace TownOfHost
             var TasksToRemove = new List<LateTask>();
             Tasks.ForEach((task) =>
             {
-                if (task.run(deltaTime))
+                try
                 {
-                    Logger.info("LateTask \"" + task.name + "\" is finished");
+                    if (task.run(deltaTime))
+                    {
+                        Logger.info($"\"{task.name}\" is finished", "LateTask");
+                        TasksToRemove.Add(task);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.error($"{ex.GetType().ToString()}: {ex.Message}  in \"{task.name}\"", "LateTask.Error");
                     TasksToRemove.Add(task);
                 }
             });


### PR DESCRIPTION
# 変更内容
LateTask内で例外が発生した場合にmodスタンプが動かなくなる問題を修正
例外が発生したLateTaskは例外内容を出力後、再実行されることはありません。
#379 のv1.5版です。
# 動作確認内容
例外を発生させるだけのLateTaskを作成し、実行してもmodスタンプが止まらないことを確認