### PR TITLE
[v2.0.0]MODクライアントでAliveImpostorsが初期化されない点の修正

### DIFF
--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -240,6 +240,8 @@ namespace TownOfHost
                 {
                     PlayerState.InitTask(pc);
                 }
+                Utils.CountAliveImpostors();
+                Utils.NotifyRoles();
             }
         }
     }


### PR DESCRIPTION
AliveImpostorsが初期化されていないためMODクライアントで
Mafiaが開始時点でキル可能になるなどの不具合発生

初期化を追加しました。
