### PR TITLE
EndGameにnullチェックを追加

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -270,6 +270,7 @@ namespace TownOfHost
         }
         public static void EndGame()
         {
+            if (ShipStatus.Instance == null) return;
             main.currentWinner = CustomWinner.Draw;
             if (AmongUsClient.Instance.AmHost)
             {


### PR DESCRIPTION
廃村コマンドを船が始まり切る前に実行すると例外が発生する問題を修正
- 船が始まっていない場合EndGameを実行しないように修正