### PR TITLE
fix/HideAndSeek

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -12,6 +12,7 @@ namespace TownOfHost
         VersionCheck = 60,
         SyncCustomSettings = 80,
         SetDeathReason,
+        TrollWin,
         JesterExiled,
         TerroristWin,
         ExecutionerWin,
@@ -85,6 +86,10 @@ namespace TownOfHost
                     break;
                 case CustomRPC.SetDeathReason:
                     RPC.GetDeathReason(reader);
+                    break;
+                case CustomRPC.TrollWin:
+                    byte wonTroll = reader.ReadByte();
+                    RPC.TrollWin(wonTroll);
                     break;
                 case CustomRPC.JesterExiled:
                     byte exiledJester = reader.ReadByte();
@@ -227,6 +232,12 @@ namespace TownOfHost
             PlayerState.isDead[playerId] = true;
         }
 
+        public static void TrollWin(byte trollID)
+        {
+            main.WonTrollID = trollID;
+            main.currentWinner = CustomWinner.HASTroll;
+            CustomWinTrigger(trollID);
+        }
         public static void JesterExiled(byte jesterID)
         {
             main.ExiledJesterID = jesterID;

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using Hazel;
 
 namespace TownOfHost
 {
@@ -133,6 +134,10 @@ namespace TownOfHost
                 if (!hasRole) return false;
                 if (role == CustomRoles.HASTroll && pc.Data.IsDead)
                 {
+                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TrollWin, Hazel.SendOption.Reliable, -1);
+                    writer.Write(pc.PlayerId);
+                    AmongUsClient.Instance.FinishRpcImmediately(writer);
+                    RPC.TrollWin(pc.PlayerId);
                     __instance.enabled = false;
                     ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
                     return true;
@@ -234,7 +239,7 @@ namespace TownOfHost
                             else
                             {
                                 //HideAndSeek中
-                                if (role == CustomRoles.Crewmate) numTotalAlive++;
+                                if (role != CustomRoles.HASFox && role != CustomRoles.HASTroll) numTotalAlive++;
                             }
 
                             if (playerInfo.Role.TeamType == RoleTeamTypes.Impostor &&

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -167,24 +167,26 @@ namespace TownOfHost
                 {
                     var hasRole = main.AllPlayerCustomRoles.TryGetValue(pc.PlayerId, out var role);
                     if (!hasRole) continue;
-                    if (role == CustomRoles.Crewmate)
+                    if (role.getRoleType() == RoleType.Impostor)
                     {
-                        if (pc.Data.Role.IsImpostor && TempData.DidImpostorsWin(endGameResult.GameOverReason))
-                            winners.Add(pc);
-                        if (!pc.Data.Role.IsImpostor && TempData.DidHumansWin(endGameResult.GameOverReason))
+                        if (TempData.DidImpostorsWin(endGameResult.GameOverReason))
                             winners.Add(pc);
                     }
-                    if (role == CustomRoles.HASFox && !pc.Data.IsDead)
+                    else if (role.getRoleType() == RoleType.Crewmate)
                     {
-                        winners.Add(pc);
-                        main.additionalwinners.Add(AdditionalWinners.HASFox);
+                        if (TempData.DidHumansWin(endGameResult.GameOverReason))
+                            winners.Add(pc);
                     }
-                    if (role == CustomRoles.HASTroll && pc.Data.IsDead)
+                    if (main.currentWinner == CustomWinner.HASTroll)
                     {
-                        main.currentWinner = CustomWinner.Troll;
                         winners = new List<PlayerControl>();
                         winners.Add(pc);
                         break;
+                    }
+                    else if (role == CustomRoles.HASFox && !pc.Data.IsDead)
+                    {
+                        winners.Add(pc);
+                        main.additionalwinners.Add(AdditionalWinners.HASFox);
                     }
                 }
                 TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
@@ -235,39 +237,44 @@ namespace TownOfHost
             {
                 //通常勝利
                 case CustomWinner.Impostor:
-                    CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Impostor)}";
+                    CustomWinnerText = Utils.getRoleName(CustomRoles.Impostor);
                     CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Impostor);
                     break;
                 case CustomWinner.Crewmate:
-                    CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Crewmate)}";
+                    CustomWinnerText = Utils.getRoleName(CustomRoles.Crewmate);
                     CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Crewmate);
                     break;
                 //特殊勝利
                 case CustomWinner.Jester:
                     __instance.BackgroundBar.material.color = Utils.getRoleColor(CustomRoles.Jester);
