### PR TITLE
[WIP]ミーティング中の死亡処理を追放後に移動

### DIFF
--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -87,7 +87,7 @@ namespace TownOfHost
                     Main.isCurseAndKill[pc.PlayerId] = false;
                 }
             }
-            Main.AfterMeetingExilePlayers.Do(p => Utils.GetPlayerById(p));
+            Main.AfterMeetingExilePlayers.Do(p => Utils.GetPlayerById(p).RpcExileV2());
             Main.AfterMeetingExilePlayers.Clear();
             Utils.CountAliveImpostors();
             Utils.AfterMeetingTasks();

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -63,7 +63,6 @@ namespace TownOfHost
                     {
                         PlayerState.SetDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
                         Main.AfterMeetingExilePlayers.Add(p.PlayerId);
-                        p.RpcMurderPlayer(p);
                     }
                 }
                 if (exiled.Object.Is(CustomRoles.TimeThief))
@@ -88,6 +87,8 @@ namespace TownOfHost
                     Main.isCurseAndKill[pc.PlayerId] = false;
                 }
             }
+            Main.AfterMeetingExilePlayers.Do(p => Utils.GetPlayerById(p));
+            Main.AfterMeetingExilePlayers.Clear();
             Utils.CountAliveImpostors();
             Utils.AfterMeetingTasks();
             Utils.CustomSyncAllSettings();

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -62,7 +62,7 @@ namespace TownOfHost
                     foreach (var p in Main.SpelledPlayer)
                     {
                         PlayerState.SetDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
-                        Main.IgnoreReportPlayers.Add(p.PlayerId);
+                        Main.AfterMeetingExilePlayers.Add(p.PlayerId);
                         p.RpcMurderPlayer(p);
                     }
                 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -43,7 +43,6 @@ namespace TownOfHost
                         {
                             case VoteMode.Suicide:
                                 PlayerState.SetDeathReason(ps.TargetPlayerId, PlayerState.DeathReason.Suicide);
-                                voter.RpcExileV2();
                                 Logger.Info($"スキップしたため{voter.GetNameWithRole()}を自殺させました", "Vote");
                                 Main.AfterMeetingExilePlayers.Add(voter.PlayerId);
                                 break;
@@ -61,7 +60,6 @@ namespace TownOfHost
                         {
                             case VoteMode.Suicide:
                                 PlayerState.SetDeathReason(ps.TargetPlayerId, PlayerState.DeathReason.Suicide);
-                                voter.RpcExileV2();
                                 Logger.Info($"無投票のため{voter.GetNameWithRole()}を自殺させました", "Vote");
                                 Main.AfterMeetingExilePlayers.Add(voter.PlayerId);
                                 break;
@@ -129,7 +127,6 @@ namespace TownOfHost
                     {
                         PlayerState.SetDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
                         Main.AfterMeetingExilePlayers.Add(p.PlayerId);
-                        p.RpcExileV2();
                     }
                 }
                 Main.SpelledPlayer.Clear();
@@ -358,7 +355,6 @@ namespace TownOfHost
                     });
                     states = statesList.ToArray();
                     isDictatorVote = true;
-                    pc.RpcExileV2(); //自殺
                     __instance.RpcVotingComplete(states, voteTarget.Data, false); //RPC
                     Main.AfterMeetingExilePlayers.Add(pc.PlayerId);
                     Logger.Info("ディクテーターによる強制会議終了", "Special Phase");

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -45,7 +45,7 @@ namespace TownOfHost
                                 PlayerState.SetDeathReason(ps.TargetPlayerId, PlayerState.DeathReason.Suicide);
                                 voter.RpcExileV2();
                                 Logger.Info($"スキップしたため{voter.GetNameWithRole()}を自殺させました", "Vote");
-                                Main.IgnoreReportPlayers.Add(voter.PlayerId);
+                                Main.AfterMeetingExilePlayers.Add(voter.PlayerId);
                                 break;
                             case VoteMode.SelfVote:
                                 ps.VotedFor = ps.TargetPlayerId;
@@ -63,7 +63,7 @@ namespace TownOfHost
                                 PlayerState.SetDeathReason(ps.TargetPlayerId, PlayerState.DeathReason.Suicide);
                                 voter.RpcExileV2();
                                 Logger.Info($"無投票のため{voter.GetNameWithRole()}を自殺させました", "Vote");
-                                Main.IgnoreReportPlayers.Add(voter.PlayerId);
+                                Main.AfterMeetingExilePlayers.Add(voter.PlayerId);
                                 break;
                             case VoteMode.SelfVote:
                                 ps.VotedFor = ps.TargetPlayerId;
@@ -128,7 +128,7 @@ namespace TownOfHost
                     foreach (var p in Main.SpelledPlayer)
                     {
                         PlayerState.SetDeathReason(p.PlayerId, PlayerState.DeathReason.Spell);
-                        Main.IgnoreReportPlayers.Add(p.PlayerId);
+                        Main.AfterMeetingExilePlayers.Add(p.PlayerId);
                         p.RpcExileV2();
                     }
                 }
