### PR TITLE
[v2.0.0]Fix/deathReasonRpc

### DIFF
--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -33,6 +33,14 @@ namespace TownOfHost
         public static Dictionary<byte, TaskState> taskState = new();
         public static void setDeathReason(byte p, DeathReason reason) { deathReasons[p] = reason; }
         public static DeathReason getDeathReason(byte p) { return deathReasons.TryGetValue(p, out var reason) ? reason : DeathReason.etc; }
+        public static void setDead(byte p)
+        {
+            isDead[p] = true;
+            if (AmongUsClient.Instance.AmHost)
+            {
+                RPC.SendDeathReason(p, deathReasons[p]);
+            }
+        }
         public static bool isSuicide(byte p) { return deathReasons[p] == DeathReason.Suicide; }
         public static void InitTask(PlayerControl player)
         {
@@ -77,7 +85,7 @@ namespace TownOfHost
             if (player == null || player.Data == null || player.Data.Tasks == null) return;
             if (!Utils.hasTasks(player.Data, false)) return;
             hasTasks = true;
-            AllTasksCount=player.Data.Tasks.Count;
+            AllTasksCount = player.Data.Tasks.Count;
 
             //役職ごとにタスク量の調整を行う
             var adjustedTasksCount = AllTasksCount;
@@ -98,7 +106,7 @@ namespace TownOfHost
             Logger.info($"{player.name}: UpdateTask", "TaskCounts");
             if (!hasTasks) return;
             //初期化出来ていなかったら初期化
-            if(AllTasksCount==-1)Init(player);
+            if (AllTasksCount == -1) Init(player);
             //クリアしてたらカウントしない
             if (CompletedTasksCount >= AllTasksCount) return;
 

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -11,6 +11,7 @@ namespace TownOfHost
     {
         VersionCheck = 60,
         SyncCustomSettings = 80,
+        SetDeathReason,
         JesterExiled,
         TerroristWin,
         ArsonistWin,
@@ -79,6 +80,9 @@ namespace TownOfHost
                         //すべてのカスタムオプションについてインデックス値で受信
                         co.Selection = reader.ReadInt32();
                     }
+                    break;
+                case CustomRPC.SetDeathReason:
+                    RPC.GetDeathReason(reader);
                     break;
                 case CustomRPC.JesterExiled:
                     byte exiledJester = reader.ReadByte();
@@ -197,6 +201,21 @@ namespace TownOfHost
             AmongUsClient.Instance.FinishRpcImmediately(writer);
             main.playerVersion[PlayerControl.LocalPlayer.PlayerId] = new PlayerVersion(main.PluginVersion, $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})");
         }
+        public static void SendDeathReason(byte playerId, PlayerState.DeathReason deathReason)
+        {
+            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetDeathReason, Hazel.SendOption.Reliable, -1);
+            writer.Write(playerId);
+            writer.Write((int)deathReason);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+        }
+        public static void GetDeathReason(MessageReader reader)
+        {
+            var playerId = reader.ReadByte();
+            var deathReason = (PlayerState.DeathReason)reader.ReadInt32();
+            PlayerState.deathReasons[playerId] = deathReason;
+            PlayerState.isDead[playerId] = true;
+        }
+
         public static void JesterExiled(byte jesterID)
         {
             main.ExiledJesterID = jesterID;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -323,7 +323,7 @@ namespace TownOfHost
                         //生存者は爆死
                         pc.MurderPlayer(pc);
                         PlayerState.setDeathReason(pc.PlayerId, PlayerState.DeathReason.Bombed);
-                        PlayerState.isDead[pc.PlayerId] = true;
+                        PlayerState.setDead(pc.PlayerId);
                     }
                 }
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TerroristWin, Hazel.SendOption.Reliable, -1);

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -48,7 +48,7 @@ namespace TownOfHost
                         p.RpcMurderPlayer(p);
                     }
                 }
-                PlayerState.isDead[exiled.PlayerId] = true;
+                PlayerState.setDead(exiled.PlayerId);
             }
             if (AmongUsClient.Instance.AmHost && main.isFixedCooldown)
                 main.RefixCooldownDelay = main.RealOptionsData.KillCooldown - 3f;

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -58,7 +58,7 @@ namespace TownOfHost
                 if (pc.isLastImpostor())
                     main.AllPlayerKillCooldown[pc.PlayerId] = Options.LastImpostorKillCooldown.GetFloat();
             }
-            PlayerState.isDead[target.PlayerId] = true;
+            PlayerState.setDead(target.PlayerId);
             Utils.CountAliveImpostors();
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -32,10 +32,10 @@ namespace TownOfHost
     {
         public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ClientData data, [HarmonyArgument(1)] DisconnectReasons reason)
         {
-//            Logger.info($"RealNames[{data.Character.PlayerId}]を削除");
-//            main.RealNames.Remove(data.Character.PlayerId);
+            //            Logger.info($"RealNames[{data.Character.PlayerId}]を削除");
+            //            main.RealNames.Remove(data.Character.PlayerId);
             PlayerState.setDeathReason(data.Character.PlayerId, PlayerState.DeathReason.Disconnected);
-            PlayerState.isDead[data.Character.PlayerId] = true;
+            PlayerState.setDead(data.Character.PlayerId);
             Logger.info("切断理由:" + reason.ToString());
         }
     }


### PR DESCRIPTION
MODクライアントに死因・死亡が通知されていなかったためRPCを追加。
死亡が確定した段階でRPCを飛ばすように変更

死亡、追放、回線落ちで通知が飛ぶことを確認しました