### PR TITLE
[v1.4]Fix/vanpire meeting

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -195,7 +195,7 @@ namespace TownOfHost
             }
             main.BitPlayers = new Dictionary<byte, (byte, float)>();
 
-            //if(__instance.Data.IsDead) return true;
+            if(__instance.Data.IsDead) return true;
             //=============================================
             //以下、ボタンが押されることが確定したものとする。
             //=============================================

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -112,7 +112,22 @@ namespace TownOfHost
             }
             if (__instance.isVampire() && !target.isBait())
             { //キルキャンセル&自爆処理
-                __instance.RpcGuardAndKill(target);
+                __instance.RpcProtectPlayer(target, 0);
+                new LateTask(() => {
+                    if (target.protectedByGuardian)
+                    {
+                        //通常はこちら
+                        __instance.RpcMurderPlayer(target);
+                    }
+                    else
+                    {
+                        //会議開始と同時キルでガードが外れてしまっている場合
+                        //自殺させる
+                        target.RpcMurderPlayer(target);
+                        //キルブロック解除
+                        main.BlockKilling[__instance.PlayerId] = false;
+                    }
+                }, 0.2f, "Vampire Bite");
                 main.BitPlayers.Add(target.PlayerId, (__instance.PlayerId, 0f));
                 return false;
             }
@@ -178,7 +193,7 @@ namespace TownOfHost
             }
             main.BitPlayers = new Dictionary<byte, (byte, float)>();
 
-            if(__instance.Data.IsDead) return true;
+            //if(__instance.Data.IsDead) return true;
             //=============================================
             //以下、ボタンが押されることが確定したものとする。
             //=============================================

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -122,8 +122,6 @@ namespace TownOfHost
                     else
                     {
                         //会議開始と同時キルでガードが外れてしまっている場合
-                        //自殺させる
-                        target.RpcMurderPlayer(target);
                         //キルブロック解除
                         main.BlockKilling[__instance.PlayerId] = false;
                     }
@@ -186,9 +184,13 @@ namespace TownOfHost
                 if(pc.Data.IsDead)
                     Logger.SendToFile("Vampireに噛まれている" + pc.name + "はすでに死んでいました。");
                 else{
-                    pc.RpcMurderPlayer(pc);
-                    main.PlaySoundRPC(bp.Value.Item1, Sounds.KillSound);
-                    Logger.SendToFile("Vampireに噛まれている" + pc.name + "を自爆させました。");
+                    //ガードされた(会議ボタンのほうが早かった)時は殺さない
+                    if (!pc.protectedByGuardian)
+                    {
+                        pc.RpcMurderPlayer(pc);
+                        main.PlaySoundRPC(bp.Value.Item1, Sounds.KillSound);
+                        Logger.SendToFile("Vampireに噛まれている" + pc.name + "を自爆させました。");
+                    }
                 }
             }
             main.BitPlayers = new Dictionary<byte, (byte, float)>();


### PR DESCRIPTION
バグ #v1_4_0085対応

ミーティングボタンから会議開始の間にヴァンパイアキルが行なわれた時

1．キルブロックの有効化
2．RpcProtectPlayerでターゲットに守護
3．会議ボタンの割り込みによってターゲットの呪殺→守護による死亡回避
4．守護解除されているため、守護を確認してからのターゲットキル(守護のリセット)が呼ばれない
5．ターゲットキルが発生しないためキルブロックの無効化が呼ばれない
というプロセスでターゲットが死なない、ヴァンパイアがこれ以降キルできないが発生してました。

=>ターゲットは死なない、キルブロックは解除するというように変更しました

・通常ヴァンパイアキルが動作することを確認
・会議直後のヴァンパイアキルでターゲットが死なないことを確認
・その後ターゲット、その他クルーを正常にキルできることを確認