### PR TITLE
[v1.5]Refact/task state

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -376,31 +376,7 @@ namespace TownOfHost
 
         public static TaskState getPlayerTaskState(this PlayerControl player)
         {
-            if (player == null || player.Data == null || player.Data.Tasks == null) return new TaskState();
-            if (!Utils.hasTasks(player.Data, false)) return new TaskState();
-            int AllTasksCount = 0;
-            int CompletedTaskCount = 0;
-            foreach (var task in player.Data.Tasks)
-            {
-                AllTasksCount++;
-                if (task.Complete) CompletedTaskCount++;
-            }
-            //役職ごとにタスク量の調整を行う
-            var adjustedTasksCount = AllTasksCount;
-            switch (player.getCustomRole())
-            {
-                case CustomRoles.MadSnitch:
-                    adjustedTasksCount = Options.MadSnitchTasks.GetInt();
-                    break;
-                default:
-                    break;
-            }
-            //タスク数が通常タスクより多い場合は再設定が必要
-            AllTasksCount = Math.Min(adjustedTasksCount, AllTasksCount);
-            //調整後のタスク量までしか表示しない
-            CompletedTaskCount = Math.Min(AllTasksCount, CompletedTaskCount);
-            Logger.info($"{player.name}: {CompletedTaskCount}/{AllTasksCount}", "TaskCounts");
-            return new TaskState(AllTasksCount, CompletedTaskCount);
+            return PlayerState.UpdateTask(player);
         }
 
         public static GameOptionsData DeepCopy(this GameOptionsData opt)

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -373,10 +373,9 @@ namespace TownOfHost
             writer.WriteBytesAndSize(opt.ToBytes(5));
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
-
         public static TaskState getPlayerTaskState(this PlayerControl player)
         {
-            return PlayerState.UpdateTask(player);
+            return PlayerState.taskState[player.PlayerId];
         }
 
         public static GameOptionsData DeepCopy(this GameOptionsData opt)

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -38,11 +38,9 @@ namespace TownOfHost
         {
             taskState[player.PlayerId].Init(player);
         }
-        public static TaskState UpdateTask(PlayerControl player)
+        public static void UpdateTask(PlayerControl player)
         {
-            var task = taskState[player.PlayerId];
-            task.Update(player);
-            return task;
+            taskState[player.PlayerId].Update(player);
         }
         public enum DeathReason
         {
@@ -98,20 +96,18 @@ namespace TownOfHost
         public void Update(PlayerControl player)
         {
             Logger.info($"{player.name}: UpdateTask", "TaskCounts");
-            if (player == null || player.Data == null || player.Data.Tasks == null) return;
-            if (!Utils.hasTasks(player.Data, false)) return;
+            if (!hasTasks) return;
             //初期化出来ていなかったら初期化
             if(AllTasksCount==-1)Init(player);
             //クリアしてたらカウントしない
             if (CompletedTasksCount >= AllTasksCount) return;
 
-            foreach (var task in player.Data.Tasks)
-            {
-                if (task.Complete) CompletedTasksCount++;
-            }
+            CompletedTasksCount++;
+
             //調整後のタスク量までしか表示しない
             CompletedTasksCount = Math.Min(AllTasksCount, CompletedTasksCount);
             Logger.info($"{player.name}: {CompletedTasksCount}/{AllTasksCount}", "TaskCounts");
+
         }
     }
 }

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace TownOfHost
@@ -15,23 +16,34 @@ namespace TownOfHost
             players = new();
             isDead = new();
             deathReasons = new();
-            isDead = new();
+            taskState = new();
 
             foreach (var p in PlayerControl.AllPlayerControls)
             {
                 players.Add(p.PlayerId);
                 isDead.Add(p.PlayerId, false);
                 deathReasons.Add(p.PlayerId, DeathReason.etc);
+                taskState.Add(p.PlayerId, new());
             }
 
         }
         public static List<byte> players = new List<byte>();
         public static Dictionary<byte, bool> isDead = new Dictionary<byte, bool>();
         public static Dictionary<byte, DeathReason> deathReasons = new Dictionary<byte, DeathReason>();
+        public static Dictionary<byte, TaskState> taskState = new();
         public static void setDeathReason(byte p, DeathReason reason) { deathReasons[p] = reason; }
         public static DeathReason getDeathReason(byte p) { return deathReasons.TryGetValue(p, out var reason) ? reason : DeathReason.etc; }
         public static bool isSuicide(byte p) { return deathReasons[p] == DeathReason.Suicide; }
