### PR TITLE
RpcGuardAndKill()周りの修正

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -145,28 +145,19 @@ namespace TownOfHost
         public static void RpcGuardAndKill(this PlayerControl killer, PlayerControl target = null, int colorId = 0)
         {
             if (target == null) target = killer;
+            main.SelfGuard[target.PlayerId] = true;
             killer.RpcProtectPlayer(target, colorId);
             new LateTask(() =>
             {
                 if (target == null) return;
+                main.SelfGuard[target.PlayerId] = false;
                 if (!target.Data.IsDead && target.protectedByGuardian)
                 {
                     killer?.RpcMurderPlayer(target);
                 }
                 else
                 {
-                    /*
-                    //ガードはがされていたら剥がした人のキルにする
-                    if (main.LastKiller.TryGetValue(target, out var lastKiller))
-                    {
-                        Logger.info($"LastKiller:{lastKiller.name} killer:{killer.name}");
-                        if(lastKiller != killer)
-                        {
-                            lastKiller?.RpcMurderPlayer(target);
-
-                        }
-                    }
-                    */
+                    main.BlockKilling[killer.PlayerId] = false;
                 }
             }, 0.5f, "GuardAndKill");
         }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -99,8 +99,6 @@ namespace TownOfHost
             }
             FixedUpdatePatch.LoversSuicide(target.PlayerId);
 
-            main.LastKiller.Remove(target);
-
             PlayerState.setDead(target.PlayerId);
             Utils.CountAliveImpostors();
             Utils.CustomSyncAllSettings();
@@ -216,7 +214,11 @@ namespace TownOfHost
                 main.AirshipMeetingCheck = false;
                 Utils.CustomSyncAllSettings();
             }
-            main.LastKiller[target] = __instance;
+            if (main.SelfGuard[target.PlayerId])
+            {
+                main.SelfGuard[target.PlayerId] = false;
+                target.RpcMurderPlayer(target);
+            }
             Logger.info($"{__instance.getNameWithRole()} => {target.getNameWithRole()}", "CheckMurder");
 
 
@@ -508,7 +510,8 @@ namespace TownOfHost
                 {
                     PlayerState.setDeathReason(bitten.PlayerId, PlayerState.DeathReason.Bite);
                     //Protectは強制的にはがす
-                    bitten.RemoveProtection();
+                    if(bitten.protectedByGuardian)
+                        bitten.RpcMurderPlayer(bitten);
                     bitten.RpcMurderPlayer(bitten);
                     RPC.PlaySoundRPC(vampireID, Sounds.KillSound);
                     Logger.info("Vampireに噛まれている" + bitten.Data.PlayerName + "を自爆させました。", "ReportDeadBody");
@@ -974,7 +977,7 @@ namespace TownOfHost
                                 main.IgnoreReportPlayers.Add(partnerPlayer.PlayerId);   //通報不可な死体にする
                                 CheckForEndVotingPatch.recall = true;
                             }
-                            partnerPlayer.CheckMurder(partnerPlayer);
+                            partnerPlayer.RpcMurderPlayer(partnerPlayer);
                         }
                     }
                 }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -54,7 +54,7 @@ namespace TownOfHost
             main.RealOptionsData = PlayerControl.GameOptions.DeepCopy();
             main.RealNames = new Dictionary<byte, string>();
             main.BlockKilling = new Dictionary<byte, bool>();
-            main.LastKiller = new();
+            main.SelfGuard = new();
 
             main.introDestroyed = false;
 
@@ -76,6 +76,7 @@ namespace TownOfHost
                 main.AllPlayerSpeed[pc.PlayerId] = main.RealOptionsData.PlayerSpeedMod; //移動速度をデフォルトの移動速度に変更
                 main.RealNames[pc.PlayerId] = pc.name;
                 pc.nameText.text = pc.name;
+                main.SelfGuard[pc.PlayerId] = false;
             }
             main.VisibleTasksCount = true;
             if (__instance.AmHost)

--- a/main.cs
+++ b/main.cs
@@ -49,7 +49,7 @@ namespace TownOfHost
         public static Dictionary<(byte, byte), string> LastNotifyNames;
         public static Dictionary<byte, CustomRoles> AllPlayerCustomRoles;
         public static Dictionary<byte, CustomRoles> AllPlayerCustomSubRoles;
-        public static Dictionary<PlayerControl, PlayerControl> LastKiller;
+        public static Dictionary<byte, bool> SelfGuard;
         public static Dictionary<byte, bool> BlockKilling;
         public static Dictionary<byte, float> SheriffShotLimit;
         public static Dictionary<CustomRoles, String> roleColors;


### PR DESCRIPTION
RpcGuardAndKillに関連して過去の修正(#456, #542など)を含めて
・アーソニストの塗り中の会議で死亡する
・アーソニストの塗り中のキャラをキルできない
・バウンティ、シリアルキラーのガードエフェクト中の会議で死亡
・バウンティ、シリアルキラーのガードエフェクト中にキルできない
・ウィッチのスペルでキル出来てしまう
など、不具合がありました。

対策
・LastKillerによるキラー管理の廃止

・RpcGuardAndKillによるガードか守護天使によるガードか区別するためSelfGuardフラグを作成
SelfGuardに対するキル行為に対してRpcMurderPlayerを呼ぶことでガード解除
※RemoveProtection()はローカルに対してのみ働くためキル行為で解除

・RpcGuardAndKillのLateTaskに対して
　死亡している場合の再キル回避
　キル不要な時、キラーのブロック解除を追加

確認済み事項
アーソニストの塗りエフェクト中の会議開始で死亡しないことを確認
アーソニストの塗りエフェクトに対して、キルが通ることを確認
ヴァンパイアキル直後の会議に対して無駄なキルが発生していないことを確認
ヴァンパイアキルのエフェクト中のキルが通ることを確認
ウィッチのスペルでキルが発生しないことを確認
シリアル、バウンティのエフェクト中の会議で死亡しないことの確認
