### PR TITLE
ログの追加とリファクタリング

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -22,7 +22,7 @@ namespace TownOfHost
             }
             catch
             {
-                Logger.error($"Error loading sprite from path: {path}");
+                Logger.error($"Error loading sprite from path: {path}", "LoadSprite");
             }
             return null;
         }
@@ -42,7 +42,7 @@ namespace TownOfHost
             }
             catch
             {
-                Logger.error($"Error loading texture from resources: {path}");
+                Logger.error($"Error loading texture from resources: {path}", "LoadTexture");
             }
             return null;
         }

--- a/Modules/Debugger.cs
+++ b/Modules/Debugger.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System;
 using System.Collections.Generic;
+using LogLevel = BepInEx.Logging.LogLevel;
 
 namespace TownOfHost
 {
@@ -59,7 +60,7 @@ namespace TownOfHost
             if (DestroyableSingleton<HudManager>._instance) DestroyableSingleton<HudManager>.Instance.Notifier.AddItem(text);
             //SendToFile("<InGame>" + text);
         }
-        public static void SendToFile(string text, LogLevel level = LogLevel.Normal, string tag = "")
+        public static void SendToFile(string text, LogLevel level = LogLevel.Info, string tag = "")
         {
             if (!isEnable || disableList.Contains(tag)) return;
             string t = DateTime.Now.ToString("HH:mm:ss");
@@ -76,7 +77,7 @@ namespace TownOfHost
             var logger = main.Logger;
             switch (level)
             {
-                case LogLevel.Normal:
+                case LogLevel.Info:
                     logger.LogInfo(log_text);
                     break;
                 case LogLevel.Warning:
@@ -97,18 +98,15 @@ namespace TownOfHost
                     break;
             }
         }
-        public static void info(string text, string tag = "") => SendToFile(text, LogLevel.Normal, tag);
+        public static void info(string text, string tag = "") => SendToFile(text, LogLevel.Info, tag);
         public static void warn(string text, string tag = "") => SendToFile(text, LogLevel.Warning, tag);
         public static void error(string text, string tag = "") => SendToFile(text, LogLevel.Error, tag);
         public static void fatal(string text, string tag = "") => SendToFile(text, LogLevel.Fatal, tag);
         public static void msg(string text, string tag = "") => SendToFile(text, LogLevel.Message, tag);
-    }
-    public enum LogLevel
-    {
-        Normal = 0,
-        Warning,
-        Error,
-        Fatal,
-        Message
+        public static void currentMethod()
+        {
+            StackFrame stack = new StackFrame(1);
+            Logger.msg($"Called in \"{stack.GetMethod().ReflectedType.Name}.{stack.GetMethod().Name}\"", "Method");
+        }
     }
 }

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -121,7 +121,7 @@ namespace TownOfHost
             }
             main.LastNotifyNames[(player.PlayerId, seer.PlayerId)] = name;
             HudManagerPatch.LastSetNameDesyncCount++;
-            Logger.info($"Set:{player.name}:{name} for {seer.name}", "RpcSetNamePrivate");
+            Logger.info($"Set:{player.Data.PlayerName}:{name} for {seer.getNameWithRole()}", "RpcSetNamePrivate");
 
             var clientId = seer.getClientId();
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.SetName, Hazel.SendOption.Reliable, clientId);
@@ -508,7 +508,7 @@ namespace TownOfHost
             }
             var target = cTargets[rand.Next(0, cTargets.Count - 1)];
             main.BountyTargets[player.PlayerId] = target;
-            Logger.info($"プレイヤー{player.name}のターゲットを{target.name}に変更", "BountyHunter");
+            Logger.info($"プレイヤー{player.getNameWithRole()}のターゲットを{target.getNameWithRole()}に変更", "BountyHunter");
 
             //RPCによる同期
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetBountyTarget, SendOption.Reliable, -1);
@@ -617,7 +617,7 @@ namespace TownOfHost
         }
         public static void TrapperKilled(this PlayerControl killer, PlayerControl target)
         {
-            Logger.info(target.name + $"はTrapperだった", "Trapper");
+            Logger.info($"{target.Data.PlayerName}はTrapperだった", "Trapper");
             main.AllPlayerSpeed[killer.PlayerId] = 0.00001f;
             killer.CustomSyncSettings();
             new LateTask(() =>

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -404,6 +404,10 @@ namespace TownOfHost
             text += player.getCustomSubRole() != CustomRoles.NoSubRoleAssigned ? $" + {player.getSubRoleName()}" : "";
             return text;
         }
+        public static string getNameWithRole(this PlayerControl player)
+        {
+            return $"{player.Data.PlayerName}({player.getAllRoleName()})";
+        }
         public static string getRoleColorCode(this PlayerControl player)
         {
             return Utils.getRoleColorCode(player.getCustomRole());

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -394,6 +394,16 @@ namespace TownOfHost
         {
             return $"{Utils.getRoleName(player.getCustomRole())}" /*({getString("Last")})"*/;
         }
+        public static string getSubRoleName(this PlayerControl player)
+        {
+            return $"{Utils.getRoleName(player.getCustomSubRole())}";
+        }
+        public static string getAllRoleName(this PlayerControl player)
+        {
+            var text = player.getRoleName();
+            text += player.getCustomSubRole() != CustomRoles.NoSubRoleAssigned ? $" + {player.getSubRoleName()}" : "";
+            return text;
+        }
         public static string getRoleColorCode(this PlayerControl player)
         {
             return Utils.getRoleColorCode(player.getCustomRole());

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -68,7 +68,7 @@ namespace TownOfHost
             var cRole = CustomRoles.Crewmate;
             if (player == null)
             {
-                Logger.warn("CustomRoleを取得しようとしましたが、対象がnullでした。");
+                Logger.warn("CustomRoleを取得しようとしましたが、対象がnullでした。", "getCustomRole");
                 return cRole;
             }
             var cRoleFound = main.AllPlayerCustomRoles.TryGetValue(player.PlayerId, out cRole);
@@ -90,7 +90,7 @@ namespace TownOfHost
         {
             if (player == null)
             {
-                Logger.warn("CustomSubRoleを取得しようとしましたが、対象がnullでした。");
+                Logger.warn("CustomSubRoleを取得しようとしましたが、対象がnullでした。", "getCustomSubRole");
                 return CustomRoles.NoSubRoleAssigned;
             }
             var cRoleFound = main.AllPlayerCustomSubRoles.TryGetValue(player.PlayerId, out var cRole);
@@ -454,7 +454,7 @@ namespace TownOfHost
                 RealName = player.name;
                 if (RealName == "Player(Clone)") return RealName;
                 main.RealNames[player.PlayerId] = RealName;
-                TownOfHost.Logger.warn("プレイヤー" + player.PlayerId + "のRealNameが見つからなかったため、" + RealName + "を代入しました");
+                TownOfHost.Logger.warn("プレイヤー" + player.PlayerId + "のRealNameが見つからなかったため、" + RealName + "を代入しました", "getRealName");
             }
             return RealName;
         }
@@ -489,12 +489,12 @@ namespace TownOfHost
             var rand = new System.Random();
             if (cTargets.Count <= 0)
             {
-                Logger.error("バウンティ―ハンターのターゲットの指定に失敗しました:ターゲット候補が存在しません");
+                Logger.error("ターゲットの指定に失敗しました:ターゲット候補が存在しません", "BountyHunter");
                 return null;
             }
             var target = cTargets[rand.Next(0, cTargets.Count - 1)];
             main.BountyTargets[player.PlayerId] = target;
-            Logger.info($"プレイヤー{player.name}のターゲットを{target.name}に変更");
+            Logger.info($"プレイヤー{player.name}のターゲットを{target.name}に変更", "BountyHunter");
 
             //RPCによる同期
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetBountyTarget, SendOption.Reliable, -1);
@@ -603,7 +603,7 @@ namespace TownOfHost
         }
         public static void TrapperKilled(this PlayerControl killer, PlayerControl target)
         {
-            Logger.SendToFile(target.name + $"はTrapperだった");
+            Logger.info(target.name + $"はTrapperだった", "Trapper");
             main.AllPlayerSpeed[killer.PlayerId] = 0.00001f;
             killer.CustomSyncSettings();
             new LateTask(() =>

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -83,16 +83,16 @@ namespace TownOfHost
 
         public void Init(PlayerControl player)
         {
-            Logger.info($"{player.name}: InitTask", "TaskCounts");
+            Logger.info($"{player.getNameWithRole()}: InitTask", "TaskCounts");
             if (player == null || player.Data == null || player.Data.Tasks == null) return;
             if (!Utils.hasTasks(player.Data, false)) return;
             hasTasks = true;
             AllTasksCount = player.Data.Tasks.Count;
-            Logger.info($"{player.name}: {CompletedTasksCount}/{AllTasksCount}", "TaskCounts");
+            Logger.info($"{player.getNameWithRole()}: {CompletedTasksCount}/{AllTasksCount}", "TaskCounts");
         }
         public void Update(PlayerControl player)
         {
-            Logger.info($"{player.name}: UpdateTask", "TaskCounts");
+            Logger.info($"{player.getNameWithRole()}: UpdateTask", "TaskCounts");
             if (!hasTasks) return;
             //初期化出来ていなかったら初期化
             if (AllTasksCount == -1) Init(player);
@@ -103,7 +103,7 @@ namespace TownOfHost
 
             //調整後のタスク量までしか表示しない
             CompletedTasksCount = Math.Min(AllTasksCount, CompletedTasksCount);
-            Logger.info($"{player.name}: {CompletedTasksCount}/{AllTasksCount}", "TaskCounts");
+            Logger.info($"{player.getNameWithRole()}: {CompletedTasksCount}/{AllTasksCount}", "TaskCounts");
 
         }
     }

--- a/Modules/LateTask.cs
+++ b/Modules/LateTask.cs
@@ -24,7 +24,7 @@ namespace TownOfHost
             this.timer = time;
             this.name = name;
             Tasks.Add(this);
-            Logger.info("New LateTask \"" + name + "\" is created");
+            Logger.info("\"" + name + "\" is created", "LateTask");
         }
         public static void Update(float deltaTime)
         {

--- a/Modules/ModUpdater.cs
+++ b/Modules/ModUpdater.cs
@@ -143,7 +143,7 @@ namespace TownOfHost
             }
             catch (System.Exception e)
             {
-                Logger.error("Exception occurred when clearing old versions:\n" + e);
+                Logger.error("Exception occurred when clearing old versions:\n" + e, "ModUpdater");
             }
         }
 
