### PR TITLE
[v2.0.0]Feature/ReduceNameNotify

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -189,7 +189,7 @@ namespace TownOfHost
             if (!taskState.hasTasks) return "null";
             return $"<color=#ffff00>({taskState.CompletedTasksCount}/{taskState.AllTasksCount})</color>";
         }
-        public static string getTaskText(byte  playerId)
+        public static string getTaskText(byte playerId)
         {
             var taskState = PlayerState.taskState[playerId];
             if (!taskState.hasTasks) return "";
@@ -464,8 +464,7 @@ namespace TownOfHost
                 SelfRoleName += SelfName += SelfSuffix == "" ? "" : "\r\n" + SelfSuffix;
 
                 //適用
-                seer.RpcSetNamePrivate(SelfName, true);
-                HudManagerPatch.LastSetNameDesyncCount++;
+                seer.RpcSetNamePrivate(SelfName, true, force: isMeeting);
 
                 //他人用の変数定義
                 bool SeerKnowsImpostors = false; //trueの時、インポスターの名前が赤色に見える
@@ -548,8 +547,7 @@ namespace TownOfHost
                         //全てのテキストを合成します。
                         string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetMark}";
                         //適用
-                        target.RpcSetNamePrivate(TargetName, true, seer);
-                        HudManagerPatch.LastSetNameDesyncCount++;
+                        target.RpcSetNamePrivate(TargetName, true, seer, force: isMeeting);
 
                         TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.name + ":END", "NotifyRoles");
                     }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -210,7 +210,7 @@ namespace TownOfHost
                 {
                     foreach (var pc in PlayerControl.AllPlayerControls)
                     {
-                        pc.RpcSetName(pc.getRealName(isMeeting: true));
+                        pc.RpcSetNameEx(pc.getRealName(isMeeting: true));
                     }
                 }, 3f, "SetName To Chat");
             }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -395,9 +395,9 @@ namespace TownOfHost
         {
             //async Taskじゃ警告出るから仕方ないよね。
             var revertName = PlayerControl.LocalPlayer.name;
-            PlayerControl.LocalPlayer.RpcSetName(name);
+            PlayerControl.LocalPlayer.RpcSetNameEx(name);
             await Task.Delay(time);
-            PlayerControl.LocalPlayer.RpcSetName(revertName);
+            PlayerControl.LocalPlayer.RpcSetNameEx(revertName);
         }
     }
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.FixedUpdate))]

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -57,7 +57,7 @@ namespace TownOfHost
             {
                 foreach (var seer in PlayerControl.AllPlayerControls)
                 {
-                    var pair=(target.PlayerId, seer.PlayerId);
+                    var pair = (target.PlayerId, seer.PlayerId);
                     main.LastNotifyNames[pair] = target.name;
                 }
             }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -52,6 +52,15 @@ namespace TownOfHost
             main.introDestroyed = false;
 
             NameColorManager.Instance.RpcReset();
+            main.LastNotifyNames = new();
+            foreach (var target in PlayerControl.AllPlayerControls)
+            {
+                foreach (var seer in PlayerControl.AllPlayerControls)
+                {
+                    var pair=(target.PlayerId, seer.PlayerId);
+                    main.LastNotifyNames[pair] = target.name;
+                }
+            }
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
                 main.AllPlayerSpeed[pc.PlayerId] = main.RealOptionsData.PlayerSpeedMod; //移動速度をデフォルトの移動速度に変更

--- a/main.cs
+++ b/main.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.IL2CPP;
@@ -47,6 +47,7 @@ namespace TownOfHost
         public static HashSet<AdditionalWinners> additionalwinners = new HashSet<AdditionalWinners>();
         public static GameOptionsData RealOptionsData;
         public static Dictionary<byte, string> AllPlayerNames;
+        public static Dictionary<(byte,byte), string> LastNotifyNames;
         public static Dictionary<byte, CustomRoles> AllPlayerCustomRoles;
         public static Dictionary<byte, CustomRoles> AllPlayerCustomSubRoles;
         public static Dictionary<byte, bool> BlockKilling;

--- a/main.cs
+++ b/main.cs
@@ -47,7 +47,7 @@ namespace TownOfHost
         public static HashSet<AdditionalWinners> additionalwinners = new HashSet<AdditionalWinners>();
         public static GameOptionsData RealOptionsData;
         public static Dictionary<byte, string> AllPlayerNames;
-        public static Dictionary<(byte,byte), string> LastNotifyNames;
+        public static Dictionary<(byte, byte), string> LastNotifyNames;
         public static Dictionary<byte, CustomRoles> AllPlayerCustomRoles;
         public static Dictionary<byte, CustomRoles> AllPlayerCustomSubRoles;
         public static Dictionary<byte, bool> BlockKilling;


### PR DESCRIPTION
名前の履歴を残して変更不要なRpcSetNameを削減
・保存用Dictionaryの追加
・RpcSetNamePrivateの改良
　ミーティング時は念のため強制出来るように引数追加
　履歴と比較してキャンセル
・RpcSetNameの履歴残し版RpcSetNameExの追加
・LastSetNameDesyncCountのカウントタイミング変更