-                    CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Jester)}";
+                    CustomWinnerText = Utils.getRoleName(CustomRoles.Jester);
                     CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Jester);
                     break;
                 case CustomWinner.Terrorist:
                     __instance.Foreground.material.color = Color.red;
                     __instance.BackgroundBar.material.color = Color.green;
-                    CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Terrorist)}";
+                    CustomWinnerText = Utils.getRoleName(CustomRoles.Terrorist);
                     CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Terrorist);
                     break;
                 case CustomWinner.Executioner:
                     __instance.BackgroundBar.material.color = Utils.getRoleColor(CustomRoles.Executioner);
-                    CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Executioner)}";
+                    CustomWinnerText = Utils.getRoleName(CustomRoles.Executioner);
                     CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Executioner);
                     break;
                 case CustomWinner.Arsonist:
                     __instance.BackgroundBar.material.color = Utils.getRoleColor(CustomRoles.Arsonist);
-                    CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Arsonist)}";
+                    CustomWinnerText = Utils.getRoleName(CustomRoles.Arsonist);
                     CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Arsonist);
                     break;
                 case CustomWinner.Egoist:
                     __instance.BackgroundBar.material.color = Utils.getRoleColor(CustomRoles.Egoist);
-                    CustomWinnerText = $"{Utils.getRoleName(CustomRoles.Egoist)}";
+                    CustomWinnerText = Utils.getRoleName(CustomRoles.Egoist);
                     CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.Egoist);
+                    break;
+                case CustomWinner.HASTroll:
+                    __instance.BackgroundBar.material.color = Utils.getRoleColor(CustomRoles.HASTroll);
+                    CustomWinnerText = Utils.getRoleName(CustomRoles.HASTroll);
+                    CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.HASTroll);
                     break;
                 //引き分け処理
                 case CustomWinner.Draw:
@@ -292,22 +299,6 @@ namespace TownOfHost
 
                 if (main.additionalwinners.Contains(AdditionalWinners.HASFox))
                     AdditionalWinnerText += $"＆<color={Utils.getRoleColorCode(CustomRoles.HASFox)}>{Utils.getRoleName(CustomRoles.HASFox)}</color>";