@@ -157,7 +157,7 @@ namespace TownOfHost
                 var response = await http.GetAsync(new System.Uri("https://api.github.com/repos/tukasa0001/TownOfHost/releases/latest"), HttpCompletionOption.ResponseContentRead);
                 if (response.StatusCode != HttpStatusCode.OK || response.Content == null)
                 {
-                    Logger.error("Server returned no data: " + response.StatusCode.ToString());
+                    Logger.error("Server returned no data: " + response.StatusCode.ToString(), "ModUpdater");
                     return false;
                 }
                 string json = await response.Content.ReadAsStringAsync();
@@ -204,7 +204,7 @@ namespace TownOfHost
             }
             catch (System.Exception ex)
             {
-                Logger.error(ex.ToString());
+                Logger.error(ex.ToString(), "ModUpdater");
             }
             return false;
         }
@@ -218,7 +218,7 @@ namespace TownOfHost
                 var response = await http.GetAsync(new System.Uri(updateURI), HttpCompletionOption.ResponseContentRead);
                 if (response.StatusCode != HttpStatusCode.OK || response.Content == null)
                 {
-                    Logger.error("Server returned no data: " + response.StatusCode.ToString());
+                    Logger.error("Server returned no data: " + response.StatusCode.ToString(), "ModUpdater");
                     return false;
                 }
                 string codeBase = Assembly.GetExecutingAssembly().CodeBase;
@@ -241,7 +241,7 @@ namespace TownOfHost
             }
             catch (System.Exception ex)
             {
-                Logger.error(ex.ToString());
+                Logger.error(ex.ToString(), "ModUpdater");
             }
             showPopup(getString("updateFailed"));
             return false;

--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -86,7 +86,7 @@ namespace TownOfHost
 
         public static void Begin()
         {
-            Logger.info("NameColorManagerをリセット");
+            Logger.info("NameColorManagerをリセット", "NameColorManager");
             Instance = new NameColorManager();
         }
     }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -54,6 +54,10 @@ namespace TownOfHost
                     Logger.info("名前変更:" + __instance.getNameWithRole() + " => " + name, "SetName");
                     if (subReader.BytesRemaining > 0 && subReader.ReadBoolean()) return false;
                     break;
+                case RpcCalls.StartMeeting:
+                    var p = Utils.getPlayerById(subReader.ReadByte());
+                    Logger.info($"{__instance.getNameWithRole()} => {p?.getNameWithRole() ?? "null"}", "StartMeeting");
+                    break;
             }
             return true;
         }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -46,21 +46,14 @@ namespace TownOfHost
         public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] byte callId, [HarmonyArgument(1)] MessageReader reader)
         {
             var rpcType = (RpcCalls)callId;
+            MessageReader subReader = MessageReader.Get(reader);
             switch (rpcType)
             {
                 case RpcCalls.SetName: //SetNameRPC
-                    string name = reader.ReadString();
-                    bool DontShowOnModdedClient = false;
-                    if (reader.BytesRemaining > 0)
-                    {
-                        DontShowOnModdedClient = reader.ReadBoolean();
-                    }
-                    Logger.info("名前変更:" + __instance.name + " => " + name, "SetName"); //ログ
-                    if (!DontShowOnModdedClient)
-                    {
-                        __instance.SetName(name);
-                    }
-                    return false;
+                    string name = subReader.ReadString();
+                    Logger.info("名前変更:" + __instance.getNameWithRole() + " => " + name, "SetName");
+                    if (subReader.BytesRemaining > 0 && subReader.ReadBoolean()) return false;
+                    break;
             }
             return true;
         }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -75,7 +75,7 @@ namespace TownOfHost
                     }
                     catch
                     {
-                        Logger.info($"{__instance.getRealName()}({__instance.PlayerId}): バージョン情報が無効です", "RpcVersionCheck");
+                        Logger.info($"{__instance.Data.PlayerName}({__instance.PlayerId}): バージョン情報が無効です", "RpcVersionCheck");
                     }
                     break;
                 case CustomRPC.SyncCustomSettings:

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -55,7 +55,7 @@ namespace TownOfHost
                     {
                         DontShowOnModdedClient = reader.ReadBoolean();
                     }
-                    Logger.info("名前変更:" + __instance.name + " => " + name); //ログ
+                    Logger.info("名前変更:" + __instance.name + " => " + name, "SetName"); //ログ
                     if (!DontShowOnModdedClient)
                     {
                         __instance.SetName(name);

--- a/Modules/Translator.cs
+++ b/Modules/Translator.cs
@@ -8,9 +8,9 @@ namespace TownOfHost
         public static Dictionary<string, Dictionary<int, string>> tr;
         public static void init()
         {
-            Logger.info("Language Dictionary Initialize...");
+            Logger.info("Language Dictionary Initialize...", "Translator");
             loadLangs();
-            Logger.info("Language Dictionary Initialize Finished");
+            Logger.info("Language Dictionary Initialize Finished", "Translator");
         }
         public static void loadLangs()
         {
@@ -46,7 +46,7 @@ namespace TownOfHost
                 {
                     var err = $"翻訳用CSVファイルに誤りがあります。\n{currentLine}行目:";
                     foreach (var c in fields) err += $" [{c}]";
-                    Logger.warn(err);
+                    Logger.warn(err, "Translator");
                     continue;
                 }
                 for (var i = 1; i < fields.Count; i++)
@@ -54,7 +54,7 @@ namespace TownOfHost
                     var tmp_str = fields[i].Replace("\\n", "\n").Trim('"');
                     tmp.Add(Int32.Parse(header[i]), tmp_str);
                 }
-                if (tr.ContainsKey(fields[0])) { Logger.warn($"翻訳用CSVに重複があります。\n{currentLine}行目: \"{fields[0]}\""); continue; }
+                if (tr.ContainsKey(fields[0])) { Logger.warn($"翻訳用CSVに重複があります。\n{currentLine}行目: \"{fields[0]}\"", "Translator"); continue; }
                 tr.Add(fields[0], tmp);
             }
         }
