### PR TITLE
[v2.0.0]Fix/試合結果周り色々

### DIFF
--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -31,21 +31,17 @@ namespace TownOfHost
         public static Dictionary<byte, bool> isDead = new Dictionary<byte, bool>();
         public static Dictionary<byte, DeathReason> deathReasons = new Dictionary<byte, DeathReason>();
         public static Dictionary<byte, TaskState> taskState = new();
-        public static void setDead(byte p,bool dead)
+        public static void setDead(byte p)
         {
-            isDead[p] = dead;
+            isDead[p] = true;
             if (AmongUsClient.Instance.AmHost)
             {
-                RPC.SendDeathReason(p, deathReasons[p], dead);
+                RPC.SendDeathReason(p, deathReasons[p]);
             }
         }
         public static void setDeathReason(byte p, DeathReason reason)
         {
             deathReasons[p] = reason;
-            if (AmongUsClient.Instance.AmHost)
-            {
-                RPC.SendDeathReason(p, reason, false);
-            }
         }
         public static DeathReason getDeathReason(byte p) { return deathReasons.TryGetValue(p, out var reason) ? reason : DeathReason.etc; }
         public static bool isSuicide(byte p) { return deathReasons[p] == DeathReason.Suicide; }

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -31,7 +31,22 @@ namespace TownOfHost
         public static Dictionary<byte, bool> isDead = new Dictionary<byte, bool>();
         public static Dictionary<byte, DeathReason> deathReasons = new Dictionary<byte, DeathReason>();
         public static Dictionary<byte, TaskState> taskState = new();
-        public static void setDeathReason(byte p, DeathReason reason) { deathReasons[p] = reason; }
+        public static void setDead(byte p,bool dead)
+        {
+            isDead[p] = dead;
+            if (AmongUsClient.Instance.AmHost)
+            {
+                RPC.SendDeathReason(p, deathReasons[p], dead);
+            }
+        }
+        public static void setDeathReason(byte p, DeathReason reason)
+        {
+            deathReasons[p] = reason;
+            if (AmongUsClient.Instance.AmHost)
+            {
+                RPC.SendDeathReason(p, reason, false);
+            }
+        }
         public static DeathReason getDeathReason(byte p) { return deathReasons.TryGetValue(p, out var reason) ? reason : DeathReason.etc; }
         public static bool isSuicide(byte p) { return deathReasons[p] == DeathReason.Suicide; }
         public static void InitTask(PlayerControl player)

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -196,24 +196,19 @@ namespace TownOfHost
             AmongUsClient.Instance.FinishRpcImmediately(writer);
             main.playerVersion[PlayerControl.LocalPlayer.PlayerId] = new PlayerVersion(main.PluginVersion, $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})");
         }
-        public static void SendDeathReason(byte playerId, PlayerState.DeathReason deathReason, bool isDead)
+        public static void SendDeathReason(byte playerId, PlayerState.DeathReason deathReason)
         {
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetDeathReason, Hazel.SendOption.Reliable, -1);
             writer.Write(playerId);
             writer.Write((int)deathReason);
-            writer.Write(isDead);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
         public static void GetDeathReason(MessageReader reader)
         {
             var playerId = reader.ReadByte();
-            var deathReason = reader.ReadInt32();
-            var isDead = reader.ReadBoolean();
-            PlayerState.deathReasons[playerId] = (PlayerState.DeathReason)deathReason;
-            if (isDead)
-            {
-                PlayerState.isDead[playerId] = true;
-            }
+            var deathReason = (PlayerState.DeathReason)reader.ReadInt32();
+            PlayerState.deathReasons[playerId] = deathReason;
+            PlayerState.isDead[playerId] = true;
         }
 
         public static void JesterExiled(byte jesterID)

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -10,6 +10,7 @@ namespace TownOfHost
     {
         VersionCheck = 60,
         SyncCustomSettings = 80,
+        SetDeathReason,
         JesterExiled,
         TerroristWin,
         ArsonistWin,
@@ -74,6 +75,9 @@ namespace TownOfHost
                         //すべてのカスタムオプションについてインデックス値で受信
                         co.Selection = reader.ReadInt32();
                     }
