### PR TITLE
[v1.4]Fix/control-patch-exception-v1.4

### DIFF
--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -14,7 +14,7 @@ namespace TownOfHost
         {
 
             //##ホスト専用コマンド##
-            if (Input.GetKeyDown(KeyCode.Return) && Input.GetKey(KeyCode.L) && Input.GetKey(KeyCode.LeftShift) && AmongUsClient.Instance.AmHost)
+            if (Input.GetKeyDown(KeyCode.Return) && Input.GetKey(KeyCode.L) && Input.GetKey(KeyCode.LeftShift) && AmongUsClient.Instance.AmHost &&  AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Started)
             {
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -20,12 +20,12 @@ namespace TownOfHost
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
                 RPCProcedure.EndGame();
             }
-            if (Input.GetKeyDown(KeyCode.LeftShift) && GameStartManager.Instance?.startState == GameStartManager.StartingStates.Countdown && AmongUsClient.Instance.AmHost)
+            if (Input.GetKeyDown(KeyCode.LeftShift) && GameStartManager.InstanceExists && GameStartManager.Instance?.startState == GameStartManager.StartingStates.Countdown && AmongUsClient.Instance.AmHost)
             {
                 Logger.info("CountDownTimer set to 0");
                 GameStartManager.Instance.countDownTimer = 0;
             }
-            if (Input.GetKeyDown(KeyCode.C) && GameStartManager.Instance?.startState == GameStartManager.StartingStates.Countdown && AmongUsClient.Instance.AmHost)
+            if (Input.GetKeyDown(KeyCode.C) && GameStartManager.InstanceExists && GameStartManager.Instance?.startState == GameStartManager.StartingStates.Countdown && AmongUsClient.Instance.AmHost)
             {
                 Logger.info("Reset CountDownTimer");
                 GameStartManager.Instance.ResetStartState();


### PR DESCRIPTION
ロビー以外で左シフトを押した際に例外が出る問題を修正
- GameStartManagerのインスタンスがある時かのチェックを追加
廃村コマンドをゲーム外で使用すると例外が発生する問題を修正