@@ -85,7 +85,7 @@ namespace TownOfHost
                 {
                     if (dic.TryGetValue(0, out res))
                     {
-                        Logger.info($"Redirect to English: {res}");
+                        Logger.info($"Redirect to English: {res}", "Translator");
                         return res;
                     }
                     else

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -740,5 +740,13 @@ namespace TownOfHost
         {
             return getPlayerById(playerId)?.getAllRoleName() ?? "";
         }
+        public static string getNameWithRole(byte playerId)
+        {
+            return getPlayerById(playerId)?.getNameWithRole() ?? "";
+        }
+        public static string getNameWithRole(this GameData.PlayerInfo player)
+        {
+            return getPlayerById(player.PlayerId)?.getNameWithRole() ?? "";
+        }
     }
 }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -733,7 +733,7 @@ namespace TownOfHost
                 CustomRoles pc_role = pc.getCustomRole();
                 if (pc_role.isImpostor() && !pc.Data.IsDead) AliveImpostorCount++;
             }
-            TownOfHost.Logger.info("生存しているインポスター:" + AliveImpostorCount + "人");
+            TownOfHost.Logger.info("生存しているインポスター:" + AliveImpostorCount + "人", "CountAliveImpostors");
             main.AliveImpostorCount = AliveImpostorCount;
         }
     }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -736,5 +736,9 @@ namespace TownOfHost
             TownOfHost.Logger.info("生存しているインポスター:" + AliveImpostorCount + "人", "CountAliveImpostors");
             main.AliveImpostorCount = AliveImpostorCount;
         }
+        public static string getAllRoleName(byte playerId)
+        {
+            return getPlayerById(playerId)?.getAllRoleName() ?? "";
+        }
     }
 }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -463,7 +463,7 @@ namespace TownOfHost
             {
                 string fontSize = "1.5";
                 if (isMeeting && (seer.getClient().PlatformData.Platform.ToString() == "Playstation" || seer.getClient().PlatformData.Platform.ToString() == "Switch")) fontSize = "70%";
-                TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.name + ":START", "NotifyRoles");
+                TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.getNameWithRole() + ":START", "NotifyRoles");
                 //Loop1-bottleのSTART-END間でKeyNotFoundException
                 //seerが落ちているときに何もしない
                 if (seer.Data.Disconnected) continue;
@@ -593,7 +593,7 @@ namespace TownOfHost
                     {
                         //targetがseer自身の場合は何もしない
                         if (target == seer) continue;
-                        TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.name + ":START", "NotifyRoles");
+                        TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.getNameWithRole() + ":START", "NotifyRoles");
 
                         //他人のタスクはtargetがタスクを持っているかつ、seerが死んでいる場合のみ表示されます。それ以外の場合は空になります。
                         string TargetTaskText = hasTasks(target.Data, false) && seer.Data.IsDead && Options.GhostCanSeeOtherRoles.GetBool() ? $"{getTaskText(target)}" : "";
@@ -682,10 +682,10 @@ namespace TownOfHost
                         //適用
                         target.RpcSetNamePrivate(TargetName, true, seer, force: isMeeting);
 
-                        TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.name + ":END", "NotifyRoles");
+                        TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.getNameWithRole() + ":END", "NotifyRoles");
                     }
                 }
-                TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.name + ":END", "NotifyRoles");
+                TownOfHost.Logger.info("NotifyRoles-Loop1-" + seer.getNameWithRole() + ":END", "NotifyRoles");
             }
             main.witchMeeting = false;
         }

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -176,7 +176,7 @@ namespace TownOfHost
             }
             if (canceled)
             {
-                Logger.info("Command Canceled");
+                Logger.info("Command Canceled", "ChatCommand");
                 __instance.TextArea.Clear();
                 __instance.TextArea.SetText(cancelVal);
                 __instance.quickChatMenu.ResetGlyphs();

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -38,7 +38,7 @@ namespace TownOfHost
                     string version_text = "";
                     foreach (var kvp in main.playerVersion.OrderBy(pair => pair.Key))
                     {
-                        version_text += $"{kvp.Key}:{Utils.getPlayerById(kvp.Key).getRealName()}:{kvp.Value.version}({kvp.Value.tag})\n";
+                        version_text += $"{kvp.Key}:{Utils.getPlayerById(kvp.Key).Data.PlayerName}:{kvp.Value.version}({kvp.Value.tag})\n";
                     }
                     if (version_text != "") HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, version_text);
                     break;

--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -11,7 +11,7 @@ namespace TownOfHost
         {
             if (ModUpdater.hasUpdate)
             {
-                Logger.SendInGame(getString("onSetPublicNoLatest"));
+                Logger.info(getString("onSetPublicNoLatest"), "MakePublicPatch");
                 return false;
             }
             return true;

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -35,13 +35,13 @@ namespace TownOfHost
             //即スタート
             if (Input.GetKeyDown(KeyCode.LeftShift) && GameStates.isCountDown)
             {
-                Logger.info("CountDownTimer set to 0");
+                Logger.info("CountDownTimer set to 0", "KeyCommand");
                 GameStartManager.Instance.countDownTimer = 0;
             }
             //カウントダウンキャンセル
             if (Input.GetKeyDown(KeyCode.C) && GameStates.isCountDown)
             {
-                Logger.info("Reset CountDownTimer");
+                Logger.info("Reset CountDownTimer", "KeyCommand");
                 GameStartManager.Instance.ResetStartState();
             }
             //現在の有効な設定を表示

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -253,19 +253,19 @@ namespace TownOfHost
     {
         public static void Prefix(HudManager __instance)
         {
-            Logger.info("--------名前表示--------");
+            Logger.info("------------名前表示------------", "Info");
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
                 Logger.info($"{pc.PlayerId}:{pc.name}:{pc.nameText.text}");
                 main.RealNames[pc.PlayerId] = pc.name;
                 pc.nameText.text = pc.name;
             }
-            Logger.info("------役職割り当て------");
+            Logger.info("----------役職割り当て----------", "Info");
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
-                Logger.info($"{pc.name}({pc.PlayerId}):{pc.getRoleName()}");
+                Logger.info($"{pc.name}({pc.PlayerId}):{pc.getRoleName()}", "Info");
             }
-            Logger.info("----------環境----------");
+            Logger.info("--------------環境--------------", "Info");
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
                 var text = pc.PlayerId == PlayerControl.LocalPlayer.PlayerId ? "[*]" : "";
@@ -276,12 +276,12 @@ namespace TownOfHost
                     text += $"{pv.tag})";
                 }
                 else text += ":Vanilla";
-                Logger.info(text);
+                Logger.info(text, "Info");
             }
-            Logger.info("--------基本設定--------");
-            Logger.info(PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10));
-            Logger.info("---------その他---------");
-            Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人");
+            Logger.info("------------基本設定------------", "Info");
+            Logger.info(PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10), "Info");
+            Logger.info("-------------その他-------------", "Info");
+            Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人", "Info");
         }
     }
     class RepairSender

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -1,8 +1,8 @@
+using System.Linq;
 using System;
 using HarmonyLib;
 using UnityEngine;
 using UnhollowerBaseLib;
-using System.Collections.Generic;
 using static TownOfHost.Translator;
 
 namespace TownOfHost
@@ -256,30 +256,28 @@ namespace TownOfHost
             Logger.info("------------名前表示------------", "Info");
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
-                Logger.info($"{pc.PlayerId}:{pc.name}:{pc.nameText.text}");
+                Logger.info($"{pc.PlayerId}:{pc.name}\t:{pc.nameText.text}", "Info");
                 main.RealNames[pc.PlayerId] = pc.name;
                 pc.nameText.text = pc.name;
             }
             Logger.info("----------役職割り当て----------", "Info");
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
-                Logger.info($"{pc.name}({pc.PlayerId}):{pc.getRoleName()}", "Info");
+                Logger.info($"{pc.PlayerId}:{pc.Data.PlayerName}\t:{pc.getAllRoleName()}", "Info");
             }
             Logger.info("--------------環境--------------", "Info");
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
-                var text = pc.PlayerId == PlayerControl.LocalPlayer.PlayerId ? "[*]" : "";
-                text += $"{pc.PlayerId}:{pc.name}:{(pc.getClient().PlatformData.Platform).ToString().Replace("Standalone", "")}";
+                var text = pc.AmOwner ? "[*]" : "   ";
+                text += $"{pc.PlayerId}:{pc.Data.PlayerName}\t:{(pc.getClient().PlatformData.Platform).ToString().Replace("Standalone", "")}";
                 if (main.playerVersion.TryGetValue(pc.PlayerId, out PlayerVersion pv))
-                {
-                    text += $":Mod({pv.version}:";
-                    text += $"{pv.tag})";
-                }
-                else text += ":Vanilla";
+                    text += $"\t:Mod({pv.version}:{pv.tag})";
+                else text += "\t:Vanilla";
                 Logger.info(text, "Info");
             }
             Logger.info("------------基本設定------------", "Info");