+                    break;
+                case (byte)CustomRPC.SetDeathReason:
+                    RPC.GetDeathReason(reader);
                     break;
                 case (byte)CustomRPC.JesterExiled:
                     byte exiledJester = reader.ReadByte();
@@ -192,6 +196,26 @@ namespace TownOfHost
             AmongUsClient.Instance.FinishRpcImmediately(writer);
             main.playerVersion[PlayerControl.LocalPlayer.PlayerId] = new PlayerVersion(main.PluginVersion, $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})");
         }
+        public static void SendDeathReason(byte playerId,PlayerState.DeathReason deathReason,bool isDead)
+        {
+            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetDeathReason, Hazel.SendOption.Reliable, -1);
+            writer.Write(playerId);
+            writer.Write((int)deathReason);
+            writer.Write(isDead);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+        }
+        public static void GetDeathReason(MessageReader reader)
+        {
+            var playerId=reader.ReadByte();
+            var deathReason=reader.ReadInt32();
+            var isDead=reader.ReadBoolean();
+            PlayerState.deathReasons[playerId]=(PlayerState.DeathReason)deathReason;
+            if (isDead)
+            {
+                PlayerState.isDead[playerId] = true;
+            }
+        }
+
         public static void JesterExiled(byte jesterID)
         {
             main.ExiledJesterID = jesterID;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -323,7 +323,7 @@ namespace TownOfHost
                         //生存者は爆死
                         pc.RpcMurderPlayer(pc);
                         PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Bombed);
-                        PlayerState.setDead(pc.PlayerId, true);
+                        PlayerState.setDead(pc.PlayerId);
                     }
                 }
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TerroristWin, Hazel.SendOption.Reliable, -1);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -294,9 +294,9 @@ namespace TownOfHost
                     else if (!pc.Data.IsDead)
                     {
                         //生存者は爆死
-                        pc.MurderPlayer(pc);
+                        pc.RpcMurderPlayer(pc);
                         PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Bombed);
-                        PlayerState.isDead[pc.PlayerId] = true;
+                        PlayerState.setDead(pc.PlayerId, true);
                     }
                 }
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TerroristWin, Hazel.SendOption.Reliable, -1);

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -224,6 +224,7 @@ namespace TownOfHost
                             {
                                 //HideAndSeek中
                                 if (role == CustomRoles.Crewmate) numTotalAlive++;
+                                if (role.isImpostor()) numTotalAlive++;
                             }
 
                             if (playerInfo.Role.TeamType == RoleTeamTypes.Impostor &&

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -48,7 +48,7 @@ namespace TownOfHost
                         p.RpcMurderPlayer(p);
                     }
                 }
-                PlayerState.setDead(exiled.PlayerId, true);
+                PlayerState.setDead(exiled.PlayerId);
             }
             if (AmongUsClient.Instance.AmHost && main.isFixedCooldown)
                 main.RefixCooldownDelay = main.RealOptionsData.KillCooldown - 3f;

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -48,7 +48,7 @@ namespace TownOfHost
                         p.RpcMurderPlayer(p);
                     }
                 }
-                PlayerState.isDead[exiled.PlayerId] = true;
+                PlayerState.setDead(exiled.PlayerId, true);
             }
             if (AmongUsClient.Instance.AmHost && main.isFixedCooldown)
                 main.RefixCooldownDelay = main.RealOptionsData.KillCooldown - 3f;

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -273,6 +273,16 @@ namespace TownOfHost
             Logger.info(PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10));
             Logger.info("---------その他---------");
             Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人");
+
+            if (!AmongUsClient.Instance.AmHost)
+            {
+                //クライアントの役職初期設定はここで行う
+                foreach (var pc in PlayerControl.AllPlayerControls)
+                {
+                    PlayerState.InitTask(pc);
+                }
+                Utils.CountAliveImpostors();
+            }
         }
     }
     class RepairSender

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -149,6 +149,7 @@ namespace TownOfHost
                     if (role == CustomRoles.Troll && pc.Data.IsDead)
                     {
                         main.currentWinner = CustomWinner.Troll;
+                        main.additionalwinners = new();
                         winner = new();
                         winner.Add(pc);
                         break;

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -217,6 +217,11 @@ namespace TownOfHost
                     CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Egoist)}";
                     CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Egoist);
                     break;
