### PR TITLE
シェイプシフト中に元の名前が表示される問題を修正

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -724,7 +724,7 @@ namespace TownOfHost
                     string Suffix = "";
 
                     //名前変更
-                    RealName = target.Data.PlayerName;
+                    RealName = target.getRealName();
 
 
                     //名前色変更処理


### PR DESCRIPTION
シェイプシフト中にMODクライアントにて元の名前が表示されてしまう問題を修正