-            Logger.info(PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10), "Info");
+            var tmp = PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10).Split("\r\n").Skip(1);
+            foreach (var t in tmp) Logger.info(t, "Info");
             Logger.info("-------------その他-------------", "Info");
             Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人", "Info");
         }

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -278,6 +278,10 @@ namespace TownOfHost
             Logger.info("------------基本設定------------", "Info");
             var tmp = PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10).Split("\r\n").Skip(1);
             foreach (var t in tmp) Logger.info(t, "Info");
+            Logger.info("------------詳細設定------------", "Info");
+            foreach (var o in CustomOption.Options)
+                if (!o.IsHidden(Options.CurrentGameMode) && (o.Parent == null ? !o.GetString().Equals("0%") : o.Parent.Enabled))
+                    Logger.info(String.Format("{0}{1,-36}:{2}", o.Parent == null ? "" : "┗ ", o.Name, o.GetString()), "Info");
             Logger.info("-------------その他-------------", "Info");
             Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人", "Info");
         }

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -135,7 +135,7 @@ namespace TownOfHost
                 Color LerpingColor = Color.Lerp(start, end, time);
                 if (__instance == null || milliseconds > 500)
                 {
-                    Logger.info("ループを終了します");
+                    Logger.info("ループを終了します", "StartFadeIntro");
                     break;
                 }
                 __instance.BackgroundBar.material.color = LerpingColor;