+                case CustomWinner.Troll:
+                    __instance.BackgroundBar.material.color = Utils.getRoleColor(CustomRoles.Troll);
+                    CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Troll)}";
+                    CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Troll);
+                    break;
                 //引き分け処理
                 case CustomWinner.Draw:
                     __instance.BackgroundBar.material.color = Color.gray;

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -58,60 +58,48 @@ namespace TownOfHost
                     winner.Add(p);
                 }
             }
-            foreach (var p in winner)
-            {
-                TempData.winners.Add(new WinningPlayerData(p.Data));
-            }
 
             //単独勝利
             if (main.currentWinner == CustomWinner.Jester && CustomRoles.Jester.isEnable())
             { //Jester単独勝利
-                TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
+                winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
                     if (p.PlayerId == main.ExiledJesterID)
                     {
-                        TempData.winners.Add(new WinningPlayerData(p.Data));
-                        winner = new();
                         winner.Add(p);
                     }
                 }
             }
             if (main.currentWinner == CustomWinner.Terrorist && CustomRoles.Terrorist.isEnable())
             { //Terrorist単独勝利
-                TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
+                winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
                     if (p.PlayerId == main.WonTerroristID)
                     {
-                        TempData.winners.Add(new WinningPlayerData(p.Data));
-                        winner = new();
                         winner.Add(p);
                     }
                 }
             }
             if (main.currentWinner == CustomWinner.Arsonist && CustomRoles.Arsonist.isEnable())
             { //Arsonist単独勝利
-                TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
+                winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
                     if (p.PlayerId == main.WonArsonistID)
                     {
-                        TempData.winners.Add(new WinningPlayerData(p.Data));
-                        winner = new();
                         winner.Add(p);
                     }
                 }
             }
             if (main.currentWinner == CustomWinner.Egoist && CustomRoles.Egoist.isEnable())
             { //Egoist横取り勝利
-                TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
                 winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
                     if ((p.isEgoist() && !p.Data.IsDead) || p.isEgoSchrodingerCat())
                     {
-                        TempData.winners.Add(new WinningPlayerData(p.Data));
                         winner.Add(p);
                     }
                 }
@@ -121,7 +109,6 @@ namespace TownOfHost
             {
                 if (pc.isOpportunist() && !pc.Data.IsDead && main.currentWinner != CustomWinner.Draw && main.currentWinner != CustomWinner.Terrorist)
                 {
-                    TempData.winners.Add(new WinningPlayerData(pc.Data));
                     winner.Add(pc);
                     main.additionalwinners.Add(AdditionalWinners.Opportunist);
                 }
@@ -132,7 +119,6 @@ namespace TownOfHost
                 {
                     if (pc.isSchrodingerCat() && main.currentWinner == CustomWinner.Crewmate)
                     {
-                        TempData.winners.Add(new WinningPlayerData(pc.Data));
                         winner.Add(pc);
                         main.additionalwinners.Add(AdditionalWinners.SchrodingerCat);
                     }
@@ -142,40 +128,38 @@ namespace TownOfHost
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek &&
                 main.currentWinner != CustomWinner.Draw)
             {
-                var winners = new List<PlayerControl>();
+                winner = new();
                 foreach (var pc in PlayerControl.AllPlayerControls)
                 {
                     var hasRole = main.AllPlayerCustomRoles.TryGetValue(pc.PlayerId, out var role);
                     if (!hasRole) continue;
-                    if (role == CustomRoles.Crewmate)
+                    if (role.isImpostor() && main.currentWinner == CustomWinner.Impostor)
                     {
-                        if (pc.Data.Role.IsImpostor && TempData.DidImpostorsWin(endGameResult.GameOverReason))
-                            winners.Add(pc);
-                        if (!pc.Data.Role.IsImpostor && TempData.DidHumansWin(endGameResult.GameOverReason))
-                            winners.Add(pc);
+                        winner.Add(pc);
+                    }
+                    if (role == CustomRoles.Crewmate && main.currentWinner == CustomWinner.Crewmate)
+                    {
+                        winner.Add(pc);
                     }
                     if (role == CustomRoles.Fox && !pc.Data.IsDead)
                     {
-                        winners.Add(pc);
+                        winner.Add(pc);
                         main.additionalwinners.Add(AdditionalWinners.Fox);
                     }
                     if (role == CustomRoles.Troll && pc.Data.IsDead)
                     {
                         main.currentWinner = CustomWinner.Troll;
-                        winners = new List<PlayerControl>();
-                        winners.Add(pc);
+                        winner = new();
+                        winner.Add(pc);
                         break;
                     }
                 }
-                TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
-                foreach (var pc in winners)
-                {
-                    TempData.winners.Add(new WinningPlayerData(pc.Data));
-                }
             }
+            //勝者リスト登録
             main.winnerList = new();
             foreach (var pc in winner)
             {
+                TempData.winners.Add(new WinningPlayerData(pc.Data));
                 main.winnerList.Add(pc.PlayerId);
             }
         }

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -247,22 +247,7 @@ namespace TownOfHost
                     AdditionalWinnerText += $"＆<color={Utils.getRoleColorCode(CustomRoles.Fox)}>{Utils.getRoleName(CustomRoles.Fox)}</color>";
                 }
             }
