### PR TITLE
Fix/set is dead in murder player

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -58,6 +58,7 @@ namespace TownOfHost
                 if (pc.isLastImpostor())
                     main.AllPlayerKillCooldown[pc.PlayerId] = Options.LastImpostorKillCooldown.GetFloat();
             }
+            PlayerState.isDead[target.PlayerId] = true;
             Utils.CountAliveImpostors();
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();


### PR DESCRIPTION
MurderPlayer内でのisDead設定が消えていたため、試合結果が正常に出ていませんでした。
