### PR TITLE
MODクライアントの例外を修正

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -47,7 +47,7 @@ namespace TownOfHost
         public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] byte callId, [HarmonyArgument(1)] MessageReader reader)
         {
             var rpcType = (RpcCalls)callId;
-            Logger.info($"{__instance.Data.PlayerId}({__instance.Data.PlayerName}):{callId}({RPC.getRpcName(callId)})", "ReceiveRPC");
+            Logger.info($"{__instance?.Data?.PlayerId}({__instance?.Data?.PlayerName}):{callId}({RPC.getRpcName(callId)})", "ReceiveRPC");
             MessageReader subReader = MessageReader.Get(reader);
             switch (rpcType)
             {

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -216,7 +216,7 @@ namespace TownOfHost
                 ProgressText = $"<color=#ffff00>({Completed}/{taskState.AllTasksCount})</color>";
             }
             //塗りテキスト
-            else if (main.AllPlayerCustomRoles[pc.PlayerId] == CustomRoles.Arsonist)
+            else if (pc.Is(CustomRoles.Arsonist))
                 ProgressText = $"<color={getRoleColorCode(CustomRoles.Arsonist)}>({main.DousedPlayerCount[pc.PlayerId].Item1}/{main.DousedPlayerCount[pc.PlayerId].Item2})</color>";
 
             return ProgressText;


### PR DESCRIPTION
MODクライアントで例外が出る問題を修正
- getProgressTextが役職が知らされる前に呼ばれると辞書で例外が出る問題を修正
- ReceiveRPCログでPlayerNameがnullの時があるのでnullチェックを追加