-
+        public static void InitTask(PlayerControl player)
+        {
+            taskState[player.PlayerId].Init(player);
+        }
+        public static TaskState UpdateTask(PlayerControl player)
+        {
+            var task = taskState[player.PlayerId];
+            task.Update(player);
+            return task;
+        }
         public enum DeathReason
         {
             Kill,
@@ -54,17 +66,52 @@ namespace TownOfHost
         public int RemainingTasksCount => AllTasksCount - CompletedTasksCount;
         public bool doExpose => RemainingTasksCount <= Options.SnitchExposeTaskLeft && hasTasks;
         public bool isTaskFinished => RemainingTasksCount <= 0 && hasTasks;
-        public TaskState(int all, int completed)
-        {
-            this.AllTasksCount = all;
-            this.CompletedTasksCount = completed;
-            this.hasTasks = true;
-        }
         public TaskState()
         {
-            this.AllTasksCount = 0;
+            this.AllTasksCount = -1;
             this.CompletedTasksCount = 0;
             this.hasTasks = false;
+        }
+
+        public void Init(PlayerControl player)
+        {
+            Logger.info($"{player.name}: InitTask", "TaskCounts");
+            if (player == null || player.Data == null || player.Data.Tasks == null) return;
+            if (!Utils.hasTasks(player.Data, false)) return;
+            hasTasks = true;
+            AllTasksCount=player.Data.Tasks.Count;
+
+            //役職ごとにタスク量の調整を行う
+            var adjustedTasksCount = AllTasksCount;
+            switch (player.getCustomRole())
+            {
+                case CustomRoles.MadSnitch:
+                    adjustedTasksCount = Options.MadSnitchTasks.GetInt();
+                    break;
+                default:
+                    break;
+            }
+            //タスク数が通常タスクより多い場合は再設定が必要
+            AllTasksCount = Math.Min(adjustedTasksCount, AllTasksCount);
+            Logger.info($"{player.name}: {CompletedTasksCount}/{AllTasksCount}", "TaskCounts");
+        }
+        public void Update(PlayerControl player)
+        {
+            Logger.info($"{player.name}: UpdateTask", "TaskCounts");
+            if (player == null || player.Data == null || player.Data.Tasks == null) return;
+            if (!Utils.hasTasks(player.Data, false)) return;
+            //初期化出来ていなかったら初期化
+            if(AllTasksCount==-1)Init(player);
+            //クリアしてたらカウントしない
+            if (CompletedTasksCount >= AllTasksCount) return;
+
+            foreach (var task in player.Data.Tasks)
+            {
+                if (task.Complete) CompletedTasksCount++;
+            }
+            //調整後のタスク量までしか表示しない
+            CompletedTasksCount = Math.Min(AllTasksCount, CompletedTasksCount);
+            Logger.info($"{player.name}: {CompletedTasksCount}/{AllTasksCount}", "TaskCounts");
         }
     }
 }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -162,6 +162,12 @@ namespace TownOfHost
             if (!taskState.hasTasks) return "null";
             return $"<color=#ffff00>({taskState.CompletedTasksCount}/{taskState.AllTasksCount})</color>";
         }
