### PR TITLE
[v2.0.0]fix/SetNameRpc

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -41,7 +41,11 @@ namespace TownOfHost
             {
                 case RpcCalls.SetName: //SetNameRPC
                     string name = reader.ReadString();
-                    bool DontShowOnModdedClient = reader.ReadBoolean();
+                    bool DontShowOnModdedClient = false;
+                    if (reader.BytesRemaining > 0)
+                    {
+                        DontShowOnModdedClient=reader.ReadBoolean();
+                    }
                     Logger.info("名前変更:" + __instance.name + " => " + name); //ログ
                     if (!DontShowOnModdedClient)
                     {

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -44,7 +44,7 @@ namespace TownOfHost
                     bool DontShowOnModdedClient = false;
                     if (reader.BytesRemaining > 0)
                     {
-                        DontShowOnModdedClient=reader.ReadBoolean();
+                        DontShowOnModdedClient = reader.ReadBoolean();
                     }
                     Logger.info("名前変更:" + __instance.name + " => " + name); //ログ
                     if (!DontShowOnModdedClient)


### PR DESCRIPTION
純正のRpcCalls.SetName を受け取った時、ReadBoolean()に失敗して例外を吐いてました
残りデータ量からModからのSetNameかRpcSetNamePrivateかを判定する処理を追加