### PR TITLE
mainブランチ以外ではブランチ名とハッシュを表示

### DIFF
--- a/Patches/CredentialsPatch.cs
+++ b/Patches/CredentialsPatch.cs
@@ -51,6 +51,8 @@ namespace TownOfHost
         static void Postfix(VersionShower __instance)
         {
             main.credentialsText = $"\r\n<color={main.modColor}>Town Of Host</color> v{main.PluginVersion}";
+            if (ThisAssembly.Git.Branch != "main")
+                main.credentialsText += $"\r\n<color={main.modColor}>{ThisAssembly.Git.Branch}({ThisAssembly.Git.Commit})</color>";
             if (main.AmDebugger.Value)
                 main.credentialsText += "\r\n<color=#00ff00>デバッグモード</color>";
             var credentials = UnityEngine.Object.Instantiate<TMPro.TextMeshPro>(__instance.text);


### PR DESCRIPTION
mainブランチ以外ではバージョンの下にブランチ名とハッシュを表示。
main以外でリリースを作成したときに気づけたり、SSだけ貼られた場合でも最低限分かるように。