### PR TITLE
Feature/RecallDespawn

### DIFF
--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -1,6 +1,5 @@
 using HarmonyLib;
 using Hazel;
-using System.Linq;
 
 namespace TownOfHost
 {

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using Hazel;
+using System.Linq;
 
 namespace TownOfHost
 {

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -379,7 +379,6 @@ namespace TownOfHost
         {
             if (!AmongUsClient.Instance.AmHost) return;
 
-            //生きてる適当なプレイヤーを選択
             if (CheckForEndVotingPatch.recall && GameStates.IsInGame)
                 new LateTask(() =>
                 {

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -383,25 +383,18 @@ namespace TownOfHost
             //エアシップの場合スポーン位置選択が発生するため死体消し用の会議を5秒遅らせる。
             var additional = PlayerControl.GameOptions.MapId == 4 ? 5f : 0f;
 
-            if (CheckForEndVotingPatch.recall && GameStates.IsInGame)
+            //生きてる適当なプレイヤーを選択
+            new LateTask(() =>
             {
-                new LateTask(() =>
+                var pc = PlayerControl.AllPlayerControls.ToArray().Where(p => !p.Data.IsDead).FirstOrDefault();
+                if (pc != null)
                 {
-                    //生きてる適当なプレイヤーを選択
-                    var pc = PlayerControl.AllPlayerControls.ToArray().Where(p => !p.Data.IsDead).FirstOrDefault();
-                    if (pc != null)
-                    {
-                        pc.ReportDeadBody(Utils.GetPlayerById(Main.IgnoreReportPlayers.Last()).Data);
-                        new LateTask(() =>
-                        {
-                            MeetingHud.Instance.RpcClose();
-                            CheckForEndVotingPatch.recall = false;
-                        },
-                        0.5f, "Cancel Meeting");
-                    }
-                },
-                0.2f + additional, "Recall Meeting");
-            }
+                    pc.ReportDeadBody(Utils.GetPlayerById(Main.IgnoreReportPlayers.Last()).Data);
+                    Main.IgnoreReportPlayers.Clear();
+                    MeetingHud.Instance?.Despawn();
+                    CheckForEndVotingPatch.recall = false;
+                }
+            }, 0.2f, "Recall Meeting");
         }
     }
 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -382,13 +382,15 @@ namespace TownOfHost
             if (CheckForEndVotingPatch.recall && GameStates.IsInGame)
                 new LateTask(() =>
                 {
-                    var reporter = PlayerControl.LocalPlayer;
-                    MeetingRoomManager.Instance.AssignSelf(reporter, reporter?.Data);
-                    DestroyableSingleton<HudManager>.Instance.OpenMeetingRoom(reporter);
-                    reporter.RpcStartMeeting(reporter?.Data);
-                    Main.IgnoreReportPlayers.Clear();
-                    MeetingHud.Instance?.Despawn(); //会議終了
-                    CheckForEndVotingPatch.recall = false;
+                    //生きてる適当なプレイヤーを選択
+                    var pc = PlayerControl.AllPlayerControls.ToArray().Where(p => !p.Data.IsDead).FirstOrDefault();
+                    if (pc != null)
+                    {
+                        pc.ReportDeadBody(Utils.GetPlayerById(Main.IgnoreReportPlayers.Last()).Data);
+                        Main.IgnoreReportPlayers.Clear();
+                        MeetingHud.Instance?.Despawn(); //会議終了
+                        CheckForEndVotingPatch.recall = false;
+                    }
                 }, 3f, "Recall Meeting");
             else Logger.Info("------------会議終了------------", "Phase");
         }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -375,12 +375,12 @@ namespace TownOfHost
     [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.OnDestroy))]
     class MeetingHudOnDestroyPatch
     {
-        public static void Postfix(MeetingHud __instance)
+        public static void Postfix()
         {
             if (!AmongUsClient.Instance.AmHost) return;
 
             //生きてる適当なプレイヤーを選択
-            if (CheckForEndVotingPatch.recall)
+            if (CheckForEndVotingPatch.recall && GameStates.IsInGame)
                 new LateTask(() =>
                 {
                     var reporter = PlayerControl.LocalPlayer;

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -388,6 +388,7 @@ namespace TownOfHost
                     pc.RpcStartMeeting(Utils.GetPlayerById(Main.IgnoreReportPlayers.Last()).Data);
                     Main.IgnoreReportPlayers.Clear();
                     CheckForEndVotingPatch.recall = false;
+                    Logger.Info("Recall Meeting", "Recall");
                 }
             }
             Logger.Info("------------会議終了------------", "Phase");

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -380,19 +380,17 @@ namespace TownOfHost
             if (!AmongUsClient.Instance.AmHost) return;
 
             if (CheckForEndVotingPatch.recall && GameStates.IsInGame)
-                new LateTask(() =>
+            {
+                //生きてる適当なプレイヤーを選択
+                var pc = PlayerControl.AllPlayerControls.ToArray().Where(p => !p.Data.IsDead).FirstOrDefault();
+                if (pc != null)
                 {
-                    //生きてる適当なプレイヤーを選択
-                    var pc = PlayerControl.AllPlayerControls.ToArray().Where(p => !p.Data.IsDead).FirstOrDefault();
-                    if (pc != null)
-                    {
-                        pc.ReportDeadBody(Utils.GetPlayerById(Main.IgnoreReportPlayers.Last()).Data);
-                        Main.IgnoreReportPlayers.Clear();
-                        MeetingHud.Instance?.Despawn(); //会議終了
-                        CheckForEndVotingPatch.recall = false;
-                    }
-                }, 3f, "Recall Meeting");
-            else Logger.Info("------------会議終了------------", "Phase");
+                    pc.RpcStartMeeting(Utils.GetPlayerById(Main.IgnoreReportPlayers.Last()).Data);
+                    Main.IgnoreReportPlayers.Clear();
+                    CheckForEndVotingPatch.recall = false;
+                }
+            }
+            Logger.Info("------------会議終了------------", "Phase");
         }
     }
 }


### PR DESCRIPTION
Recallでの死体処理会議を発生させた後にSpawnMiniGameが2重になっている仕様の踏み倒し

(アイデア : よっキングさん)

ホストのみ死体消し会議のモーションが入らないのは仕様です。