-            }
-            if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
-            {
-                foreach (var p in PlayerControl.AllPlayerControls)
-                {
-                    if (p.Data.IsDead)
-                    {
-                        var hasRole = main.AllPlayerCustomRoles.TryGetValue(p.PlayerId, out var role);
-                        if (hasRole && role == CustomRoles.HASTroll)
-                        {
-                            __instance.BackgroundBar.material.color = Color.green;
-                            CustomWinnerText = $"{Utils.getRoleName(CustomRoles.HASTroll)}";
-                            CustomWinnerColor = Utils.getRoleColorCode(CustomRoles.HASTroll);
-                        }
-                    }
-                }
             }
             if (main.currentWinner != CustomWinner.Draw)
             {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -647,11 +647,11 @@ namespace TownOfHost
                 if (GameStates.isInGame)
                 {
                     var RoleTextData = Utils.GetRoleText(__instance);
-                    if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
-                    {
-                        var hasRole = main.AllPlayerCustomRoles.TryGetValue(__instance.PlayerId, out var role);
-                        if (hasRole) RoleTextData = Utils.GetRoleTextHideAndSeek(__instance.Data.Role.Role, role);
-                    }
+                    //if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
+                    //{
+                    //    var hasRole = main.AllPlayerCustomRoles.TryGetValue(__instance.PlayerId, out var role);
+                    //    if (hasRole) RoleTextData = Utils.GetRoleTextHideAndSeek(__instance.Data.Role.Role, role);
+                    //}
                     RoleText.text = RoleTextData.Item1;
                     RoleText.color = RoleTextData.Item2;
                     if (__instance.AmOwner) RoleText.enabled = true; //自分ならロールを表示

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -188,106 +188,80 @@ namespace TownOfHost
             var rand = new System.Random();
             main.KillOrSpell = new Dictionary<byte, bool>();
 
+            List<PlayerControl> Crewmates = new List<PlayerControl>();
+            List<PlayerControl> Impostors = new List<PlayerControl>();
+            List<PlayerControl> Scientists = new List<PlayerControl>();
+            List<PlayerControl> Engineers = new List<PlayerControl>();
+            List<PlayerControl> GuardianAngels = new List<PlayerControl>();
+            List<PlayerControl> Shapeshifters = new List<PlayerControl>();
+
+            foreach (var pc in PlayerControl.AllPlayerControls)
+            {
+                pc.Data.IsDead = false; //プレイヤーの死を解除する
+                if (main.AllPlayerCustomRoles.ContainsKey(pc.PlayerId)) continue; //既にカスタム役職が割り当てられていればスキップ
+                switch (pc.Data.Role.Role)
+                {
+                    case RoleTypes.Crewmate:
+                        Crewmates.Add(pc);
+                        main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Crewmate);
+                        break;
+                    case RoleTypes.Impostor:
+                        Impostors.Add(pc);
+                        main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Impostor);
+                        break;
+                    case RoleTypes.Scientist:
+                        Scientists.Add(pc);
+                        main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Scientist);
+                        break;
+                    case RoleTypes.Engineer:
+                        Engineers.Add(pc);
+                        main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Engineer);
+                        break;
+                    case RoleTypes.GuardianAngel:
+                        GuardianAngels.Add(pc);
+                        main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.GuardianAngel);
+                        break;
+                    case RoleTypes.Shapeshifter:
+                        Shapeshifters.Add(pc);
+                        main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Shapeshifter);
+                        break;
+                    default:
+                        Logger.SendInGame("エラー:役職設定中に無効な役職のプレイヤーを発見しました(" + pc.name + ")");
+                        break;
+                }
+            }
+
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
             {
-                rand = new System.Random();
                 SetColorPatch.IsAntiGlitchDisabled = true;
-
-                //Hide And Seek時の処理
-                List<PlayerControl> Impostors = new List<PlayerControl>();
-                List<PlayerControl> Crewmates = new List<PlayerControl>();
-                //リスト作成兼色設定処理
                 foreach (var pc in PlayerControl.AllPlayerControls)
                 {
-                    main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Crewmate);
-                    if (pc.Data.Role.IsImpostor)
-                    {
-                        Impostors.Add(pc);
+                    if (pc.Is(RoleType.Impostor))
                         pc.RpcSetColor(0);
-                    }
-                    else
-                    {
-                        Crewmates.Add(pc);
+                    else if (pc.Is(RoleType.Crewmate))
                         pc.RpcSetColor(1);
-                    }
-                    if (Options.IgnoreCosmetics.GetBool())
-                    {
-                        //pc.RpcSetHat("");
-                        //pc.RpcSetSkin("");
-                    }
                 }
-                //FoxCountとTrollCountを適切に修正する
-                int FixedFoxCount = Math.Clamp(CustomRoles.HASFox.getCount(), 0, Crewmates.Count);
-                int FixedTrollCount = Math.Clamp(CustomRoles.HASTroll.getCount(), 0, Crewmates.Count - FixedFoxCount);
-                List<PlayerControl> FoxList = new List<PlayerControl>();
-                List<PlayerControl> TrollList = new List<PlayerControl>();
+
                 //役職設定処理
