### PR TITLE
Recall例外対策のやり直し

### DIFF
--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -386,28 +386,24 @@ namespace TownOfHost
             //エアシップの場合スポーン位置選択が発生するため死体消し用の会議を5秒遅らせる。
             var additional = PlayerControl.GameOptions.MapId == 4 ? 5f : 0f;
 
-            if (CheckForEndVotingPatch.recall)
+            if (CheckForEndVotingPatch.recall && GameStates.isInGame)
             {
-                foreach (var pc in PlayerControl.AllPlayerControls)
+                new LateTask(() =>
                 {
-                    if (!pc.Data.IsDead)
+                    //生きてる適当なプレイヤーを選択
+                    var pc = PlayerControl.AllPlayerControls.ToArray().Where(p => !p.Data.IsDead).FirstOrDefault();
+                    if (pc != null)
                     {
+                        pc.ReportDeadBody(Utils.getPlayerById(main.IgnoreReportPlayers.Last()).Data);
                         new LateTask(() =>
                         {
-                            if (MeetingHud.Instance != null)
-                                pc.ReportDeadBody(Utils.getPlayerById(main.IgnoreReportPlayers.Last()).Data);
-                        },
-                            0.2f + additional, "Recall Meeting");
-                        new LateTask(() =>
-                        {
-                            if (MeetingHud.Instance != null)
-                                MeetingHud.Instance.RpcClose();
+                            MeetingHud.Instance.RpcClose();
                             CheckForEndVotingPatch.recall = false;
                         },
-                            0.5f + additional, "Cancel Meeting");
-                        break;
+                        0.5f, "Cancel Meeting");
                     }
-                }
+                },
+                0.2f + additional, "Recall Meeting");
             }
         }
     }


### PR DESCRIPTION
#546、#562の対応にミスがあったため修正

ミーティングが終わってた時にRecallしない
→ゲームが終わっていた時にRecallしないに変更

ミーティングが発生していない場合会議クローズしない
→会議クローズ用のLateTaskはRecall用LateTask内で作成する。

報告用プレイヤーは念のためLateTask内で検索することとする。