--- a/Patches/JoinGameButtonPatch.cs
+++ b/Patches/JoinGameButtonPatch.cs
@@ -14,7 +14,7 @@ namespace TownOfHost
             if (__instance.GameIdText == null) return;
             if (Regex.IsMatch(GUIUtility.systemCopyBuffer, @"[A-Z]{6}"))
             {
-                Logger.info($"{GUIUtility.systemCopyBuffer}");
+                Logger.info($"{GUIUtility.systemCopyBuffer}", "ClipBoard");
                 __instance.GameIdText.SetText(GUIUtility.systemCopyBuffer);
             }
         }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -36,7 +36,7 @@ namespace TownOfHost
                 {
                     PlayerVoteArea ps = __instance.playerStates[i];
                     if (ps == null) continue;
-                    Logger.info($"{ps.TargetPlayerId}:{ps.VotedFor}");
+                    Logger.info($"{ps.TargetPlayerId}:{ps.VotedFor}", "Vote");
                     var voter = Utils.getPlayerById(ps.TargetPlayerId);
                     if (voter == null || voter.Data == null || voter.Data.Disconnected) continue;
                     if (ps.VotedFor == 253 && !voter.Data.IsDead)//スキップ
@@ -98,27 +98,27 @@ namespace TownOfHost
                 var VotingData = __instance.CustomCalculateVotes();
                 byte exileId = byte.MaxValue;
                 int max = 0;
-                Logger.info("===追放者確認処理開始===");
+                Logger.info("===追放者確認処理開始===", "Vote");
                 foreach (var data in VotingData)
                 {
-                    Logger.info(data.Key + ": " + data.Value);
+                    Logger.info(data.Key + ": " + data.Value, "Vote");
                     if (data.Value > max)
                     {
-                        Logger.info(data.Key + "番が最高値を更新(" + data.Value + ")");
+                        Logger.info(data.Key + "番が最高値を更新(" + data.Value + ")", "Vote");
                         exileId = data.Key;
                         max = data.Value;
                         tie = false;
                     }
                     else if (data.Value == max)
                     {
-                        Logger.info(data.Key + "番が" + exileId + "番と同数(" + data.Value + ")");
+                        Logger.info(data.Key + "番が" + exileId + "番と同数(" + data.Value + ")", "Vote");
                         exileId = byte.MaxValue;
                         tie = true;
                     }
-                    Logger.info("exileId: " + exileId + ", max: " + max);
+                    Logger.info("exileId: " + exileId + ", max: " + max, "Vote");
                 }
 
-                Logger.info("追放者決定: " + exileId);
+                Logger.info("追放者決定: " + exileId, "Vote");
                 exiledPlayer = GameData.Instance.AllPlayers.ToArray().FirstOrDefault(info => !tie && info.PlayerId == exileId);
 
                 __instance.RpcVotingComplete(states, exiledPlayer, tie); //RPC
@@ -166,7 +166,7 @@ namespace TownOfHost
     {
         public static Dictionary<byte, int> CustomCalculateVotes(this MeetingHud __instance)
         {
-            Logger.info("CustomCalculateVotes開始");
+            Logger.info("CustomCalculateVotes開始", "Vote");
             Dictionary<byte, int> dic = new Dictionary<byte, int>();
             //| 投票された人 | 投票された回数 |
             for (int i = 0; i < __instance.playerStates.Length; i++)
@@ -190,7 +190,7 @@ namespace TownOfHost
     {
         public static void Prefix(MeetingHud __instance)
         {
-            Logger.info("会議が開始", "Phase");
+            Logger.info("------------会議開始------------", "Phase");
             main.witchMeeting = true;
             Utils.NotifyRoles(isMeeting: true);
             main.witchMeeting = false;
@@ -212,7 +212,7 @@ namespace TownOfHost
             {
                 if (AmongUsClient.Instance.AmHost) PlayerControl.LocalPlayer.RpcSetName("test");
                 Utils.SendMessage("緊急会議ボタンはあと" + (Options.SyncedButtonCount.GetFloat() - Options.UsedButtonCount) + "回使用可能です。");
-                Logger.SendToFile("緊急会議ボタンはあと" + (Options.SyncedButtonCount.GetFloat() - Options.UsedButtonCount) + "回使用可能です。", LogLevel.Message);
+                Logger.info("緊急会議ボタンはあと" + (Options.SyncedButtonCount.GetFloat() - Options.UsedButtonCount) + "回使用可能です。", "SyncButtonMode");
             }
 
             if (AmongUsClient.Instance.AmHost)
@@ -365,7 +365,7 @@ namespace TownOfHost
     {
         public static void Postfix(MeetingHud __instance)
         {
-            Logger.info("会議が終了", "Phase");
+            Logger.info("------------会議終了------------", "Phase");
             if (!AmongUsClient.Instance.AmHost) return;
 
             //エアシップの場合スポーン位置選択が発生するため死体消し用の会議を5秒遅らせる。

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -12,7 +12,7 @@ namespace TownOfHost
         {
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-            Logger.info("ゲームが終了", "Phase");
+            Logger.info("-----------ゲーム終了-----------", "Phase");
             //winnerListリセット
             TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
             main.additionalwinners = new HashSet<AdditionalWinners>();

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -16,7 +16,6 @@ namespace TownOfHost
             Logger.info($"{__instance.getNameWithRole()} => {target.getNameWithRole()}", "MurderPlayer");
             if (!target.Data.IsDead || !AmongUsClient.Instance.AmHost)
                 return;
-            Logger.info(__instance.name + " => " + target.name, "MurderPlayer");
             if (PlayerState.getDeathReason(target.PlayerId) == PlayerState.DeathReason.etc)
             {
                 //死因が設定されていない場合は死亡判定
@@ -25,7 +24,7 @@ namespace TownOfHost
             //When Bait is killed
             if (target.getCustomRole() == CustomRoles.Bait && __instance.PlayerId != target.PlayerId)
             {
-                Logger.info(target.name + "はBaitだった", "MurderPlayer");
+                Logger.info(target.Data.PlayerName + "はBaitだった", "MurderPlayer");
                 new LateTask(() => __instance.CmdReportDeadBody(target.Data), 0.15f, "Bait Self Report");
             }
             else
@@ -38,12 +37,12 @@ namespace TownOfHost
                     Utils.CustomSyncAllSettings();//キルクール処理を同期
                     main.isTargetKilled.Remove(__instance.PlayerId);
                     main.isTargetKilled.Add(__instance.PlayerId, true);
-                    Logger.info($"{__instance.getRealName()}:ターゲットをキル", "BountyHunter");
+                    Logger.info($"{__instance.Data.PlayerName}:ターゲットをキル", "BountyHunter");
                 }
                 else
                 {
                     main.AllPlayerKillCooldown[__instance.PlayerId] = Options.BountyFailureKillCooldown.GetFloat();
-                    Logger.info($"{__instance.getRealName()}:ターゲット以外をキル", "BountyHunter");
+                    Logger.info($"{__instance.Data.PlayerName}:ターゲット以外をキル", "BountyHunter");
                     Utils.CustomSyncAllSettings();//キルクール処理を同期
                 }
             }
@@ -55,7 +54,7 @@ namespace TownOfHost
             //Terrorist
             if (target.Is(CustomRoles.Terrorist))
             {
-                Logger.info(target.name + "はTerroristだった", "MurderPlayer");
+                Logger.info(target.Data.PlayerName + "はTerroristだった", "MurderPlayer");
                 Utils.CheckTerroristWin(target.Data);
             }
             if (target.Is(CustomRoles.Trapper) && !__instance.Is(CustomRoles.Trapper))
@@ -106,7 +105,7 @@ namespace TownOfHost
                             {
                                 dis = Vector2.Distance(cppos, p.transform.position);
                                 cpdistance.Add(p, dis);
-                                Logger.info($"{p.name}の位置{dis}", "Warlock");
+                                Logger.info($"{p.Data.PlayerName}の位置{dis}", "Warlock");
                             }
                         }
                         var min = cpdistance.OrderBy(c => c.Value).FirstOrDefault();//一番小さい値を取り出す
@@ -222,13 +221,13 @@ namespace TownOfHost
             {
                 if (!__instance.CanUseKillButton())
                 {
-                    Logger.info(__instance.name + "はMafiaだったので、キルはキャンセルされました。", "CheckMurder");
+                    Logger.info(__instance.Data.PlayerName + "はMafiaだったので、キルはキャンセルされました。", "CheckMurder");
                     main.BlockKilling[__instance.PlayerId] = false;
                     return false;
                 }
                 else
                 {
-                    Logger.info(__instance.name + "はMafiaですが、他のインポスターがいないのでキルが許可されました。", "CheckMurder");
+                    Logger.info(__instance.Data.PlayerName + "はMafiaですが、他のインポスターがいないのでキルが許可されました。", "CheckMurder");
                 }
             }
             if (__instance.Is(CustomRoles.SerialKiller) && !target.Is(CustomRoles.SchrodingerCat))
@@ -421,10 +420,10 @@ namespace TownOfHost
                     PlayerState.setDeathReason(bitten.PlayerId, PlayerState.DeathReason.Bite);
                     bitten.RpcMurderPlayer(bitten);
                     RPC.PlaySoundRPC(vampireID, Sounds.KillSound);
-                    Logger.info("Vampireに噛まれている" + bitten.name + "を自爆させました。", "ReportDeadBody");
+                    Logger.info("Vampireに噛まれている" + bitten.Data.PlayerName + "を自爆させました。", "ReportDeadBody");
                 }
                 else
-                    Logger.SendToFile("Vampireに噛まれている" + bitten.name + "はすでに死んでいました。");
+                    Logger.SendToFile("Vampireに噛まれている" + bitten.Data.PlayerName + "はすでに死んでいました。");
             }
             main.BitPlayers = new Dictionary<byte, (byte, float)>();
 
@@ -482,13 +481,13 @@ namespace TownOfHost
                                 PlayerState.setDeathReason(bitten.PlayerId, PlayerState.DeathReason.Bite);
                                 __instance.RpcMurderPlayer(bitten);
                                 RPC.PlaySoundRPC(vampireID, Sounds.KillSound);
-                                Logger.info("Vampireに噛まれている" + bitten.name + "を自爆させました。", "Vampire");
+                                Logger.info("Vampireに噛まれている" + bitten.Data.PlayerName + "を自爆させました。", "Vampire");
                                 if (bitten.Is(CustomRoles.Trapper))
                                     Utils.getPlayerById(vampireID).TrapperKilled(bitten);
                             }
                             else
                             {
-                                Logger.info("Vampireに噛まれている" + bitten.name + "はすでに死んでいました。", "Vampire");
+                                Logger.info("Vampireに噛まれている" + bitten.Data.PlayerName + "はすでに死んでいました。", "Vampire");
                             }
                             main.BitPlayers.Remove(bitten.PlayerId);
                         }
@@ -685,7 +684,7 @@ namespace TownOfHost
                     if (!AmongUsClient.Instance.IsGameStarted && AmongUsClient.Instance.GameMode != GameModes.FreePlay)
                     {
                         RoleText.enabled = false; //ゲームが始まっておらずフリープレイでなければロールを非表示
-                        if (!__instance.AmOwner) __instance.nameText.text = __instance.name;
+                        if (!__instance.AmOwner) __instance.nameText.text = __instance.Data.PlayerName;
                     }
                     if (main.VisibleTasksCount && Utils.hasTasks(__instance.Data, false)) //他プレイヤーでVisibleTasksCountは有効なおかつタスクがあるなら
                         RoleText.text += $" {Utils.getTaskText(__instance)}"; //ロールの横にタスク表示
@@ -702,7 +701,7 @@ namespace TownOfHost
                     string Suffix = "";
 
                     //名前変更
-                    RealName = target.getRealName();
+                    RealName = target.Data.PlayerName;
 
 
                     //名前色変更処理

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -13,6 +13,7 @@ namespace TownOfHost
     {
         public static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
         {
+            Logger.info($"{__instance.getNameWithRole()} => {target.getNameWithRole()}", "MurderPlayer");
             if (!target.Data.IsDead || !AmongUsClient.Instance.AmHost)
                 return;
             Logger.info(__instance.name + " => " + target.name, "MurderPlayer");

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -111,7 +111,7 @@ namespace TownOfHost
                         }
                         var min = cpdistance.OrderBy(c => c.Value).FirstOrDefault();//一番小さい値を取り出す
                         PlayerControl targetw = min.Key;
-                        Logger.info($"{targetw.name}was killed", "Warlock");
+                        Logger.info($"{targetw.getNameWithRole()}was killed", "Warlock");
                         cp.RpcMurderPlayer(targetw);//殺す
                         __instance.RpcGuardAndKill(__instance);
                         main.isCurseAndKill[__instance.PlayerId] = false;
@@ -156,7 +156,7 @@ namespace TownOfHost
         public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
         {
             if (!AmongUsClient.Instance.AmHost) return false;
-            Logger.info("CheckProtect発生: " + __instance.name + "=>" + target.name, "CheckProtect");
+            Logger.info("CheckProtect発生: " + __instance.getNameWithRole() + "=>" + target.getNameWithRole(), "CheckProtect");
             if (__instance.Is(CustomRoles.Sheriff))
             {
                 if (__instance.Data.IsDead)
@@ -180,7 +180,7 @@ namespace TownOfHost
                 Utils.CustomSyncAllSettings();
             }
             main.LastKiller[target] = __instance;
-            Logger.info($"{__instance.name} => {target.name}", "CheckMurder");
+            Logger.info($"{__instance.getNameWithRole()} => {target.getNameWithRole()}", "CheckMurder");
             if (__instance.PlayerId == target.PlayerId)
             {
                 //自殺ならノーチェック
@@ -257,7 +257,7 @@ namespace TownOfHost
 
                 if (main.SheriffShotLimit[__instance.PlayerId] == 0)
                 {
-                    //Logger.info($"シェリフ:{__instance.getRealName()}はキル可能回数に達したため、RoleTypeを守護天使に変更しました。");
+                    //Logger.info($"シェリフ:{__instance.name}はキル可能回数に達したため、RoleTypeを守護天使に変更しました。");
                     //__instance.RpcSetRoleDesync(RoleTypes.GuardianAngel);
                     //Utils.hasTasks(__instance.Data, false);
                     //Utils.NotifyRoles();
@@ -265,7 +265,7 @@ namespace TownOfHost
                 }
 
                 main.SheriffShotLimit[__instance.PlayerId]--;
-                Logger.info($"{__instance.getRealName()} : 残り{main.SheriffShotLimit[__instance.PlayerId]}発", "Sheriff");
+                Logger.info($"{__instance.getNameWithRole()} : 残り{main.SheriffShotLimit[__instance.PlayerId]}発", "Sheriff");
                 __instance.RpcSetSheriffShotLimit();
 
                 if (!target.canBeKilledBySheriff())
@@ -387,7 +387,7 @@ namespace TownOfHost
             main.SerialKillerTimer.Clear();
             if (target != null)
             {
-                Logger.info($"{__instance.name} => {target.PlayerName}", "ReportDeadBody");
+                Logger.info($"{__instance.getNameWithRole()} => {target.getNameWithRole()}", "ReportDeadBody");
                 if (main.IgnoreReportPlayers.Contains(target.PlayerId) && !CheckForEndVotingPatch.recall)
                 {
                     Logger.info($"{target.PlayerName}は通報が禁止された死体なのでキャンセルされました", "ReportDeadBody");
@@ -541,7 +541,7 @@ namespace TownOfHost
                     {
                         main.BountyTimer[__instance.PlayerId] = 0f;
                         main.AllPlayerKillCooldown[__instance.PlayerId] = 10;
-                        Logger.info($"{__instance.getRealName()}:ターゲットリセット", "BountyHunter");
+                        Logger.info($"{__instance.getNameWithRole()}:ターゲットリセット", "BountyHunter");
                         Utils.CustomSyncAllSettings();//ここでの処理をキルクールの変更の処理と同期
                         __instance.RpcGuardAndKill(__instance);//タイマー（変身クールダウン）のリセットと、名前の変更のためのKill
                         __instance.ResetBountyTarget();//ターゲットの選びなおし
@@ -584,7 +584,7 @@ namespace TownOfHost
                         main.ArsonistTimer.Remove(__instance.PlayerId);//塗が完了したのでDictionaryから削除
                         main.isDoused[(__instance.PlayerId, ar_target.PlayerId)] = true;//塗り完了
                         main.DousedPlayerCount[__instance.PlayerId] = ((ArsonistDic.Item1 + 1), ArsonistDic.Item2);//塗った人数を増やす
-                        Logger.info($"{__instance.getRealName()} : {main.DousedPlayerCount[__instance.PlayerId]}", "Arsonist");
+                        Logger.info($"{__instance.getNameWithRole()} : {main.DousedPlayerCount[__instance.PlayerId]}", "Arsonist");
                         __instance.RpcSendDousedPlayerCount();
                         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetDousedPlayer, SendOption.Reliable, -1);//RPCによる同期
                         writer.Write(__instance.PlayerId);
@@ -618,7 +618,7 @@ namespace TownOfHost
                             {
                                 main.isDeadDoused[target.PlayerId] = true;
                                 var ArsonistDic = main.DousedPlayerCount[__instance.PlayerId];
-                                Logger.info($"{__instance.getRealName()} : {ArsonistDic}", "Arsonist");
+                                Logger.info($"{__instance.getNameWithRole()} : {ArsonistDic}", "Arsonist");
                                 main.DousedPlayerCount[__instance.PlayerId] = (ArsonistDic.Item1, ArsonistDic.Item2 - 1);
                                 __instance.RpcSendDousedPlayerCount();
                             }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -15,7 +15,7 @@ namespace TownOfHost
         {
             if (!target.Data.IsDead || !AmongUsClient.Instance.AmHost)
                 return;
-            Logger.SendToFile("MurderPlayer発生: " + __instance.name + "=>" + target.name);
+            Logger.info(__instance.name + " => " + target.name, "MurderPlayer");
             if (PlayerState.getDeathReason(target.PlayerId) == PlayerState.DeathReason.etc)
             {
                 //死因が設定されていない場合は死亡判定
@@ -24,7 +24,7 @@ namespace TownOfHost
             //When Bait is killed
             if (target.getCustomRole() == CustomRoles.Bait && __instance.PlayerId != target.PlayerId)
             {
-                Logger.SendToFile(target.name + "はBaitだった");
+                Logger.info(target.name + "はBaitだった", "MurderPlayer");
                 new LateTask(() => __instance.CmdReportDeadBody(target.Data), 0.15f, "Bait Self Report");
             }
             else
@@ -37,12 +37,12 @@ namespace TownOfHost
                     Utils.CustomSyncAllSettings();//キルクール処理を同期
                     main.isTargetKilled.Remove(__instance.PlayerId);
                     main.isTargetKilled.Add(__instance.PlayerId, true);
-                    Logger.info($"{__instance.getRealName()}:ターゲットをキル");
+                    Logger.info($"{__instance.getRealName()}:ターゲットをキル", "BountyHunter");
                 }
                 else
                 {
                     main.AllPlayerKillCooldown[__instance.PlayerId] = Options.BountyFailureKillCooldown.GetFloat();
-                    Logger.info($"{__instance.getRealName()}:ターゲット以外をキル");
+                    Logger.info($"{__instance.getRealName()}:ターゲット以外をキル", "BountyHunter");
                     Utils.CustomSyncAllSettings();//キルクール処理を同期
                 }
             }
@@ -54,7 +54,7 @@ namespace TownOfHost
             //Terrorist
             if (target.Is(CustomRoles.Terrorist))
             {
-                Logger.SendToFile(target.name + "はTerroristだった");
+                Logger.info(target.name + "はTerroristだった", "MurderPlayer");
                 Utils.CheckTerroristWin(target.Data);
             }
             if (target.Is(CustomRoles.Trapper) && !__instance.Is(CustomRoles.Trapper))
@@ -105,12 +105,12 @@ namespace TownOfHost
                             {
                                 dis = Vector2.Distance(cppos, p.transform.position);
                                 cpdistance.Add(p, dis);
-                                Logger.info($"{p.name}の位置{dis}");
+                                Logger.info($"{p.name}の位置{dis}", "Warlock");
                             }
                         }
                         var min = cpdistance.OrderBy(c => c.Value).FirstOrDefault();//一番小さい値を取り出す
                         PlayerControl targetw = min.Key;
-                        Logger.info($"{targetw.name}was killed");
+                        Logger.info($"{targetw.name}was killed", "Warlock");
                         cp.RpcMurderPlayer(targetw);//殺す
                         __instance.RpcGuardAndKill(__instance);
                         main.isCurseAndKill[__instance.PlayerId] = false;
@@ -155,12 +155,12 @@ namespace TownOfHost
         public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
         {
             if (!AmongUsClient.Instance.AmHost) return false;
-            Logger.SendToFile("CheckProtect発生: " + __instance.name + "=>" + target.name);
+            Logger.info("CheckProtect発生: " + __instance.name + "=>" + target.name, "CheckProtect");
             if (__instance.Is(CustomRoles.Sheriff))
             {
                 if (__instance.Data.IsDead)
                 {
-                    Logger.info("守護をブロックしました。");
+                    Logger.info("守護をブロックしました。", "CheckProtect");
                     return false;
                 }
             }
@@ -179,7 +179,7 @@ namespace TownOfHost
                 Utils.CustomSyncAllSettings();
             }
             main.LastKiller[target] = __instance;
-            Logger.SendToFile("CheckMurder発生: " + __instance.name + "=>" + target.name);
+            Logger.info($"{__instance.name} => {target.name}", "CheckMurder");
             if (__instance.PlayerId == target.PlayerId)
             {
                 //自殺ならノーチェック
@@ -188,14 +188,14 @@ namespace TownOfHost
             }
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek && Options.HideAndSeekKillDelayTimer > 0)
             {
-                Logger.info("HideAndSeekの待機時間中だったため、キルをキャンセルしました。");
+                Logger.info("HideAndSeekの待機時間中だったため、キルをキャンセルしました。", "CheckMurder");
                 return false;
             }
             if (__instance.Is(CustomRoles.SKMadmate)) return false;//シェリフがサイドキックされた場合
 
             if (main.BlockKilling.TryGetValue(__instance.PlayerId, out bool isBlocked) && isBlocked)
             {
-                Logger.info("キルをブロックしました。");
+                Logger.info("キルをブロックしました。", "CheckMurder");
                 return false;
             }
 
@@ -221,13 +221,13 @@ namespace TownOfHost
             {
                 if (!__instance.CanUseKillButton())
                 {
-                    Logger.SendToFile(__instance.name + "はMafiaだったので、キルはキャンセルされました。");
+                    Logger.info(__instance.name + "はMafiaだったので、キルはキャンセルされました。", "CheckMurder");
                     main.BlockKilling[__instance.PlayerId] = false;
                     return false;
                 }
                 else
                 {
-                    Logger.SendToFile(__instance.name + "はMafiaですが、他のインポスターがいないのでキルが許可されました。");
+                    Logger.info(__instance.name + "はMafiaですが、他のインポスターがいないのでキルが許可されました。", "CheckMurder");
                 }
             }
             if (__instance.Is(CustomRoles.SerialKiller) && !target.Is(CustomRoles.SchrodingerCat))
@@ -264,7 +264,7 @@ namespace TownOfHost
                 }
 
                 main.SheriffShotLimit[__instance.PlayerId]--;
-                Logger.info($"{__instance.getRealName()} : 残り{main.SheriffShotLimit[__instance.PlayerId]}発");
+                Logger.info($"{__instance.getRealName()} : 残り{main.SheriffShotLimit[__instance.PlayerId]}発", "Sheriff");
                 __instance.RpcSetSheriffShotLimit();
 
                 if (!target.canBeKilledBySheriff())
@@ -386,26 +386,26 @@ namespace TownOfHost
             main.SerialKillerTimer.Clear();
             if (target != null)
             {
-                Logger.info($"{__instance.name} => {target.PlayerName}");
+                Logger.info($"{__instance.name} => {target.PlayerName}", "ReportDeadBody");
                 if (main.IgnoreReportPlayers.Contains(target.PlayerId) && !CheckForEndVotingPatch.recall)
                 {
-                    Logger.info($"{target.PlayerName}は通報が禁止された死体なのでキャンセルされました");
+                    Logger.info($"{target.PlayerName}は通報が禁止された死体なのでキャンセルされました", "ReportDeadBody");
                     return false;
                 }
             }
 
             if (Options.SyncButtonMode.GetBool() && target == null)
             {
-                Logger.SendToFile("最大:" + Options.SyncedButtonCount + ", 現在:" + Options.UsedButtonCount, LogLevel.Message);
+                Logger.info("最大:" + Options.SyncedButtonCount + ", 現在:" + Options.UsedButtonCount, "ReportDeadBody");
                 if (Options.SyncedButtonCount.GetFloat() <= Options.UsedButtonCount)
                 {
-                    Logger.SendToFile("使用可能ボタン回数が最大数を超えているため、ボタンはキャンセルされました。", LogLevel.Message);
+                    Logger.info("使用可能ボタン回数が最大数を超えているため、ボタンはキャンセルされました。", "ReportDeadBody");
                     return false;
                 }
                 else Options.UsedButtonCount++;
                 if (Options.SyncedButtonCount.GetFloat() == Options.UsedButtonCount)
                 {
-                    Logger.SendToFile("使用可能ボタン回数が最大数に達しました。");
+                    Logger.info("使用可能ボタン回数が最大数に達しました。", "ReportDeadBody");
                 }
             }
 
@@ -420,7 +420,7 @@ namespace TownOfHost
                     PlayerState.setDeathReason(bitten.PlayerId, PlayerState.DeathReason.Bite);
                     bitten.RpcMurderPlayer(bitten);
                     RPC.PlaySoundRPC(vampireID, Sounds.KillSound);
-                    Logger.SendToFile("Vampireに噛まれている" + bitten.name + "を自爆させました。");
+                    Logger.info("Vampireに噛まれている" + bitten.name + "を自爆させました。", "ReportDeadBody");
                 }
                 else
                     Logger.SendToFile("Vampireに噛まれている" + bitten.name + "はすでに死んでいました。");
@@ -481,13 +481,13 @@ namespace TownOfHost
                                 PlayerState.setDeathReason(bitten.PlayerId, PlayerState.DeathReason.Bite);
                                 __instance.RpcMurderPlayer(bitten);
                                 RPC.PlaySoundRPC(vampireID, Sounds.KillSound);
-                                Logger.SendToFile("Vampireに噛まれている" + bitten.name + "を自爆させました。");
+                                Logger.info("Vampireに噛まれている" + bitten.name + "を自爆させました。", "Vampire");
                                 if (bitten.Is(CustomRoles.Trapper))
                                     Utils.getPlayerById(vampireID).TrapperKilled(bitten);
                             }
                             else
                             {
-                                Logger.SendToFile("Vampireに噛まれている" + bitten.name + "はすでに死んでいました。");
+                                Logger.info("Vampireに噛まれている" + bitten.name + "はすでに死んでいました。", "Vampire");
                             }
                             main.BitPlayers.Remove(bitten.PlayerId);
                         }
@@ -540,7 +540,7 @@ namespace TownOfHost
                     {
                         main.BountyTimer[__instance.PlayerId] = 0f;
                         main.AllPlayerKillCooldown[__instance.PlayerId] = 10;
-                        Logger.info($"{__instance.getRealName()}:ターゲットリセット");
+                        Logger.info($"{__instance.getRealName()}:ターゲットリセット", "BountyHunter");
                         Utils.CustomSyncAllSettings();//ここでの処理をキルクールの変更の処理と同期
                         __instance.RpcGuardAndKill(__instance);//タイマー（変身クールダウン）のリセットと、名前の変更のためのKill
                         __instance.ResetBountyTarget();//ターゲットの選びなおし

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -9,7 +9,7 @@ namespace TownOfHost
     {
         public static void Postfix(AmongUsClient __instance)
         {
-            Logger.info("RealNamesをリセット");
+            Logger.info("RealNamesをリセット", "OnGameJoined");
             main.RealNames = new Dictionary<byte, string>();
             main.playerVersion = new Dictionary<byte, PlayerVersion>();
             RPC.RpcVersionCheck();
@@ -36,7 +36,7 @@ namespace TownOfHost
             //            main.RealNames.Remove(data.Character.PlayerId);
             PlayerState.setDeathReason(data.Character.PlayerId, PlayerState.DeathReason.Disconnected);
             PlayerState.setDead(data.Character.PlayerId);
-            Logger.info("切断理由:" + reason.ToString());
+            Logger.info("切断理由:" + reason.ToString(), "Session");
         }
     }
 }

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -10,6 +10,7 @@ namespace TownOfHost
         public static void Postfix(AmongUsClient __instance)
         {
             Logger.info("RealNamesをリセット", "OnGameJoined");
+            Logger.info($"{__instance.GameId}に参加", "OnGameJoined");
             main.RealNames = new Dictionary<byte, string>();
             main.playerVersion = new Dictionary<byte, PlayerVersion>();
             RPC.RpcVersionCheck();
@@ -21,8 +22,10 @@ namespace TownOfHost
     [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerJoined))]
     class OnPlayerJoinedPatch
     {
-        public static void Postfix(AmongUsClient __instance)
+        public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ClientData client)
         {
+
+            Logger.info($"{client.PlayerName}(ClientID:{client.Id})が参加", "Session");
             main.playerVersion = new Dictionary<byte, PlayerVersion>();
             RPC.RpcVersionCheck();
         }
