### PR TITLE
[v1.5]RpcVersionCheckの遅延秒数を修正

### DIFF
--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -12,7 +12,7 @@ namespace TownOfHost
             Logger.info("RealNamesをリセット");
             main.RealNames = new Dictionary<byte, string>();
             main.playerVersion = new Dictionary<byte, PlayerVersion>();
-            new LateTask(() => RPC.RpcVersionCheck(), 0.5f, "RpcVersionCheck");
+            new LateTask(() => RPC.RpcVersionCheck(), 0.7f, "RpcVersionCheck");
 
             NameColorManager.Begin();
             Options.Load();


### PR DESCRIPTION
- クライアント側でLocalPlayerが取得できずにエラーを吐いていたため、0.5f→0.7fに修正