+        public static string getTaskText(byte  playerId)
+        {
+            var taskState = PlayerState.taskState[playerId];
+            if (!taskState.hasTasks) return "";
+            return $"<color=#ffff00>({taskState.CompletedTasksCount}/{taskState.AllTasksCount})</color>";
+        }
         public static void ShowActiveRoles()
         {
             SendMessage(getString("CurrentActiveSettingsHelp") + ":");

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -293,13 +293,13 @@ namespace TownOfHost
             Dictionary<byte, CustomRoles> cloneRoles = new(main.AllPlayerCustomRoles);
             foreach (var id in main.winnerList)
             {
-                roleSummaryText += $"\n<color={CustomWinnerColor}>★</color> {main.RealNames[id]} : <color={Utils.getRoleColorCode(main.AllPlayerCustomRoles[id])}>{Utils.getRoleName(main.AllPlayerCustomRoles[id])}</color> {Utils.getVitalText(id)}  {Utils.getVitalText(id)}";
+                roleSummaryText += $"\n<color={CustomWinnerColor}>★</color> {main.RealNames[id]} : <color={Utils.getRoleColorCode(main.AllPlayerCustomRoles[id])}>{Utils.getRoleName(main.AllPlayerCustomRoles[id])}</color> {Utils.getTaskText(id)}  {Utils.getVitalText(id)}";
                 cloneRoles.Remove(id);
             }
             foreach (var kvp in cloneRoles)
             {
                 var id = kvp.Key;
-                roleSummaryText += $"\n　 {main.RealNames[id]} : <color={Utils.getRoleColorCode(main.AllPlayerCustomRoles[id])}>{Utils.getRoleName(main.AllPlayerCustomRoles[id])}</color> {Utils.getVitalText(id)}  {Utils.getVitalText(id)}";
+                roleSummaryText += $"\n　 {main.RealNames[id]} : <color={Utils.getRoleColorCode(main.AllPlayerCustomRoles[id])}>{Utils.getRoleName(main.AllPlayerCustomRoles[id])}</color> {Utils.getTaskText(id)}  {Utils.getVitalText(id)}";
             }
             TMPro.TMP_Text roleSummaryTextMesh = roleSummary.GetComponent<TMPro.TMP_Text>();
             roleSummaryTextMesh.alignment = TMPro.TextAlignmentOptions.TopLeft;

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -12,14 +12,6 @@ namespace TownOfHost
         {
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-            //タスク情報保存
-            main.FinalTaskState = new Dictionary<byte, string>();
-            foreach (var pc in PlayerControl.AllPlayerControls)
-            {
-                main.FinalTaskState.Add(pc.PlayerId, Utils.getTaskText(pc));
-                if (main.FinalTaskState[pc.PlayerId] == "null")
-                    main.FinalTaskState[pc.PlayerId] = "";
-            }
             Logger.info("ゲームが終了", "Phase");
             //winnerListリセット
             TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
@@ -301,13 +293,13 @@ namespace TownOfHost
             Dictionary<byte, CustomRoles> cloneRoles = new(main.AllPlayerCustomRoles);
             foreach (var id in main.winnerList)
             {
-                roleSummaryText += $"\n<color={CustomWinnerColor}>★</color> {main.RealNames[id]} : <color={Utils.getRoleColorCode(main.AllPlayerCustomRoles[id])}>{Utils.getRoleName(main.AllPlayerCustomRoles[id])}</color> {main.FinalTaskState[id]}  {Utils.getVitalText(id)}";
+                roleSummaryText += $"\n<color={CustomWinnerColor}>★</color> {main.RealNames[id]} : <color={Utils.getRoleColorCode(main.AllPlayerCustomRoles[id])}>{Utils.getRoleName(main.AllPlayerCustomRoles[id])}</color> {Utils.getVitalText(id)}  {Utils.getVitalText(id)}";
                 cloneRoles.Remove(id);
             }
             foreach (var kvp in cloneRoles)
             {
                 var id = kvp.Key;
-                roleSummaryText += $"\n　 {main.RealNames[id]} : <color={Utils.getRoleColorCode(main.AllPlayerCustomRoles[id])}>{Utils.getRoleName(main.AllPlayerCustomRoles[id])}</color> {main.FinalTaskState[id]}  {Utils.getVitalText(id)}";
+                roleSummaryText += $"\n　 {main.RealNames[id]} : <color={Utils.getRoleColorCode(main.AllPlayerCustomRoles[id])}>{Utils.getRoleName(main.AllPlayerCustomRoles[id])}</color> {Utils.getVitalText(id)}  {Utils.getVitalText(id)}";
             }
             TMPro.TMP_Text roleSummaryTextMesh = roleSummary.GetComponent<TMPro.TMP_Text>();
             roleSummaryTextMesh.alignment = TMPro.TextAlignmentOptions.TopLeft;

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -777,6 +777,7 @@ namespace TownOfHost
         {
             Logger.info($"TaskComplete:{__instance.PlayerId}", "CompleteTask");
             PlayerState.UpdateTask(__instance);
+            Utils.NotifyRoles();
         }
     }
 }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -770,5 +770,14 @@ namespace TownOfHost
             main.RealNames[__instance.PlayerId] = name;
         }
     }
