### PR TITLE
ログの詳細表示を標準で無効に

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -131,7 +131,7 @@ namespace TownOfHost
             TownOfHost.Logger.disable("SendRPC");
             TownOfHost.Logger.disable("ReceiveRPC");
             TownOfHost.Logger.disable("SwitchSystem");
-            TownOfHost.Logger.isDetail = true;
+            //TownOfHost.Logger.isDetail = true;
 
             currentWinner = CustomWinner.Default;
             additionalwinners = new HashSet<AdditionalWinners>();


### PR DESCRIPTION
細かい情報が欲しい調査時以外ではむしろ邪魔になっている気もするのでデフォルトで無効に。
必要な時にコメントを外してください。