@@ -36,7 +39,7 @@ namespace TownOfHost
             //            main.RealNames.Remove(data.Character.PlayerId);
             PlayerState.setDeathReason(data.Character.PlayerId, PlayerState.DeathReason.Disconnected);
             PlayerState.setDead(data.Character.PlayerId);
-            Logger.info("切断理由:" + reason.ToString(), "Session");
+            Logger.info($"{data.PlayerName}(ClientID:{data.Id})が切断(理由:{reason})", "Session");
         }
     }
 }

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -49,7 +49,7 @@ namespace TownOfHost
                     if (target.Data.IsDead || target.Data.Disconnected)
                     {
                         pc.ResetBountyTarget();
-                        Logger.info($"{pc.name}のターゲットが無効だったため、ターゲットを更新しました", "BountyHunter");
+                        Logger.info($"{pc.getNameWithRole()}のターゲットが無効だったため、ターゲットを更新しました", "BountyHunter");
                         DoNotifyRoles = true;
                     }
                 }
@@ -65,10 +65,10 @@ namespace TownOfHost
             [HarmonyArgument(1)] PlayerControl player,
             [HarmonyArgument(2)] byte amount)
         {
-            Logger.msg("SystemType: " + systemType.ToString() + ", PlayerName: " + player.name + ", amount: " + amount, "RepairSystem");
+            Logger.msg("SystemType: " + systemType.ToString() + ", PlayerName: " + player.getNameWithRole() + ", amount: " + amount, "RepairSystem");
             if (RepairSender.enabled && AmongUsClient.Instance.GameMode != GameModes.OnlineGame)
             {
-                Logger.SendInGame("SystemType: " + systemType.ToString() + ", PlayerName: " + player.name + ", amount: " + amount);
+                Logger.SendInGame("SystemType: " + systemType.ToString() + ", PlayerName: " + player.getNameWithRole() + ", amount: " + amount);
             }
             if (!AmongUsClient.Instance.AmHost) return true;
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek && systemType == SystemTypes.Sabotage) return false;

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -22,7 +22,7 @@ namespace TownOfHost
             {
                 Utils.CustomSyncAllSettings();
                 main.RefixCooldownDelay = float.NaN;
-                Logger.info("Refix Cooldown");
+                Logger.info("Refix Cooldown", "CoolDown");
             }
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek && main.introDestroyed)
             {
@@ -34,7 +34,7 @@ namespace TownOfHost
                 {
                     Utils.CustomSyncAllSettings();
                     Options.HideAndSeekKillDelayTimer = float.NaN;
-                    Logger.info("キル能力解禁");
+                    Logger.info("キル能力解禁", "HideAndSeek");
                 }
             }
             //BountyHunterのターゲットが無効な場合にリセット
