### PR TITLE
[v2.0.0]Loversじゃない人が心中する不具合修正

### DIFF
--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -137,7 +137,7 @@ namespace TownOfHost
 
                 if (CustomRoles.Lovers.isEnable() && main.isLoversDead == false && main.LoversPlayers.Find(lp => lp.PlayerId == exileId) != null)
                 {
-                    FixedUpdatePatch.LoversSuicide(exiledPlayer);
+                    FixedUpdatePatch.LoversSuicide(exiledPlayer.PlayerId,true);
                 }
 
                 //霊界用暗転バグ対処

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -137,7 +137,7 @@ namespace TownOfHost
 
                 if (CustomRoles.Lovers.isEnable() && main.isLoversDead == false && main.LoversPlayers.Find(lp => lp.PlayerId == exileId) != null)
                 {
-                    FixedUpdatePatch.LoversSuicide(exiledPlayer.PlayerId,true);
+                    FixedUpdatePatch.LoversSuicide(exiledPlayer.PlayerId, true);
                 }
 
                 //霊界用暗転バグ対処

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -858,7 +858,7 @@ namespace TownOfHost
             }
         }
         //FIXME: 役職クラス化のタイミングで、このメソッドは移動予定
-        public static void LoversSuicide(byte deathId = 0x7f, bool isExilrd = false)
+        public static void LoversSuicide(byte deathId = 0x7f, bool isExiled = false)
         {
             if (CustomRoles.Lovers.isEnable() && main.isLoversDead == false)
             {
@@ -878,7 +878,7 @@ namespace TownOfHost
                         if (partnerPlayer.PlayerId != deathId && !partnerPlayer.Data.IsDead)
                         {
                             PlayerState.setDeathReason(partnerPlayer.PlayerId, PlayerState.DeathReason.LoversSuicide);
-                            if (isExilrd)
+                            if (isExiled)
                             {
                                 main.IgnoreReportPlayers.Add(partnerPlayer.PlayerId);   //通報不可な死体にする
                                 if (PlayerControl.GameOptions.MapId != 4) //Airship用

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -68,6 +68,8 @@ namespace TownOfHost
                 if (pc.isLastImpostor())
                     main.AllPlayerKillCooldown[pc.PlayerId] = Options.LastImpostorKillCooldown.GetFloat();
             }
+            FixedUpdatePatch.LoversSuicide(target.PlayerId);
+
             main.LastKiller.Remove(target);
 
             PlayerState.setDead(target.PlayerId);
@@ -170,12 +172,17 @@ namespace TownOfHost
             }
             main.LastKiller[target] = __instance;
             Logger.SendToFile("CheckMurder発生: " + __instance.name + "=>" + target.name);
+            if (__instance.PlayerId == target.PlayerId)
+            {
+                //自殺ならノーチェック
+                __instance.RpcMurderPlayer(target);
+                return false;
+            }
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek && Options.HideAndSeekKillDelayTimer > 0)
             {
                 Logger.info("HideAndSeekの待機時間中だったため、キルをキャンセルしました。");
                 return false;
             }
-
             if (__instance.Is(CustomRoles.SKMadmate)) return false;//シェリフがサイドキックされた場合
 
             if (main.BlockKilling.TryGetValue(__instance.PlayerId, out bool isBlocked) && isBlocked)
@@ -851,31 +858,33 @@ namespace TownOfHost
             }
         }
         //FIXME: 役職クラス化のタイミングで、このメソッドは移動予定
-        public static void LoversSuicide(GameData.PlayerInfo exiledLoversPlayerInfo = null)
+        public static void LoversSuicide(byte deathId = 0x7f, bool isExilrd = false)
         {
             if (CustomRoles.Lovers.isEnable() && main.isLoversDead == false)
             {
                 foreach (var loversPlayer in main.LoversPlayers)
                 {
-                    if (PlayerControl.AllPlayerControls[loversPlayer.PlayerId].Data.IsDead || exiledLoversPlayerInfo != null) //ラバーズが死んでいたら or ラバーズが投票先になったら
+                    //生きていて死ぬ予定でなければスキップ
+                    if (!loversPlayer.Data.IsDead && loversPlayer.PlayerId != deathId) continue;
+
+                    main.isLoversDead = true;
+                    foreach (var partnerPlayer in main.LoversPlayers)
                     {
-                        main.isLoversDead = true;
-                        foreach (var partnerPlayer in main.LoversPlayers)
+                        //本人ならスキップ
+                        if (loversPlayer.PlayerId == partnerPlayer.PlayerId) continue;
+
+                        //残った恋人を全て殺す(2人以上可)
+                        //生きていて死ぬ予定もない場合は心中
+                        if (partnerPlayer.PlayerId != deathId && !partnerPlayer.Data.IsDead)
                         {
-                            if (loversPlayer.PlayerId == partnerPlayer.PlayerId) continue;
-                            //残った恋人を全て殺す(2人以上可)
-                            if ((exiledLoversPlayerInfo == null || exiledLoversPlayerInfo.PlayerId != partnerPlayer.PlayerId)  //投票ではない または 投票先と恋人Bが違う人
-                            && !PlayerControl.AllPlayerControls[partnerPlayer.PlayerId].Data.IsDead) //パートナーが死んでなければ自殺してもらう
+                            PlayerState.setDeathReason(partnerPlayer.PlayerId, PlayerState.DeathReason.LoversSuicide);
+                            if (isExilrd)
                             {
-                                PlayerState.setDeathReason(partnerPlayer.PlayerId, PlayerState.DeathReason.LoversSuicide);
-                                if (exiledLoversPlayerInfo != null)
-                                {
-                                    main.IgnoreReportPlayers.Add(partnerPlayer.PlayerId);   //通報不可な死体にする
-                                    if (PlayerControl.GameOptions.MapId != 4) //Airship用
-                                        CheckForEndVotingPatch.recall = true;
-                                }
-                                partnerPlayer.RpcMurderPlayer(partnerPlayer);
+                                main.IgnoreReportPlayers.Add(partnerPlayer.PlayerId);   //通報不可な死体にする
+                                if (PlayerControl.GameOptions.MapId != 4) //Airship用
+                                    CheckForEndVotingPatch.recall = true;
                             }
+                            partnerPlayer.CheckMurder(partnerPlayer);
                         }
                     }
                 }


### PR DESCRIPTION
バグ対応
・恋人プレイヤーをAllPlayerControls[partnerPlayer.PlayerId]という取り方をしていたため恋人でない対象に処理してしまっていた
=>修正しました。

合わせて
・心中処理をMurdurPlayerでおこなうように変更
・心中処理がガードキャンセル処理に割り込んだ時に対応できるようCheckMurder経由するよう変更

※念のためFixedUpdate内で呼ばれる部分は残してあります
※他役職についても必要に応じてCheckMurder経由でキルするよう見直していきます。