+    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.CompleteTask))]
+    class PlayerControlCompleteTaskPatch
+    {
+        public static void Postfix(PlayerControl __instance)
+        {
+            Logger.info($"TaskComplete:{__instance.PlayerId}", "CompleteTask");
+            PlayerState.UpdateTask(__instance);
+        }
+    }
 }
 

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -32,8 +32,8 @@ namespace TownOfHost
     {
         public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ClientData data, [HarmonyArgument(1)] DisconnectReasons reason)
         {
-            Logger.info($"RealNames[{data.Character.PlayerId}]を削除");
-            main.RealNames.Remove(data.Character.PlayerId);
+//            Logger.info($"RealNames[{data.Character.PlayerId}]を削除");
+//            main.RealNames.Remove(data.Character.PlayerId);
             PlayerState.setDeathReason(data.Character.PlayerId, PlayerState.DeathReason.Disconnected);
             PlayerState.isDead[data.Character.PlayerId] = true;
             Logger.info("切断理由:" + reason.ToString());

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -256,6 +256,11 @@ namespace TownOfHost
             Logger.info("---------その他---------");
             Logger.info($"マップ: {PlayerControl.GameOptions.MapId}");
             Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人");
+
+            foreach (var pc in PlayerControl.AllPlayerControls)
+            {
+                PlayerState.InitTask(pc);
+            }
         }
     }
     [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Begin))]
@@ -264,6 +269,12 @@ namespace TownOfHost
         public static void Postfix()
         {
             Logger.info("ShipStatus.Begin");
+
+            foreach (var pc in PlayerControl.AllPlayerControls)
+            {
+                PlayerState.InitTask(pc);
+            }
+
             Utils.NotifyRoles();
         }
     }

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -257,9 +257,13 @@ namespace TownOfHost
             Logger.info($"マップ: {PlayerControl.GameOptions.MapId}");
             Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人");
 
-            foreach (var pc in PlayerControl.AllPlayerControls)
+            if (AmongUsClient.Instance.AmClient)
             {
-                PlayerState.InitTask(pc);
+                //クライアントの役職初期設定はここで行う
+                foreach (var pc in PlayerControl.AllPlayerControls)
+                {
+                    PlayerState.InitTask(pc);
+                }
             }
         }
     }
@@ -270,6 +274,7 @@ namespace TownOfHost
         {
             Logger.info("ShipStatus.Begin");
 
+            //ホストの役職初期設定はここで行うべき？
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
                 PlayerState.InitTask(pc);

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -344,7 +344,6 @@ namespace TownOfHost
                 main.BountyTimer = new Dictionary<byte, float>();
                 foreach (var pc in PlayerControl.AllPlayerControls)
                 {
-                    PlayerState.InitTask(pc);
                     if (pc.isSheriff())
                     {
                         main.SheriffShotLimit[pc.PlayerId] = Options.SheriffShotLimit.GetFloat();

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -344,6 +344,7 @@ namespace TownOfHost
                 main.BountyTimer = new Dictionary<byte, float>();
                 foreach (var pc in PlayerControl.AllPlayerControls)
                 {
+                    PlayerState.InitTask(pc);
                     if (pc.isSheriff())
                     {
                         main.SheriffShotLimit[pc.PlayerId] = Options.SheriffShotLimit.GetFloat();

--- a/main.cs
+++ b/main.cs
@@ -53,7 +53,6 @@ namespace TownOfHost
         public static Dictionary<byte, string> AllPlayerNames;
         public static Dictionary<byte, CustomRoles> AllPlayerCustomRoles;
         public static Dictionary<byte, CustomRoles> AllPlayerCustomSubRoles;
-        public static Dictionary<byte, string> FinalTaskState;
         public static Dictionary<byte, bool> BlockKilling;
         public static Dictionary<byte, float> SheriffShotLimit;
         public static Dictionary<CustomRoles, String> roleColors;

--- a/main.cs
+++ b/main.cs
@@ -119,7 +119,6 @@ namespace TownOfHost
             Logger = BepInEx.Logging.Logger.CreateLogSource("TownOfHost");
             TownOfHost.Logger.enable();
             TownOfHost.Logger.disable("NotifyRoles");
-            TownOfHost.Logger.disable("TaskCounts");
             TownOfHost.Logger.isDetail = true;
 
             currentWinner = CustomWinner.Default;


### PR DESCRIPTION
タスク量確認するたびに計算しなおしていたため
・PlayerStateにTaskStateを保持。
・タスク更新された時だけ加算する形に変更
・不要になったためFinalTaskState を削除

クルーメイト、マッドスニッチで正しくタスク初期値が設定できることを確認
勝利画面で正しくタスク数が表示されることを確認
切断者のタスク数も表示されることを確認
MODホスト、MODクライアント、ヴァニラクライアントで確認。