### PR TITLE
ロビーでバージョンごとに名前を変更

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -751,6 +751,14 @@ namespace TownOfHost
             var RoleText = RoleTextTransform.GetComponent<TMPro.TextMeshPro>();
             if (RoleText != null && __instance != null)
             {
+                if (GameStates.isLobby)
+                {
+                    if (main.playerVersion.TryGetValue(__instance.PlayerId, out var ver))
+                        if (main.version.CompareTo(ver.version) == 0)
+                            __instance.nameText.text = ver.tag == $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})" ? $"<color=#87cefa>{__instance.name}</color>" : $"<color=#ffff00><size=1.2>{ver.tag}</size>\n{__instance?.name}</color>";
+                        else __instance.nameText.text = $"<color=#ff0000><size=1.2>v{ver.version}</size>\n{__instance?.name}</color>";
+                    else __instance.nameText.text = __instance?.Data?.PlayerName;
+                }
                 if (GameStates.isInGame)
                 {
                     var RoleTextData = Utils.GetRoleText(__instance);


### PR DESCRIPTION
ロビーでバージョンを視覚的に分かるように機能を追加。
- バニラの場合は変化なし
- バージョン・ブランチ・コミットがあっていれば名前が水色に変化
- コミットかブランチが違う場合、名前が黄色く変化しブランチ名とコミット番号が表示される
- バージョンが違う場合、名前が赤く変化しバージョンが表示される
![image](https://user-images.githubusercontent.com/72009106/169060435-df52ed5e-9d94-45b2-934b-c4c9b42e65b2.png)