### PR TITLE
シェイプシフター系の名前問題

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -599,9 +599,8 @@ namespace TownOfHost
                 SelfName += SelfSuffix == "" ? "" : "\r\n " + SelfSuffix;
                 if (!isMeeting) SelfName += "\r\n";
 
-                //変身中以外は適用
-                if (seer.Data.Role.Role != RoleTypes.Shapeshifter || !main.CheckShapeshift[seer.PlayerId])
-                    seer.RpcSetNamePrivate(SelfName, true, force: (force || isMeeting));
+                //適用
+                seer.RpcSetNamePrivate(SelfName, true, force: (force || isMeeting));
 
                 //seerが死んでいる場合など、必要なときのみ第二ループを実行する
                 if (seer.Data.IsDead //seerが死んでいる
@@ -712,9 +711,8 @@ namespace TownOfHost
                         //全てのテキストを合成します。
                         string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetDeathReason}{TargetMark}";
 
-                        //変身中以外は適用
-                        if (target.Data.Role.Role != RoleTypes.Shapeshifter || !main.CheckShapeshift[target.PlayerId])
-                            target.RpcSetNamePrivate(TargetName, true, seer, force: isMeeting);
+                        //適用
+                        target.RpcSetNamePrivate(TargetName, true, seer, force: isMeeting);
 
                         TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.getNameWithRole() + ":END", "NotifyRoles");
                     }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -615,6 +615,7 @@ namespace TownOfHost
                     || seer.Is(CustomRoles.Doctor) //seerがドクター
                     || seer.Is(CustomRoles.Puppeteer)
                     || isActive(SystemTypes.Electrical)
+                    || force
                 )
                 {
                     foreach (var target in PlayerControl.AllPlayerControls)
@@ -712,7 +713,7 @@ namespace TownOfHost
                         string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetDeathReason}{TargetMark}";
 
                         //適用
-                        target.RpcSetNamePrivate(TargetName, true, seer, force: isMeeting);
+                        target.RpcSetNamePrivate(TargetName, true, seer, force: (force || isMeeting));
 
                         TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.getNameWithRole() + ":END", "NotifyRoles");
                     }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -445,7 +445,7 @@ namespace TownOfHost
         {
             return PlayerControl.AllPlayerControls.ToArray().Where(pc => pc.PlayerId == PlayerId).FirstOrDefault();
         }
-        public static void NotifyRoles(bool isMeeting = false, PlayerControl SpecifySeer = null)
+        public static void NotifyRoles(bool isMeeting = false, PlayerControl SpecifySeer = null, bool force = false)
         {
             if (!AmongUsClient.Instance.AmHost) return;
             if (PlayerControl.AllPlayerControls == null) return;
@@ -599,8 +599,9 @@ namespace TownOfHost
                 SelfName += SelfSuffix == "" ? "" : "\r\n " + SelfSuffix;
                 if (!isMeeting) SelfName += "\r\n";
 
-                //適用
-                seer.RpcSetNamePrivate(SelfName, true, force: isMeeting);
+                //変身中以外は適用
+                if (seer.Data.Role.Role != RoleTypes.Shapeshifter || !main.CheckShapeshift[seer.PlayerId])
+                    seer.RpcSetNamePrivate(SelfName, true, force: (force || isMeeting));
 
                 //seerが死んでいる場合など、必要なときのみ第二ループを実行する
                 if (seer.Data.IsDead //seerが死んでいる
@@ -710,8 +711,10 @@ namespace TownOfHost
 
                         //全てのテキストを合成します。
                         string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetDeathReason}{TargetMark}";
-                        //適用
-                        target.RpcSetNamePrivate(TargetName, true, seer, force: isMeeting);
+
+                        //変身中以外は適用
+                        if (target.Data.Role.Role != RoleTypes.Shapeshifter || !main.CheckShapeshift[target.PlayerId])
+                            target.RpcSetNamePrivate(TargetName, true, seer, force: isMeeting);
 
                         TownOfHost.Logger.info("NotifyRoles-Loop2-" + target.getNameWithRole() + ":END", "NotifyRoles");
                     }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -888,9 +888,8 @@ namespace TownOfHost
                         Mark = isBlocked ? "(true)" : "(false)";
                     }*/
 
-                    //変身中以外はMark・Suffixの適用
-                    if (target.Data.Role.Role != RoleTypes.Shapeshifter || !main.CheckShapeshift[target.PlayerId])
-                        target.nameText.text = $"{RealName}{Mark}";
+                    //Mark・Suffixの適用
+                    target.nameText.text = $"{RealName}{Mark}";
 
                     if (Suffix != "")
                     {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -172,7 +172,7 @@ namespace TownOfHost
             {
                 new LateTask(() =>
                 {
-                    Utils.NotifyRoles(SpecifySeer: shapeshifter, force: true);
+                    Utils.NotifyRoles(force: true);
                 },
                 1.2f, "ShepeShiftNotify");
             }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -167,6 +167,7 @@ namespace TownOfHost
             if (shapeshifter.Is(CustomRoles.FireWorks)) FireWorks.ShapeShiftState(shapeshifter, shapeshifting);
             if (shapeshifter.Is(CustomRoles.Sniper)) Sniper.ShapeShiftCheck(shapeshifter, shapeshifting);
 
+            //変身解除のタイミングがずれて名前が直せなかった時のために強制書き換え
             if (!shapeshifting)
             {
                 new LateTask(() =>


### PR DESCRIPTION
変身解除後に名前が戻らないことがある
変身中に誰かのガードエフェクトが発生した場合(NotifyRoilesが飛んできたとき)に発生します。
=>変身解除後は念のため強制名前書き換え