### PR TITLE
InGame判定をカスタム役職決定後にセットするように修正

### DIFF
--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -109,15 +109,16 @@ namespace TownOfHost
     }
     public static class GameStates
     {
+        public static bool InGame = false;
         public static bool isLobby => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Joined;
-        public static bool isInGame => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Started;
+        public static bool isInGame => InGame;
         public static bool isEnded => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Ended;
         public static bool isNotJoined => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.NotJoined;
         public static bool isOnlineGame => AmongUsClient.Instance.GameMode == GameModes.OnlineGame;
         public static bool isLocalGame => AmongUsClient.Instance.GameMode == GameModes.LocalGame;
         public static bool isFreePlay => AmongUsClient.Instance.GameMode == GameModes.FreePlay;
-        public static bool isInTask => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Started && !MeetingHud.Instance;
-        public static bool isMeeting => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Started && MeetingHud.Instance;
+        public static bool isInTask => InGame && !MeetingHud.Instance;
+        public static bool isMeeting => InGame && MeetingHud.Instance;
         public static bool isCountDown => GameStartManager.InstanceExists && GameStartManager.Instance.startState == GameStartManager.StartingStates.Countdown;
     }
 }

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -68,6 +68,8 @@ namespace TownOfHost
                     Logger.info(String.Format("{0}{1,-36}:{2}", o.Parent == null ? "" : "┗ ", o.Name, o.GetString()), "Info");
             Logger.info("-------------その他-------------", "Info");
             Logger.info($"プレイヤー数: {PlayerControl.AllPlayerControls.Count}人", "Info");
+
+            GameStates.InGame = true;
         }
     }
     [HarmonyPatch(typeof(IntroCutscene), nameof(IntroCutscene.BeginCrewmate))]

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -11,6 +11,7 @@ namespace TownOfHost
         public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ref EndGameResult endGameResult)
         {
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+            GameStates.InGame = false;
 
             Logger.info("-----------ゲーム終了-----------", "Phase");
             //winnerListリセット


### PR DESCRIPTION
カスタム役職設定前にFixedUpdateで例外発生する。
=>カスタム役職設定後にInGameフラグを立てる形に変更