### PR TITLE
会議時シェイプシフト中の名前になることがある

### DIFF
--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -190,7 +190,7 @@ namespace TownOfHost
         {
             Logger.Info("------------会議開始------------", "Phase");
             Main.witchMeeting = true;
-            Utils.NotifyRoles(isMeeting: true);
+            Utils.NotifyRoles(isMeeting: true, force: true);
             Main.witchMeeting = false;
             foreach (var pc in PlayerControl.AllPlayerControls)
             {

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -173,7 +173,12 @@ namespace TownOfHost
         public static void Postfix(ShipStatus __instance)
         {
             Utils.CustomSyncAllSettings();
-            new LateTask(() => Utils.NotifyRoles(), 0.1f, "RepairSystem NotifyRoles");
+            new LateTask(
+                () =>
+                {
+                    if (!GameStates.IsMeeting)
+                        Utils.NotifyRoles();
+                }, 0.1f, "RepairSystem NotifyRoles");
         }
         private static void CheckAndOpenDoorsRange(ShipStatus __instance, int amount, int min, int max)
         {


### PR DESCRIPTION
バグ ：シェイプシフト後の名前のまま会議に入る の対策

1．会議開始直前にシステムよりRepairSystemが呼ばれる。
これにより会議開始後にNotifyRolesを呼ぶLateTaskが作成され、
会議中の名前をタスク中の名前に書き換えてしまう。
※おそらくタイミングによって間に合う、間に合わないがある？
=>RepairSystemPatchのNotifyRolesを会議中は実行しないよう修正

２．会議開始時のNortifyRolesで第2ループが回らない
=>通信・計算コスト削減策ではあるが根本原因である可能性があるため
強制的に回すよう設定