-                for (var i = 0; i < FixedFoxCount; i++)
+                AssignCustomRolesFromList(CustomRoles.HASFox, Crewmates);
+                AssignCustomRolesFromList(CustomRoles.HASTroll, Crewmates);
+                foreach (var pair in main.AllPlayerCustomRoles)
                 {
-                    var id = rand.Next(Crewmates.Count);
-                    FoxList.Add(Crewmates[id]);
-                    main.AllPlayerCustomRoles[Crewmates[id].PlayerId] = CustomRoles.HASFox;
-                    Crewmates[id].RpcSetColor(3);
-                    Crewmates[id].RpcSetCustomRole(CustomRoles.HASFox);
-                    Crewmates.RemoveAt(id);
+                    //RPCによる同期
+                    ExtendedPlayerControl.RpcSetCustomRole(pair.Key, pair.Value);
                 }
-                for (var i = 0; i < FixedTrollCount; i++)
+                //色設定処理
+                SetColorPatch.IsAntiGlitchDisabled = true;
+
+                //名前の記録
+                main.AllPlayerNames = new();
+                foreach (var pair in main.AllPlayerCustomRoles)
                 {
-                    var id = rand.Next(Crewmates.Count);
-                    TrollList.Add(Crewmates[id]);
-                    main.AllPlayerCustomRoles[Crewmates[id].PlayerId] = CustomRoles.HASTroll;
-                    Crewmates[id].RpcSetColor(2);
-                    Crewmates[id].RpcSetCustomRole(CustomRoles.HASTroll);
-                    Crewmates.RemoveAt(id);
+                    main.AllPlayerNames.Add(pair.Key, main.RealNames[pair.Key]);
                 }
-                //通常クルー・インポスター用RPC
-                foreach (var pc in Crewmates) pc.RpcSetCustomRole(CustomRoles.Crewmate);
-                foreach (var pc in Impostors) pc.RpcSetCustomRole(CustomRoles.Crewmate);
             }
             else
             {
-                List<PlayerControl> Crewmates = new List<PlayerControl>();
-                List<PlayerControl> Impostors = new List<PlayerControl>();
-                List<PlayerControl> Scientists = new List<PlayerControl>();
-                List<PlayerControl> Engineers = new List<PlayerControl>();
-                List<PlayerControl> GuardianAngels = new List<PlayerControl>();
-                List<PlayerControl> Shapeshifters = new List<PlayerControl>();
-
-                foreach (var pc in PlayerControl.AllPlayerControls)
-                {
-                    pc.Data.IsDead = false; //プレイヤーの死を解除する
-                    if (main.AllPlayerCustomRoles.ContainsKey(pc.PlayerId)) continue; //既にカスタム役職が割り当てられていればスキップ
-                    switch (pc.Data.Role.Role)
-                    {
-                        case RoleTypes.Crewmate:
-                            Crewmates.Add(pc);
-                            main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Crewmate);
-                            break;
-                        case RoleTypes.Impostor:
-                            Impostors.Add(pc);
-                            main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Impostor);
-                            break;
-                        case RoleTypes.Scientist:
-                            Scientists.Add(pc);
-                            main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Scientist);
-                            break;
-                        case RoleTypes.Engineer:
-                            Engineers.Add(pc);
-                            main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Engineer);
-                            break;
-                        case RoleTypes.GuardianAngel:
-                            GuardianAngels.Add(pc);
-                            main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.GuardianAngel);
-                            break;
-                        case RoleTypes.Shapeshifter:
-                            Shapeshifters.Add(pc);
-                            main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Shapeshifter);
-                            break;
-                        default:
-                            Logger.SendInGame("エラー:役職設定中に無効な役職のプレイヤーを発見しました(" + pc.name + ")");
-                            break;
-                    }
-                }
 
                 AssignCustomRolesFromList(CustomRoles.Jester, Crewmates);
                 AssignCustomRolesFromList(CustomRoles.Madmate, Engineers);