-            if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
-            {
-                foreach (var p in PlayerControl.AllPlayerControls)
-                {
-                    if (p.Data.IsDead)
-                    {
-                        var hasRole = main.AllPlayerCustomRoles.TryGetValue(p.PlayerId, out var role);
-                        if (hasRole && role == CustomRoles.Troll)
-                        {
-                            __instance.BackgroundBar.material.color = Color.green;
-                            CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Troll)}";
-                            CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Troll);
-                        }
-                    }
-                }
-            }
+
             if (main.currentWinner != CustomWinner.Draw)
             {
                 textRenderer.text = $"<color={CustomWinnerColor}>{CustomWinnerText}{AdditionalWinnerText}{getString("Win")}</color>";

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -58,7 +58,7 @@ namespace TownOfHost
                 if (pc.isLastImpostor())
                     main.AllPlayerKillCooldown[pc.PlayerId] = Options.LastImpostorKillCooldown.GetFloat();
             }
-            PlayerState.setDead(target.PlayerId, true);
+            PlayerState.setDead(target.PlayerId);
             Utils.CountAliveImpostors();
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -58,7 +58,7 @@ namespace TownOfHost
                 if (pc.isLastImpostor())
                     main.AllPlayerKillCooldown[pc.PlayerId] = Options.LastImpostorKillCooldown.GetFloat();
             }
-            PlayerState.isDead[target.PlayerId] = true;
+            PlayerState.setDead(target.PlayerId, true);
             Utils.CountAliveImpostors();
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();
@@ -777,6 +777,14 @@ namespace TownOfHost
             Logger.info($"TaskComplete:{__instance.PlayerId}", "CompleteTask");
             PlayerState.UpdateTask(__instance);
             Utils.NotifyRoles();
+        }
+    }
+    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.SetRole))]
+    class SetRolePatch
+    {
+        public static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] RoleType role)
+        {
+            Logger.info($"PlayerControl.SetRole Postfix");
         }
     }
 }

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -34,7 +34,7 @@ namespace TownOfHost
         {
 //            Logger.info($"RealNames[{data.Character.PlayerId}]を削除");
 //            main.RealNames.Remove(data.Character.PlayerId);
-            RPC.SendDeathReason(data.Character.PlayerId, PlayerState.DeathReason.Disconnected, true);
+            RPC.SendDeathReason(data.Character.PlayerId, PlayerState.DeathReason.Disconnected);
             Logger.info("切断理由:" + reason.ToString());
         }
     }

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -34,8 +34,7 @@ namespace TownOfHost
         {
 //            Logger.info($"RealNames[{data.Character.PlayerId}]を削除");
 //            main.RealNames.Remove(data.Character.PlayerId);
-            PlayerState.setDeathReason(data.Character.PlayerId, PlayerState.DeathReason.Disconnected);
-            PlayerState.isDead[data.Character.PlayerId] = true;
+            RPC.SendDeathReason(data.Character.PlayerId, PlayerState.DeathReason.Disconnected, true);
             Logger.info("切断理由:" + reason.ToString());
         }
     }

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -231,15 +231,6 @@ namespace TownOfHost
         {
             Logger.info("ShipStatus.Start");
             Logger.info("ゲームが開始", "Phase");
-
-            if (AmongUsClient.Instance.AmClient)
-            {
-                //クライアントの役職初期設定はここで行う
-                foreach (var pc in PlayerControl.AllPlayerControls)
-                {
-                    PlayerState.InitTask(pc);
-                }
-            }
         }
     }
     [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Begin))]

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -14,6 +14,7 @@ namespace TownOfHost
 
             main.currentWinner = CustomWinner.Default;
             main.CustomWinTrigger = false;
