### PR TITLE
[v2.0.0]Fix/fixed update

### DIFF
--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -77,7 +77,7 @@ namespace TownOfHost
             if (player == null || player.Data == null || player.Data.Tasks == null) return;
             if (!Utils.hasTasks(player.Data, false)) return;
             hasTasks = true;
-            AllTasksCount=player.Data.Tasks.Count;
+            AllTasksCount = player.Data.Tasks.Count;
 
             //役職ごとにタスク量の調整を行う
             var adjustedTasksCount = AllTasksCount;
@@ -98,7 +98,7 @@ namespace TownOfHost
             Logger.info($"{player.name}: UpdateTask", "TaskCounts");
             if (!hasTasks) return;
             //初期化出来ていなかったら初期化
-            if(AllTasksCount==-1)Init(player);
+            if (AllTasksCount == -1) Init(player);
             //クリアしてたらカウントしない
             if (CompletedTasksCount >= AllTasksCount) return;
 
@@ -119,6 +119,7 @@ namespace TownOfHost
         public static bool isOnlineGame => AmongUsClient.Instance.GameMode == GameModes.OnlineGame;
         public static bool isLocalGame => AmongUsClient.Instance.GameMode == GameModes.LocalGame;
         public static bool isFreePlay => AmongUsClient.Instance.GameMode == GameModes.FreePlay;
+        public static bool isInTask => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Started && !MeetingHud.Instance;
         public static bool isMeeting => MeetingHud.Instance;
         public static bool isCountDown => GameStartManager.InstanceExists && GameStartManager.Instance.startState == GameStartManager.StartingStates.Countdown;
     }

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -120,7 +120,7 @@ namespace TownOfHost
         public static bool isLocalGame => AmongUsClient.Instance.GameMode == GameModes.LocalGame;
         public static bool isFreePlay => AmongUsClient.Instance.GameMode == GameModes.FreePlay;
         public static bool isInTask => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Started && !MeetingHud.Instance;
