### PR TITLE
Recall例外の修正

### DIFF
--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -394,7 +394,8 @@ namespace TownOfHost
                     {
                         new LateTask(() =>
                         {
-                            pc.ReportDeadBody(Utils.getPlayerById(main.IgnoreReportPlayers.Last()).Data);
+                            if(MeetingHud.Instance!=null)
+                                pc.ReportDeadBody(Utils.getPlayerById(main.IgnoreReportPlayers.Last()).Data);
                         },
                             0.2f + additional, "Recall Meeting");
                         new LateTask(() =>

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -394,7 +394,7 @@ namespace TownOfHost
                     {
                         new LateTask(() =>
                         {
-                            if(MeetingHud.Instance!=null)
+                            if (MeetingHud.Instance != null)
                                 pc.ReportDeadBody(Utils.getPlayerById(main.IgnoreReportPlayers.Last()).Data);
                         },
                             0.2f + additional, "Recall Meeting");


### PR DESCRIPTION
ウィッチの呪いでGameEndしたとき、Recallかけようとして例外が発生
会議終了しているときはキャンセルする処理の追加