+            main.AllPlayerNames = new();
             main.AllPlayerCustomRoles = new Dictionary<byte, CustomRoles>();
             main.AllPlayerCustomSubRoles = new Dictionary<byte, CustomRoles>();
             main.AllPlayerKillCooldown = new Dictionary<byte, float>();
@@ -58,6 +59,7 @@ namespace TownOfHost
                 Logger.info($"{pc.PlayerId}:{pc.name}:{pc.nameText.text}");
                 main.RealNames[pc.PlayerId] = pc.name;
                 pc.nameText.text = pc.name;
+                main.AllPlayerNames[pc.PlayerId] = pc.name;
             }
             main.VisibleTasksCount = true;
             if (__instance.AmHost)
@@ -194,11 +196,12 @@ namespace TownOfHost
                         Crewmates.Add(pc);
                         pc.RpcSetColor(1);
                     }
-                    if (Options.IgnoreCosmetics.GetBool())
-                    {
-                        //pc.RpcSetHat("");
-                        //pc.RpcSetSkin("");
-                    }
+
+//                    if (Options.IgnoreCosmetics.GetBool())
+//                    {
+//                        pc.RpcSetHat("");
+//                        pc.RpcSetSkin("");
+//                    }
                 }
                 //FoxCountとTrollCountを適切に修正する
                 int FixedFoxCount = Math.Clamp(CustomRoles.Fox.getCount(), 0, Crewmates.Count);
@@ -226,7 +229,17 @@ namespace TownOfHost
                 }
                 //通常クルー・インポスター用RPC
                 foreach (var pc in Crewmates) pc.RpcSetCustomRole(CustomRoles.Crewmate);
-                foreach (var pc in Impostors) pc.RpcSetCustomRole(CustomRoles.Crewmate);
+                foreach (var pc in Impostors)
+                {
+                    if (pc.Data.Role.Role == RoleTypes.Impostor)
+                    {
+                        pc.RpcSetCustomRole(CustomRoles.Impostor);
+                    }
+                    else
+                    {
+                        pc.RpcSetCustomRole(CustomRoles.Shapeshifter);
+                    }
+                }
             }
             else
             {
@@ -311,14 +324,7 @@ namespace TownOfHost
                 {
                     ExtendedPlayerControl.RpcSetCustomRole(pair.Key, pair.Value);
                 }
-
-                //名前の記録
-                main.AllPlayerNames = new();
-                foreach (var pair in main.AllPlayerCustomRoles)
-                {
-                    main.AllPlayerNames.Add(pair.Key, main.RealNames[pair.Key]);
-                }
-
+ 
                 HudManager.Instance.SetHudActive(true);
                 main.KillOrSpell = new Dictionary<byte, bool>();
                 //BountyHunterのターゲットを初期化


### PR DESCRIPTION
HideAndSeak時
・名前の登録が出来ていなかったため例外発生して試合結果表示が出来なかった点の修正
・勝利者登録で通常モードの勝者リストと二重登録になる可能性があったため整理して修正
・シェイプシフターに非対応だった点の修正
・トロール勝利に狐が追加される点の修正

勝利判定ルーチン変更したので組み合わせテストしていたら不具合発見
・インポスター生存カウントされる前にゲームが終わってしまうためエゴイストが正常に判定されない
=>初期化位置移動
・deathReasonとisDeadがMODクライアントに通知されていない
=>RPCを追加

通常
　インポスター、クルー、アーソニスト、ジェスター、テロリスト、オポチュニスト、エゴイスト各勝利の確認
HAS
　インポスター1
　シェイプシフター1
　シェイプシフター1、狐１、トロル１
の組み合わせで確認