### PR TITLE
会議と同時にボタン入った時の対策

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -155,6 +155,7 @@ namespace TownOfHost
                 }
                 else
                 {
+                    /*
                     //ガードはがされていたら剥がした人のキルにする
                     if (main.LastKiller.TryGetValue(target, out var lastKiller))
                     {
@@ -165,6 +166,7 @@ namespace TownOfHost
 
                         }
                     }
+                    */
                 }
             }, 0.5f, "GuardAndKill");
         }

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -149,17 +149,21 @@ namespace TownOfHost
             new LateTask(() =>
             {
                 if (target == null) return;
-                if (target.protectedByGuardian)
+                if (!target.Data.IsDead && target.protectedByGuardian)
                 {
                     killer?.RpcMurderPlayer(target);
                 }
                 else
                 {
                     //ガードはがされていたら剥がした人のキルにする
-                    if(main.LastKiller.TryGetValue(target,out var lastKiller))
+                    if (main.LastKiller.TryGetValue(target, out var lastKiller))
                     {
-                        lastKiller?.RpcMurderPlayer(target);
+                        Logger.info($"LastKiller:{lastKiller.name} killer:{killer.name}");
+                        if(lastKiller != killer)
+                        {
+                            lastKiller?.RpcMurderPlayer(target);
 
+                        }
                     }
                 }
             }, 0.5f, "GuardAndKill");

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -507,6 +507,8 @@ namespace TownOfHost
                 if (!bitten.Data.IsDead)
                 {
                     PlayerState.setDeathReason(bitten.PlayerId, PlayerState.DeathReason.Bite);
+                    //Protectは強制的にはがす
+                    bitten.RemoveProtection();
                     bitten.RpcMurderPlayer(bitten);
                     RPC.PlaySoundRPC(vampireID, Sounds.KillSound);
                     Logger.info("Vampireに噛まれている" + bitten.Data.PlayerName + "を自爆させました。", "ReportDeadBody");


### PR DESCRIPTION
ガードエフェクトが入ったと同時に会議に入った時、死亡してしまう。
※ガードエフェクトに割り込みキルが入った場合の対策の影響

・会議に入ったあとバンパイアに噛まれたプレイヤーはガードを外して必ず殺す
・RpcGuardAndKill()のLateTaskで死亡していた時もキルしない
・割り込みキル対策をいったんコメントアウト