### PR TITLE
Recallの処理を置き換え

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -674,6 +674,12 @@ namespace TownOfHost
                 }
             }
         }
+        public static void RpcExileV2(this PlayerControl player)
+        {
+            player.Exiled();
+            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.Exiled, SendOption.None, -1);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+        }
         public static bool IsModClient(this PlayerControl player) => Main.playerVersion.ContainsKey(player.PlayerId);
 
         //汎用

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -9,7 +9,6 @@ namespace TownOfHost
     [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.CheckForEndVoting))]
     class CheckForEndVotingPatch
     {
-        public static bool recall = false;
         public static bool Prefix(MeetingHud __instance)
         {
             if (MeetingHudUpdatePatch.isDictatorVote)
@@ -29,7 +28,6 @@ namespace TownOfHost
                 MeetingHud.VoterState[] states;
                 GameData.PlayerInfo exiledPlayer = PlayerControl.LocalPlayer.Data;
                 bool tie = false;
-                recall = false;
 
                 List<MeetingHud.VoterState> statesList = new();
                 for (var i = 0; i < __instance.playerStates.Length; i++)
@@ -373,20 +371,6 @@ namespace TownOfHost
     {
         public static void Postfix()
         {
-            if (!AmongUsClient.Instance.AmHost) return;
-
-            if (CheckForEndVotingPatch.recall && GameStates.IsInGame)
-            {
-                //生きてる適当なプレイヤーを選択
-                var pc = PlayerControl.AllPlayerControls.ToArray().Where(p => !p.Data.IsDead).FirstOrDefault();
-                if (pc != null)
-                {
-                    pc.RpcStartMeeting(Utils.GetPlayerById(Main.IgnoreReportPlayers.Last()).Data);
-                    Main.IgnoreReportPlayers.Clear();
-                    CheckForEndVotingPatch.recall = false;
-                    Logger.Info("Recall Meeting", "Recall");
-                }
-            }
             Logger.Info("------------会議終了------------", "Phase");
         }
     }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -45,10 +45,9 @@ namespace TownOfHost
                         {
                             case VoteMode.Suicide:
                                 PlayerState.SetDeathReason(ps.TargetPlayerId, PlayerState.DeathReason.Suicide);
-                                voter.RpcMurderPlayer(voter);
+                                voter.RpcExileV2();
                                 Logger.Info($"スキップしたため{voter.GetNameWithRole()}を自殺させました", "Vote");
                                 Main.IgnoreReportPlayers.Add(voter.PlayerId);
-                                recall = true;
                                 break;
                             case VoteMode.SelfVote:
                                 ps.VotedFor = ps.TargetPlayerId;
@@ -64,10 +63,9 @@ namespace TownOfHost
                         {
                             case VoteMode.Suicide:
                                 PlayerState.SetDeathReason(ps.TargetPlayerId, PlayerState.DeathReason.Suicide);
-                                voter.RpcMurderPlayer(voter);
+                                voter.RpcExileV2();
                                 Logger.Info($"無投票のため{voter.GetNameWithRole()}を自殺させました", "Vote");
                                 Main.IgnoreReportPlayers.Add(voter.PlayerId);
-                                recall = true;
                                 break;
                             case VoteMode.SelfVote:
                                 ps.VotedFor = ps.TargetPlayerId;

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -131,8 +131,7 @@ namespace TownOfHost
                     {
                         PlayerState.SetDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
                         Main.IgnoreReportPlayers.Add(p.PlayerId);
-                        p.RpcMurderPlayer(p);
-                        recall = true;
+                        p.RpcExileV2();
                     }
                 }
                 Main.SpelledPlayer.Clear();

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -360,10 +360,9 @@ namespace TownOfHost
                     });
                     states = statesList.ToArray();
                     isDictatorVote = true;
-                    pc.RpcMurderPlayer(pc); //自殺
+                    pc.RpcExileV2(); //自殺
                     __instance.RpcVotingComplete(states, voteTarget.Data, false); //RPC
                     Main.IgnoreReportPlayers.Add(pc.PlayerId);
-                    CheckForEndVotingPatch.recall = true;
                     Logger.Info("ディクテーターによる強制会議終了", "Special Phase");
                 }
             }


### PR DESCRIPTION
Recallの死体消し処理をExileに置き換え
- RpcExileV2メソッドを追加
- 投票死を置き換え
- ディクテーターの自殺を置き換え
- 呪殺を置き換え
- Recallの処理自体を削除

投票死による追放でBANされないことを確認済み。