@@ -360,7 +360,7 @@ namespace TownOfHost
                     isDictatorVote = true;
                     pc.RpcExileV2(); //自殺
                     __instance.RpcVotingComplete(states, voteTarget.Data, false); //RPC
-                    Main.IgnoreReportPlayers.Add(pc.PlayerId);
+                    Main.AfterMeetingExilePlayers.Add(pc.PlayerId);
                     Logger.Info("ディクテーターによる強制会議終了", "Special Phase");
                 }
             }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -968,10 +968,9 @@ namespace TownOfHost
                         {
                             PlayerState.SetDeathReason(partnerPlayer.PlayerId, PlayerState.DeathReason.LoversSuicide);
                             if (isExiled)
-                            {
                                 Main.AfterMeetingExilePlayers.Add(partnerPlayer.PlayerId);   //通報不可な死体にする
-                            }
-                            partnerPlayer.RpcMurderPlayer(partnerPlayer);
+                            else
+                                partnerPlayer.RpcMurderPlayer(partnerPlayer);
                         }
                     }
                 }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -470,7 +470,7 @@ namespace TownOfHost
             }
             else //死体通報
             {
-                if (Main.IgnoreReportPlayers.Contains(target.PlayerId))
+                if (Main.AfterMeetingExilePlayers.Contains(target.PlayerId))
                 {
                     Logger.Info($"{target.PlayerName}は通報が禁止された死体なのでキャンセルされました", "ReportDeadBody");
                     return false;
@@ -969,7 +969,7 @@ namespace TownOfHost
                             PlayerState.SetDeathReason(partnerPlayer.PlayerId, PlayerState.DeathReason.LoversSuicide);
                             if (isExiled)
                             {
-                                Main.IgnoreReportPlayers.Add(partnerPlayer.PlayerId);   //通報不可な死体にする
+                                Main.AfterMeetingExilePlayers.Add(partnerPlayer.PlayerId);   //通報不可な死体にする
                             }
                             partnerPlayer.RpcMurderPlayer(partnerPlayer);
                         }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -968,7 +968,7 @@ namespace TownOfHost
                         {
                             PlayerState.SetDeathReason(partnerPlayer.PlayerId, PlayerState.DeathReason.LoversSuicide);
                             if (isExiled)
-                                Main.AfterMeetingExilePlayers.Add(partnerPlayer.PlayerId);   //通報後に死ぬリストに追加
+                                Main.AfterMeetingExilePlayers.Add(partnerPlayer.PlayerId);   //追放後に死ぬリストに追加
                             else
                                 partnerPlayer.RpcMurderPlayer(partnerPlayer);
                         }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -968,7 +968,7 @@ namespace TownOfHost
                         {
                             PlayerState.SetDeathReason(partnerPlayer.PlayerId, PlayerState.DeathReason.LoversSuicide);
                             if (isExiled)
-                                Main.AfterMeetingExilePlayers.Add(partnerPlayer.PlayerId);   //通報不可な死体にする
+                                Main.AfterMeetingExilePlayers.Add(partnerPlayer.PlayerId);   //通報後に死ぬリストに追加
                             else
                                 partnerPlayer.RpcMurderPlayer(partnerPlayer);
                         }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -36,7 +36,7 @@ namespace TownOfHost
             Main.isCursed = false;
             Main.PuppeteerList = new Dictionary<byte, byte>();
 
-            Main.IgnoreReportPlayers = new List<byte>();
+            Main.AfterMeetingExilePlayers = new List<byte>();
 
             Main.SheriffShotLimit = new Dictionary<byte, float>();
             Main.TimeThiefKillCount = new Dictionary<byte, int>();

--- a/main.cs
+++ b/main.cs
@@ -55,7 +55,7 @@ namespace TownOfHost
         public static bool IsFixedCooldown => CustomRoles.Vampire.IsEnable();
         public static float RefixCooldownDelay = 0f;
         public static int BeforeFixMeetingCooldown = 10;
-        public static List<byte> IgnoreReportPlayers;
+        public static List<byte> AfterMeetingExilePlayers;
         public static List<byte> winnerList;
         public static List<(string, byte)> MessagesToSend;
         public static bool isChatCommand = false;
@@ -165,7 +165,7 @@ namespace TownOfHost
             hasArgumentException = false;
             ExceptionMessage = "";
 
-            Main.IgnoreReportPlayers = new List<byte>();
+            Main.AfterMeetingExilePlayers = new List<byte>();
             try
             {
 


### PR DESCRIPTION
ミーティング中の死亡処理を追放後に移動
- IgnoreReportPlayersをAfterMeetingExilePlayersに改名
- 死亡処理をWrapUpPostfixに移動

AutoMuteUsが上手く動かない可能性があるので要検証