### PR TITLE
[v1.5]Feature/GameStates-class

### DIFF
--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -67,4 +67,16 @@ namespace TownOfHost
             this.hasTasks = false;
         }
     }
+    public static class GameStates
+    {
+        public static bool isLobby => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Joined;
+        public static bool isInGame => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Started;
+        public static bool isEnded => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Ended;
+        public static bool isNotJoined => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.NotJoined;
+        public static bool isOnlineGame => AmongUsClient.Instance.GameMode == GameModes.OnlineGame;
+        public static bool isLocalGame => AmongUsClient.Instance.GameMode == GameModes.LocalGame;
+        public static bool isFreePlay => AmongUsClient.Instance.GameMode == GameModes.FreePlay;
+        public static bool isMeeting => MeetingHud.Instance;
+        public static bool isCountDown => GameStartManager.InstanceExists && GameStartManager.Instance.startState == GameStartManager.StartingStates.Countdown;
+    }
 }


### PR DESCRIPTION
ゲームの状態をboolで取得するGameStatesクラスを追加

取得可能な情報
- ロビーか
- ゲーム中か
- ゲーム終了か
- ゲームに入っていないか
- オンラインゲームか
- ローカルゲームか
- フリープレイか
- ミーティング中か
- カウントダウン中か

テスト内容:
- ログをフェイズごとに出力し、情報に間違いがないことを確認