@@ -49,7 +49,7 @@ namespace TownOfHost
                     if (target.Data.IsDead || target.Data.Disconnected)
                     {
                         pc.ResetBountyTarget();
-                        Logger.info($"{pc.name}のターゲットが無効だったため、ターゲットを更新しました");
+                        Logger.info($"{pc.name}のターゲットが無効だったため、ターゲットを更新しました", "BountyHunter");
                         DoNotifyRoles = true;
                     }
                 }
@@ -65,7 +65,7 @@ namespace TownOfHost
             [HarmonyArgument(1)] PlayerControl player,
             [HarmonyArgument(2)] byte amount)
         {
-            Logger.msg("SystemType: " + systemType.ToString() + ", PlayerName: " + player.name + ", amount: " + amount);
+            Logger.msg("SystemType: " + systemType.ToString() + ", PlayerName: " + player.name + ", amount: " + amount, "RepairSystem");
             if (RepairSender.enabled && AmongUsClient.Instance.GameMode != GameModes.OnlineGame)
             {
                 Logger.SendInGame("SystemType: " + systemType.ToString() + ", PlayerName: " + player.name + ", amount: " + amount);
@@ -230,8 +230,8 @@ namespace TownOfHost
     {
         public static void Postfix()
         {
-            Logger.info("ShipStatus.Start");
-            Logger.info("ゲームが開始", "Phase");
+            Logger.currentMethod();
+            Logger.info("-----------ゲーム開始-----------", "Phase");
 
             if (AmongUsClient.Instance.AmClient)
             {
@@ -250,7 +250,7 @@ namespace TownOfHost
     {
         public static void Postfix()
         {
-            Logger.info("ShipStatus.Begin");
+            Logger.currentMethod();
 
             //ホストの役職初期設定はここで行うべき？
             foreach (var pc in PlayerControl.AllPlayerControls)

--- a/Patches/TaskAdderPatch.cs
+++ b/Patches/TaskAdderPatch.cs
@@ -26,7 +26,7 @@ namespace TownOfHost
         }
         public static void Postfix(TaskAdderGame __instance, [HarmonyArgument(0)] TaskFolder taskFolder)
         {
-            Logger.info("Opened " + taskFolder.FolderName);
+            Logger.info("Opened " + taskFolder.FolderName, "TaskFolder");
             float xCursor = 0f;
             float yCursor = 0f;
             float maxHeight = 0f;

--- a/Patches/TaskAssignPatch.cs
+++ b/Patches/TaskAssignPatch.cs
@@ -23,7 +23,7 @@ namespace TownOfHost
             }
             foreach (var task in disabledTasks)
             {
-                Logger.msg("削除: " + task.TaskType.ToString());
+                Logger.msg("削除: " + task.TaskType.ToString(), "AddTask");
                 unusedTasks.Remove(task);
             }
         }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -337,7 +337,7 @@ namespace TownOfHost
                     {
                         main.SheriffShotLimit[pc.PlayerId] = Options.SheriffShotLimit.GetFloat();
                         pc.RpcSetSheriffShotLimit();
-                        Logger.info($"{pc.getRealName()} : 残り{main.SheriffShotLimit[pc.PlayerId]}発");
+                        Logger.info($"{pc.getNameWithRole()} : 残り{main.SheriffShotLimit[pc.PlayerId]}発");
                     }
                     if (pc.Is(CustomRoles.BountyHunter))
                     {
@@ -388,7 +388,7 @@ namespace TownOfHost
                         var Target = targetList[rand.Next(targetList.Count)];
                         main.ExecutionerTarget.Add(pc.PlayerId, Target.PlayerId);
                         RPC.SendExecutionerTarget(pc.PlayerId, Target.PlayerId);
-                        Logger.info($"{pc.name}:{Target.name}", "Executioner");
+                        Logger.info($"{pc.getNameWithRole()}:{Target.getNameWithRole()}", "Executioner");
                     }
                 }
 

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -69,7 +69,6 @@ namespace TownOfHost
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
                 main.AllPlayerSpeed[pc.PlayerId] = main.RealOptionsData.PlayerSpeedMod; //移動速度をデフォルトの移動速度に変更
-                Logger.info($"{pc.PlayerId}:{pc.name}:{pc.nameText.text}");
                 main.RealNames[pc.PlayerId] = pc.name;
                 pc.nameText.text = pc.name;
             }
@@ -442,7 +441,7 @@ namespace TownOfHost
                 AssignedPlayers.Add(player);
                 players.Remove(player);
                 main.AllPlayerCustomRoles[player.PlayerId] = role;
-                Logger.info("役職設定:" + player.name + " = " + role.ToString());
+                Logger.info("役職設定:" + player.name + " = " + role.ToString(), "AssignRoles");
 
                 if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
                 {
@@ -483,7 +482,7 @@ namespace TownOfHost
                 main.LoversPlayers.Add(player);
                 allPlayers.Remove(player);
                 main.AllPlayerCustomSubRoles[player.PlayerId] = loversRole;
-                Logger.info("役職設定:" + player.name + " = " + player.getCustomRole().ToString() + " + " + loversRole.ToString());
+                Logger.info("役職設定:" + player.name + " = " + player.getCustomRole().ToString() + " + " + loversRole.ToString(), "AssignLovers");
             }
             RPC.SyncLoversPlayers();
         }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -231,7 +231,7 @@ namespace TownOfHost
                         main.AllPlayerCustomRoles.Add(pc.PlayerId, CustomRoles.Shapeshifter);
                         break;
                     default:
-                        Logger.SendInGame("エラー:役職設定中に無効な役職のプレイヤーを発見しました(" + pc.name + ")");
+                        Logger.SendInGame("エラー:役職設定中に無効な役職のプレイヤーを発見しました(" + pc.Data.PlayerName + ")");
                         break;
                 }
             }
