### PR TITLE
RpcGuardAndKillのガード通知を修正

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -160,7 +160,17 @@ namespace TownOfHost
                 }
             }, 0.5f, "GuardAndKill");
         }
-
+        public static void RpcSpecificProtectPlayer(this PlayerControl killer, PlayerControl target = null, int colorId = 0)
+        {
+            if (AmongUsClient.Instance.AmClient)
+            {
+                killer.ProtectPlayer(target, colorId);
+            }
+            MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, 45, SendOption.Reliable, killer.getClientId());
+            messageWriter.WriteNetObject(target);
+            messageWriter.Write(colorId);
+            AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
+        }
         public static byte GetRoleCount(this Dictionary<CustomRoles, byte> dic, CustomRoles role)
         {
             if (!dic.ContainsKey(role))

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -166,7 +166,7 @@ namespace TownOfHost
             {
                 killer.ProtectPlayer(target, colorId);
             }
-            MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, 45, SendOption.Reliable, killer.getClientId());
+            MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.Reliable, killer.getClientId());
             messageWriter.WriteNetObject(target);
             messageWriter.Write(colorId);
             AmongUsClient.Instance.FinishRpcImmediately(messageWriter);

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -142,10 +142,10 @@ namespace TownOfHost
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
 
-        public static void RpcGuardAndKill(this PlayerControl killer, PlayerControl target = null)
+        public static void RpcGuardAndKill(this PlayerControl killer, PlayerControl target = null, int colorId = 0)
         {
             if (target == null) target = killer;
-            killer.RpcProtectPlayer(target, 0);
+            killer.RpcSpecificProtectPlayer(target, colorId);
             new LateTask(() =>
             {
                 if (target.protectedByGuardian)


### PR DESCRIPTION
RpcGuardAndKillで守護天使のガード通知が見えてしまう問題を修正
- 掛けた本人にのみ通知するようにメソッドを追加
- ついでにcolorIdを指定できるように

テスト内容
- Bountyハンターでキルした直後に通報しても本人以外にガード通知されないことを確認