### PR TITLE
[v2.0.0]Fix/lovers win

### DIFF
--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -89,8 +89,8 @@ namespace TownOfHost
                 }
             }
             if (CustomRoles.Lovers.isEnable() && main.isLoversDead == false //ラバーズが生きていて
-            && main.currentWinner == CustomWinner.Impostor
-            && !endGameResult.GameOverReason.Equals(GameOverReason.HumansByTask))   //クルー勝利でタスク勝ちじゃなければ
+            && (main.currentWinner == CustomWinner.Impostor
+            || (main.currentWinner == CustomWinner.Crewmate && !endGameResult.GameOverReason.Equals(GameOverReason.HumansByTask))))   //クルー勝利でタスク勝ちじゃなければ
             { //Loversの単独勝利
                 TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
                 winner = new();


### PR DESCRIPTION
ラバーズの勝利条件が「ラバーズが生き残っていて、インポスター勝利時のみ」になっていた為
「ラバーズが生き残っていて、ｲﾝﾎﾟｽﾀｰ or クルー(タスク勝利以外)勝利時のみ」に修正