@@ -441,7 +441,7 @@ namespace TownOfHost
                 AssignedPlayers.Add(player);
                 players.Remove(player);
                 main.AllPlayerCustomRoles[player.PlayerId] = role;
-                Logger.info("役職設定:" + player.name + " = " + role.ToString(), "AssignRoles");
+                Logger.info("役職設定:" + player.Data.PlayerName + " = " + role.ToString(), "AssignRoles");
 
                 if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
                 {
@@ -482,7 +482,7 @@ namespace TownOfHost
                 main.LoversPlayers.Add(player);
                 allPlayers.Remove(player);
                 main.AllPlayerCustomSubRoles[player.PlayerId] = loversRole;
-                Logger.info("役職設定:" + player.name + " = " + player.getCustomRole().ToString() + " + " + loversRole.ToString(), "AssignLovers");
+                Logger.info("役職設定:" + player.Data.PlayerName + " = " + player.getCustomRole().ToString() + " + " + loversRole.ToString(), "AssignLovers");
             }
             RPC.SyncLoversPlayers();
         }

--- a/Roles/Sniper.cs
+++ b/Roles/Sniper.cs
@@ -129,7 +129,7 @@ namespace TownOfHost
                     var target_dir = target_pos.normalized;
                     //内積を取る
                     var target_dot = Vector3.Dot(dir, target_dir);
-                    Logger.info($"{target.name}:pos={target_pos} dir={target_dir}", "Sniper");
+                    Logger.info($"{target.Data.PlayerName}:pos={target_pos} dir={target_dir}", "Sniper");
                     Logger.info($"  Dot={target_dot}", "Sniper");
                     if (precisionshooting)
                     {
@@ -167,7 +167,7 @@ namespace TownOfHost
                     }
                     if (snipedTarget.Is(CustomRoles.Bait))
                     {
-                        Logger.SendToFile(snipedTarget.name + "はBaitだった");
+                        Logger.info(snipedTarget.Data.PlayerName + "はBaitだった", "Sniper");
                         new LateTask(() => pc.CmdReportDeadBody(snipedTarget.Data), 0.15f, "Bait Self Report");
                     }
                     else


### PR DESCRIPTION
- タグの追加
- メソッドの追加
  - 現在のメソッドを出力
  - サブ役職の取得
  - サブとメインの役職を取得
  - 名前と役職を取得
 - ログの追加
   - 詳細設定
   - 接続・切断
   - ミーティング開始
- 変更
  - ログの名前を本来の名前で出力するように
  - 一部ログに名前と役職を併記するように
  - MurderPlayerのログをクライアントでも表示するように
  - 不要なEnumを削除