@@ -416,17 +390,17 @@ namespace TownOfHost
                 if (main.RealOptionsData.NumImpostors > 1)
                     ShapeshifterNum -= CustomRoles.Egoist.getCount();
                 roleOpt.SetRoleRate(RoleTypes.Shapeshifter, ShapeshifterNum, roleOpt.GetChancePerGame(RoleTypes.Shapeshifter));
-
-                //サーバーの役職判定をだます
-                new LateTask(() =>
-                {
-                    if (AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Started)
-                        foreach (var pc in PlayerControl.AllPlayerControls)
-                        {
-                            pc.RpcSetRole(RoleTypes.Shapeshifter);
-                        }
-                }, 3f, "SetImpostorForServer");
             }
+
+            //サーバーの役職判定をだます
+            new LateTask(() =>
+            {
+                if (AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Started)
+                    foreach (var pc in PlayerControl.AllPlayerControls)
+                    {
+                        pc.RpcSetRole(RoleTypes.Shapeshifter);
+                    }
+            }, 3f, "SetImpostorForServer");
             Utils.CountAliveImpostors();
             Utils.CustomSyncAllSettings();
             SetColorPatch.IsAntiGlitchDisabled = false;
@@ -441,6 +415,7 @@ namespace TownOfHost
             if (RawCount == -1) count = Math.Clamp(role.getCount(), 0, players.Count);
             if (count <= 0) return null;
             List<PlayerControl> AssignedPlayers = new List<PlayerControl>();
+            SetColorPatch.IsAntiGlitchDisabled = true;
             for (var i = 0; i < count; i++)
             {
                 var player = players[rand.Next(0, players.Count)];
@@ -448,7 +423,16 @@ namespace TownOfHost
                 players.Remove(player);
                 main.AllPlayerCustomRoles[player.PlayerId] = role;
                 Logger.info("役職設定:" + player.name + " = " + role.ToString());
+
+                if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
+                {
+                    if (player.Is(CustomRoles.HASTroll))
+                        player.RpcSetColor(2);
+                    else if (player.Is(CustomRoles.HASFox))
+                        player.RpcSetColor(3);
+                }
             }
+            SetColorPatch.IsAntiGlitchDisabled = false;
             return AssignedPlayers;
         }
     }

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -58,8 +58,8 @@ Opportunist,Opportunist,オポチュニスト
 Egoist,Egoist,エゴイスト
 
 # HideAndSeek
-Fox,Fox,狐
-Troll,Troll,トロール
+HASFox,Fox,狐
+HASTroll,Troll,トロール
 
 # 属性
 LastImpostor,Last Impostor,ラストインポスター

--- a/main.cs
+++ b/main.cs
@@ -93,6 +93,7 @@ namespace TownOfHost
         public static bool isShipStart;
         public static Dictionary<byte, bool> CheckShapeshift = new Dictionary<byte, bool>();
         public static Dictionary<(byte, byte), string> targetArrows = new();
+        public static byte WonTrollID;
         public static byte ExiledJesterID;
         public static byte WonTerroristID;
         public static byte WonExecutionerID;
@@ -317,7 +318,7 @@ namespace TownOfHost
         Executioner,
         Arsonist,
         Egoist,
-        Troll
+        HASTroll
     }
     public enum AdditionalWinners
     {
@@ -330,7 +331,7 @@ namespace TownOfHost
     /*public enum CustomRoles : byte
     {
         Default = 0,
-        Troll = 1,
+        HASTroll = 1,
         HASHox = 2
     }*/
     public enum SuffixModes


### PR DESCRIPTION
- HideAndSeekの役職割り当てのルーチンをほぼ一新しました。
　通常モードの割り当てルーチンと似た処理をするように変更
- トロール勝利時に勝利テキストが正しく表示されないバグを修正
- 一部HASTroll,HASFoxに変わっていない箇所を変更