### PR TITLE
Fix/BanButtonStuck

### DIFF
--- a/Patches/HideBanButtonPatch.cs
+++ b/Patches/HideBanButtonPatch.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using Hazel;
+using HarmonyLib;
+using System.Linq;
+using System;
+
+namespace TownOfHost
+{
+    [HarmonyPatch(typeof(ChatController), nameof(ChatController.Toggle))]
+    class CancelBanMenuStuckPatch
+    {
+        public static void Prefix(ChatController __instance)
+        {
+            if(__instance.IsOpen) // (IsOpen==true) == 今から閉じないといけない
+            {
+                // BanButtonを非表示にする
+                __instance.BanButton.SetVisible(false);
+            }
+        }
+    }
+}

--- a/Patches/HideBanButtonPatch.cs
+++ b/Patches/HideBanButtonPatch.cs
@@ -11,7 +11,7 @@ namespace TownOfHost
     {
         public static void Prefix(ChatController __instance)
         {
-            if(__instance.IsOpen) // (IsOpen==true) == 今から閉じないといけない
+            if(__instance.IsOpen && !__instance.animating) // (IsOpen==true) == 今から閉じないといけない
             {
                 // BanButtonを非表示にする
                 __instance.BanButton.SetVisible(false);

--- a/Patches/HideBanButtonPatch.cs
+++ b/Patches/HideBanButtonPatch.cs
@@ -1,8 +1,4 @@
-using System.IO;
-using Hazel;
 using HarmonyLib;
-using System.Linq;
-using System;
 
 namespace TownOfHost
 {


### PR DESCRIPTION
# 変更内容
「チャットを閉じるアニメーション中にBANボタンをクリックするとその後のUIのクリック操作が無効化されるAmong Us側のバグ」の対策を追加
チャットを閉じるアニメーション開始直前にBANボタンが非表示になります。
# 動作確認内容
オンラインプレイのロビーとローカルプレイでの会議でアニメーション中にBANボタンが非表示になっていることを確認