### PR TITLE
Feature/TranslationReplacer

### DIFF
--- a/Modules/CustomOption.cs
+++ b/Modules/CustomOption.cs
@@ -15,6 +15,7 @@ namespace TownOfHost
         public int Id;
         public Color Color;
         public string Name;
+        public Dictionary<string, string> ReplacementDictionary;
         public string Format;
         public System.Object[] Selections;
 
@@ -73,7 +74,8 @@ namespace TownOfHost
             CustomOption parent,
             bool isHeader,
             bool isHidden,
-            string format)
+            string format,
+            Dictionary<string, string> replacementDic)
         {
             Id = id;
             Color = color;
@@ -85,6 +87,7 @@ namespace TownOfHost
             this.isHeader = isHeader;
             this.isHidden = isHidden;
             Format = format;
+            ReplacementDictionary = replacementDic;
 
             isHiddenOnDisplay = false;
 
@@ -114,9 +117,10 @@ namespace TownOfHost
             CustomOption parent = null,
             bool isHeader = false,
             bool isHidden = false,
-            string format = "")
+            string format = "",
+            Dictionary<string, string> replacementDic = null)
         {
-            return new CustomOption(id, color, name, selections, defaultValue, parent, isHeader, isHidden, format);
+            return new CustomOption(id, color, name, selections, defaultValue, parent, isHeader, isHidden, format, replacementDic);
         }
 
         public static CustomOption Create(int id,
@@ -129,7 +133,8 @@ namespace TownOfHost
             CustomOption parent = null,
             bool isHeader = false,
             bool isHidden = false,
-            string format = "")
+            string format = "",
+            Dictionary<string, string> replacementDic = null)
         {
             var selections = new List<float>();
             for (var s = min; s <= max; s += step)
@@ -137,7 +142,7 @@ namespace TownOfHost
                 selections.Add(s);
             }
 
-            return new CustomOption(id, color, name, selections.Cast<object>().ToArray(), defaultValue, parent, isHeader, isHidden, format);
+            return new CustomOption(id, color, name, selections.Cast<object>().ToArray(), defaultValue, parent, isHeader, isHidden, format, replacementDic);
         }
 
         public static CustomOption Create(int id,
@@ -147,9 +152,10 @@ namespace TownOfHost
             CustomOption parent = null,
             bool isHeader = false,
             bool isHidden = false,
-            string format = "")
+            string format = "",
+            Dictionary<string, string> replacementDic = null)
         {
-            return new CustomOption(id, color, name, new string[] { "Off", "On" }, defaultValue ? "On" : "Off", parent, isHeader, isHidden, format);
+            return new CustomOption(id, color, name, new string[] { "Off", "On" }, defaultValue ? "On" : "Off", parent, isHeader, isHidden, format, replacementDic);
         }
 
         public static CustomOption Create(string name, float defaultValue, float min, float max, float step)
@@ -235,12 +241,12 @@ namespace TownOfHost
 
         public string GetName()
         {
-            return Helpers.ColorString(Color, Translator.getString(Name));
+            return Helpers.ColorString(Color, Translator.getString(Name, ReplacementDictionary));
         }
 
         public virtual string getName(bool display = false)
         {
-            return Helpers.ColorString(Color, Translator.getString(Name));
+            return Helpers.ColorString(Color, Translator.getString(Name, ReplacementDictionary));
         }
 
         public void UpdateSelection(bool enable)

--- a/Modules/Translator.cs
+++ b/Modules/Translator.cs
@@ -67,7 +67,7 @@ namespace TownOfHost
             if (replacementDic != null)
                 foreach (var rd in replacementDic)
                 {
-                    str.Replace(rd.Key, rd.Value);
+                    str = str.Replace(rd.Key, rd.Value);
                 }
             return str;
         }

--- a/Modules/Translator.cs
+++ b/Modules/Translator.cs
@@ -59,11 +59,17 @@ namespace TownOfHost
             }
         }
 
-        public static string getString(string s)
+        public static string getString(string s, Dictionary<string, string> replacementDic = null)
         {
             var langId = TranslationController.InstanceExists ? TranslationController.Instance.currentLanguage.languageID : SupportedLangs.English;
             if (main.ForceJapanese.Value) langId = SupportedLangs.Japanese;
-            return getString(s, langId);
+            string str = getString(s, langId);
+            if (replacementDic != null)
+                foreach (var rd in replacementDic)
+                {
+                    str.Replace(rd.Key, rd.Value);
+                }
+            return str;
         }
 
         public static string getString(string s, SupportedLangs langId)


### PR DESCRIPTION
# 変更内容
Translator.getStringで文字列の置き換えを指定できるよう変更
また、その機能をCustomOptionで使えるよう変更
# 使用方法
Translator.getString関数の第二引数としてDictionary<string, string>を渡すと、翻訳後の文字列に含まれるkeyの文字列が対応するvalueの文字列に置き換えられた文字列が返ってきます。