### PR TITLE
Feature/ResetAbilityCooldownMethod

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -188,7 +188,7 @@ namespace TownOfHost
             else
             {
                 //targetがホスト以外だった場合
-                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.Reliable, -1/*target.GetClientId()*/);
+                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.None, -1/*target.GetClientId()*/);
                 writer.Write(0); //writer.WriteNetObject(null); と同じ
                 writer.Write(0);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -179,6 +179,7 @@ namespace TownOfHost
         public static void RpcResetAbilityCooldown(this PlayerControl target)
         {
             if (!AmongUsClient.Instance.AmHost) return; //ホスト以外が実行しても何も起こさない
+            Logger.Info($"アビリティクールダウンのリセット:{target.name}({target.PlayerId})", "RpcResetAbilityCooldown");
             if (PlayerControl.LocalPlayer == target)
             {
                 //targetがホストだった場合

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -176,6 +176,26 @@ namespace TownOfHost
             messageWriter.Write(colorId);
             AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
         }
+        public static void RpcResetAbilityCooldown(this PlayerControl target)
+        {
+            if (!AmongUsClient.Instance.AmHost) return; //ホスト以外が実行しても何も起こさない
+            if (PlayerControl.LocalPlayer == target)
+            {
+                //targetがホストだった場合
+                PlayerControl.LocalPlayer.Data.Role.SetCooldown();
+            }
+            else
+            {
+                //targetがホスト以外だった場合
+                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.Reliable, target.GetClientId());
+                writer.WriteNetObject(null);
+                writer.Write(0);
+                AmongUsClient.Instance.FinishRpcImmediately(writer);
+            }
+            /*  nullにバリアを張ろうとすると、アビリティーのクールダウンがリセットされてからnull参照で中断されます。
+                ホストに対しての場合、RPCを介さず直接クールダウンを書き換えています。
+                万が一他クライアントへの影響があった場合を考慮して、Desyncを使っています。*/
+        }
         public static byte GetRoleCount(this Dictionary<CustomRoles, byte> dic, CustomRoles role)
         {
             if (!dic.ContainsKey(role))

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -189,7 +189,7 @@ namespace TownOfHost
             {
                 //targetがホスト以外だった場合
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.Reliable, target.GetClientId());
-                writer.WriteNetObject(null);
+                writer.Write(0); //writer.WriteNetObject(null); と同じ
                 writer.Write(0);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
             }

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -188,14 +188,14 @@ namespace TownOfHost
             else
             {
                 //targetがホスト以外だった場合
-                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.None, -1/*target.GetClientId()*/);
+                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.None, target.GetClientId());
                 writer.Write(0); //writer.WriteNetObject(null); と同じ
                 writer.Write(0);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
             }
             /*  nullにバリアを張ろうとすると、アビリティーのクールダウンがリセットされてからnull参照で中断されます。
                 ホストに対しての場合、RPCを介さず直接クールダウンを書き換えています。
-            //  万が一他クライアントへの影響があった場合を考慮して、Desyncを使っています。*/
+                万が一他クライアントへの影響があった場合を考慮して、Desyncを使っています。*/
         }
         public static byte GetRoleCount(this Dictionary<CustomRoles, byte> dic, CustomRoles role)
         {

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -188,14 +188,14 @@ namespace TownOfHost
             else
             {
                 //targetがホスト以外だった場合
-                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.Reliable, target.GetClientId());
+                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.ProtectPlayer, SendOption.Reliable, -1/*target.GetClientId()*/);
                 writer.Write(0); //writer.WriteNetObject(null); と同じ
                 writer.Write(0);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
             }
             /*  nullにバリアを張ろうとすると、アビリティーのクールダウンがリセットされてからnull参照で中断されます。
                 ホストに対しての場合、RPCを介さず直接クールダウンを書き換えています。
-                万が一他クライアントへの影響があった場合を考慮して、Desyncを使っています。*/
+            //  万が一他クライアントへの影響があった場合を考慮して、Desyncを使っています。*/
         }
         public static byte GetRoleCount(this Dictionary<CustomRoles, byte> dic, CustomRoles role)
         {

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -119,6 +119,15 @@ namespace TownOfHost
                 Logger.isAlsoInGame = !Logger.isAlsoInGame;
                 Logger.SendInGame($"ログのゲーム内出力: {Logger.isAlsoInGame}");
             }
+            //RpcResetAbilityCooldownのテスト
+            if (Input.GetKey(KeyCode.R))
+            {
+                if (Input.GetKeyDown(KeyCode.Alpha0)) PlayerControl.LocalPlayer.RpcResetAbilityCooldown();
+                if (Input.GetKeyDown(KeyCode.Alpha1)) Utils.GetPlayerById(1)?.RpcResetAbilityCooldown();
+                if (Input.GetKeyDown(KeyCode.Alpha2)) Utils.GetPlayerById(2)?.RpcResetAbilityCooldown();
+                if (Input.GetKeyDown(KeyCode.Alpha3)) Utils.GetPlayerById(3)?.RpcResetAbilityCooldown();
+                if (Input.GetKeyDown(KeyCode.Alpha4)) Utils.GetPlayerById(4)?.RpcResetAbilityCooldown();
+            }
 
             //--以下フリープレイ用コマンド--//
             if (!GameStates.IsFreePlay) return;


### PR DESCRIPTION
[次期バージョン以降]
nullへのProtectPlayerによるアビリティークールダウンリセット関数を追加。
SendOption.Noneの革命がなかったら詰んでました。