-        public static bool isMeeting => MeetingHud.Instance;
+        public static bool isMeeting => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Started && MeetingHud.Instance;
         public static bool isCountDown => GameStartManager.InstanceExists && GameStartManager.Instance.startState == GameStartManager.StartingStates.Countdown;
     }
 }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -408,30 +408,33 @@ namespace TownOfHost
             if (AmongUsClient.Instance.AmHost)
             {//実行クライアントがホストの場合のみ実行
              //Vampireの処理
-                if (GameStates.isInTask && main.BitPlayers.ContainsKey(__instance.PlayerId))
+                if (GameStates.isInTask && CustomRoles.Vampire.isEnable())
                 {
-                    //__instance:キルされる予定のプレイヤー
-                    //main.BitPlayers[__instance.PlayerId].Item1:キルしたプレイヤーのID
-                    //main.BitPlayers[__instance.PlayerId].Item2:キルするまでの秒数
-                    if (main.BitPlayers[__instance.PlayerId].Item2 >= Options.VampireKillDelay.GetFloat())
+                    if (main.BitPlayers.ContainsKey(__instance.PlayerId))
                     {
-                        byte vampireID = main.BitPlayers[__instance.PlayerId].Item1;
-                        if (!__instance.Data.IsDead)
+                        //__instance:キルされる予定のプレイヤー
+                        //main.BitPlayers[__instance.PlayerId].Item1:キルしたプレイヤーのID
+                        //main.BitPlayers[__instance.PlayerId].Item2:キルするまでの秒数
+                        if (main.BitPlayers[__instance.PlayerId].Item2 >= Options.VampireKillDelay.GetFloat())
                         {
-                            PlayerState.setDeathReason(__instance.PlayerId, PlayerState.DeathReason.Bite);
-                            __instance.RpcMurderPlayer(__instance);
-                            RPC.PlaySoundRPC(vampireID, Sounds.KillSound);
-                            Logger.SendToFile("Vampireに噛まれている" + __instance.name + "を自爆させました。");
-                            Utils.getPlayerById(vampireID).TrapperKilled(__instance);
+                            byte vampireID = main.BitPlayers[__instance.PlayerId].Item1;
+                            if (!__instance.Data.IsDead)
+                            {
+                                PlayerState.setDeathReason(__instance.PlayerId, PlayerState.DeathReason.Bite);
+                                __instance.RpcMurderPlayer(__instance);
+                                RPC.PlaySoundRPC(vampireID, Sounds.KillSound);
+                                Logger.SendToFile("Vampireに噛まれている" + __instance.name + "を自爆させました。");
+                                Utils.getPlayerById(vampireID).TrapperKilled(__instance);
+                            }
+                            else
+                                Logger.SendToFile("Vampireに噛まれている" + __instance.name + "はすでに死んでいました。");
+                            main.BitPlayers.Remove(__instance.PlayerId);
                         }
                         else
-                            Logger.SendToFile("Vampireに噛まれている" + __instance.name + "はすでに死んでいました。");
-                        main.BitPlayers.Remove(__instance.PlayerId);
-                    }
-                    else
-                    {
-                        main.BitPlayers[__instance.PlayerId] =
-                        (main.BitPlayers[__instance.PlayerId].Item1, main.BitPlayers[__instance.PlayerId].Item2 + Time.fixedDeltaTime);
+                        {
+                            main.BitPlayers[__instance.PlayerId] =
+                            (main.BitPlayers[__instance.PlayerId].Item1, main.BitPlayers[__instance.PlayerId].Item2 + Time.fixedDeltaTime);
+                        }
                     }
                 }
                 if (GameStates.isInTask && main.SerialKillerTimer.ContainsKey(__instance.PlayerId))

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -408,7 +408,7 @@ namespace TownOfHost
             if (AmongUsClient.Instance.AmHost)
             {//実行クライアントがホストの場合のみ実行
              //Vampireの処理
-                if (main.BitPlayers.ContainsKey(__instance.PlayerId))
+                if (GameStates.isInTask && main.BitPlayers.ContainsKey(__instance.PlayerId))
                 {
                     //__instance:キルされる予定のプレイヤー
                     //main.BitPlayers[__instance.PlayerId].Item1:キルしたプレイヤーのID
@@ -434,7 +434,7 @@ namespace TownOfHost
                         (main.BitPlayers[__instance.PlayerId].Item1, main.BitPlayers[__instance.PlayerId].Item2 + Time.fixedDeltaTime);
                     }
                 }
-                if (main.SerialKillerTimer.ContainsKey(__instance.PlayerId))
+                if (GameStates.isInTask && main.SerialKillerTimer.ContainsKey(__instance.PlayerId))
                 {
                     if (main.SerialKillerTimer[__instance.PlayerId] >= Options.SerialKillerLimit.GetFloat())
                     {//自滅時間が来たとき
@@ -453,7 +453,7 @@ namespace TownOfHost
                         (main.SerialKillerTimer[__instance.PlayerId] + Time.fixedDeltaTime);//時間をカウント
                     }
                 }
-                if (main.WarlockTimer.ContainsKey(__instance.PlayerId))//処理を1秒遅らせる
+                if (GameStates.isInTask && main.WarlockTimer.ContainsKey(__instance.PlayerId))//処理を1秒遅らせる
                 {
                     if (main.WarlockTimer[__instance.PlayerId] >= 1f)
                     {
@@ -465,7 +465,7 @@ namespace TownOfHost
                     else main.WarlockTimer[__instance.PlayerId] = (main.WarlockTimer[__instance.PlayerId] + Time.fixedDeltaTime);//時間をカウント
                 }
                 //バウハンのキルクールの変換とターゲットのリセット
-                if (main.BountyTimer.ContainsKey(__instance.PlayerId))
+                if (GameStates.isInTask && main.BountyTimer.ContainsKey(__instance.PlayerId))
                 {
                     if (main.BountyTimer[__instance.PlayerId] >= Options.BountyTargetChangeTime.GetFloat() + Options.BountyFailureKillCooldown.GetFloat() - 1f && main.AirshipMeetingCheck)
                     {
@@ -489,7 +489,7 @@ namespace TownOfHost
                     if (main.BountyTimer[__instance.PlayerId] >= 0)
                         main.BountyTimer[__instance.PlayerId] = (main.BountyTimer[__instance.PlayerId] + Time.fixedDeltaTime);
                 }
-                if (main.AirshipMeetingTimer.ContainsKey(__instance.PlayerId))
+                if (GameStates.isInGame && main.AirshipMeetingTimer.ContainsKey(__instance.PlayerId))
                 {
                     if (main.AirshipMeetingTimer[__instance.PlayerId] >= 9f && !main.AirshipMeetingCheck)
                     {
@@ -523,7 +523,7 @@ namespace TownOfHost
                         main.AirshipMeetingTimer[__instance.PlayerId] = (main.AirshipMeetingTimer[__instance.PlayerId] + Time.fixedDeltaTime);
                     }
                 }
-                if (main.ArsonistTimer.ContainsKey(__instance.PlayerId))//アーソニストが誰かを塗っているとき
+                if (GameStates.isInTask && main.ArsonistTimer.ContainsKey(__instance.PlayerId))//アーソニストが誰かを塗っているとき
                 {
                     var ar_target = main.ArsonistTimer[__instance.PlayerId].Item1;//塗られる人
                     if (main.ArsonistTimer[__instance.PlayerId].Item2 >= Options.ArsonistDouseTime.GetFloat())//時間以上一緒にいて塗れた時
@@ -556,7 +556,7 @@ namespace TownOfHost
                         }
                     }
                 }
-                if (main.DousedPlayerCount.ContainsKey(__instance.PlayerId) && AmongUsClient.Instance.IsGameStarted)//試合終了判定など
+                if (GameStates.isInGame && main.DousedPlayerCount.ContainsKey(__instance.PlayerId))//試合終了判定など
                 {
                     if (main.DousedPlayerCount[__instance.PlayerId] == 0)//試合終了判定
                     {
@@ -578,7 +578,7 @@ namespace TownOfHost
                         }
                     }
                 }
-                if (main.RefixCooldownDelay <= 0)
+                if (GameStates.isInGame && main.RefixCooldownDelay <= 0)
                     foreach (var pc in PlayerControl.AllPlayerControls)
                     {
                         if (pc.isVampire() || pc.isWarlock())
@@ -588,7 +588,7 @@ namespace TownOfHost
                 if (__instance.AmOwner) Utils.ApplySuffix();
             }
 
-            if (AmongUsClient.Instance.IsGameStarted)
+            if (GameStates.isInGame)
             {
                 //役職テキストの表示
                 var RoleTextTransform = __instance.nameText.transform.Find("RoleText");


### PR DESCRIPTION
FixedUpdatePatchにてロビー中でもタイマー処理等を行っていたためモード判定を追加。
役職によってミーティング中キャンセルするしないがあると思うので役職ごとに判定を追加しています。

役職
　ヴァンパイア、シリアルキラー、ウォーロック、バウンティハンター、アーソニスト
マップ
　スケルド、エアーシップ
での正常動作を確認しました。