### PR TITLE
Fix/more task options settings shower

### DIFF
--- a/Modules/CustomOption.cs
+++ b/Modules/CustomOption.cs
@@ -239,8 +239,9 @@ namespace TownOfHost
             return Translator.getString(sel);
         }
 
-        public string GetName()
+        public string GetName(bool disableColor = false)
         {
+            if (disableColor) return Translator.getString(Name, ReplacementDictionary);
             return Helpers.ColorString(Color, Translator.getString(Name, ReplacementDictionary));
         }
 

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -475,7 +475,7 @@ namespace TownOfHost
             {
                 this.idStart = idStart;
                 this.role = role;
-                Dictionary<string, string> replacementDic = new() { { "%role%", Helpers.ColorString(Utils.getRoleColor(role), Utils.getRoleName(role)) } };
+                Dictionary<string, string> replacementDic = new() { { "%role%", Utils.getRoleName(role) } };
                 doOverride = CustomOption.Create(idStart++, Color.white, "doOverride", false, CustomRoleSpawnChances[role], false, false, "", replacementDic);
                 assignCommonTasks = CustomOption.Create(idStart++, Color.white, "assignCommonTasks", true, doOverride, false, false, "", replacementDic);
                 numLongTasks = CustomOption.Create(idStart++, Color.white, "roleLongTasksNum", 3, 0, 99, 1, doOverride, false, false, "", replacementDic);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -275,6 +275,15 @@ namespace TownOfHost
                     {
                         if (isFirst) { isFirst = false; continue; }
                         text += $"\n{c.GetName(disableColor: true)}:{c.GetString()}";
+
+                        //タスク上書き設定用の処理
+                        if (c.Name == "doOverride" && c.GetBool() == true)
+                        {
+                            foreach (var d in c.Children)
+                            {
+                                text += $"\n{d.GetName(disableColor: true)}:{d.GetString()}";
+                            }
+                        }
                     }
                 }
                 if (Options.EnableLastImpostor.GetBool()) text += String.Format("\n{0}:{1}", getString("LastImpostorKillCooldown"), Options.LastImpostorKillCooldown.GetString());

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -274,7 +274,7 @@ namespace TownOfHost
                     foreach (var c in Options.CustomRoleSpawnChances[role.Key].Children)
                     {
                         if (isFirst) { isFirst = false; continue; }
-                        text += $"\n{getString(c.Name)}:{c.GetString()}";
+                        text += $"\n{c.GetName(disableColor: true)}:{c.GetString()}";
                     }
                 }
                 if (Options.EnableLastImpostor.GetBool()) text += String.Format("\n{0}:{1}", getString("LastImpostorKillCooldown"), Options.LastImpostorKillCooldown.GetString());


### PR DESCRIPTION
# 変更内容
チャットでの設定表示時に本来役職名に置き換わるはずの"%role%"の部分が置き換わっていない問題を修正し、その他以下の問題も修正しました。
- タスク上書き設定の名前に含まれる役職名に色がついている(他のオプションにはついていない)
- チャットでの役職表示時にタスク上書き設定の通常タスクの有無などが表示されていなかった(上書きする場合のみ表示)
![image](https://user-images.githubusercontent.com/51523918/168089903-2c4a929e-9743-429d-b56b-63821e4df0b5.png)
# その他の変更
- CustomOption.GetName関数に色を付けないようにするための引数を追加
- Utils.ShowActiveSettings関数で設定の名前を取得するとき、CustomOptionのGetName関数を通すよう変更