### PR TITLE
MOD構成に異常がある場合の処理を追加

### DIFF
--- a/Modules/ModUpdater.cs
+++ b/Modules/ModUpdater.cs
@@ -92,6 +92,7 @@ namespace TownOfHost
     {
         public static bool running = false;
         public static bool hasUpdate = false;
+        public static bool isBroken = false;
         public static string updateURI = null;
         private static Task updateTask = null;
         public static string announcement = "";
@@ -194,6 +195,7 @@ namespace TownOfHost
             catch (System.Exception ex)
             {
                 Logger.Error(ex.ToString(), "ModUpdater");
+                isBroken = true;
             }
             return false;
         }

--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -25,7 +25,7 @@ namespace TownOfHost
     {
         public static void Postfix(MMOnlineManager __instance)
         {
-            if (!ModUpdater.hasUpdate) return;
+            if (!(ModUpdater.hasUpdate || ModUpdater.isBroken)) return;
             var obj = GameObject.Find("FindGameButton");
             if (obj)
             {
@@ -34,7 +34,9 @@ namespace TownOfHost
                 var textObj = Object.Instantiate<TMPro.TextMeshPro>(obj.transform.FindChild("Text_TMP").GetComponent<TMPro.TextMeshPro>());
                 textObj.transform.position = new Vector3(1f, -0.3f, 0);
                 textObj.name = "CanNotJoinPublic";
-                new LateTask(() => { textObj.text = $"<size=2><color=#ff0000>{GetString("CanNotJoinPublicRoomNoLatest")}</color></size>"; }, 0.01f, "CanNotJoinPublic");
+                var message = ModUpdater.isBroken ? $"<size=2><color=#ff0000>{GetString("ModBrokenMessage")}</color></size>"
+                    : $"<size=2><color=#ff0000>{GetString("CanNotJoinPublicRoomNoLatest")}</color></size>";
+                new LateTask(() => { textObj.text = message; }, 0.01f, "CanNotJoinPublic");
             }
         }
     }

--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -9,9 +9,12 @@ namespace TownOfHost
     {
         public static bool Prefix(GameStartManager __instance)
         {
-            if (ModUpdater.hasUpdate)
+            if (ModUpdater.isBroken || ModUpdater.hasUpdate)
             {
-                Logger.Info(GetString("onSetPublicNoLatest"), "MakePublicPatch");
+                var message = GetString("CanNotJoinPublicRoomNoLatest");
+                if (ModUpdater.isBroken) message = GetString("ModBrokenMessage");
+                Logger.Info(message, "MakePublicPatch");
+                Logger.SendInGame(message);
                 return false;
             }
             return true;

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -561,7 +561,7 @@ namespace TownOfHost
         {
             if (AmongUsClient.Instance.AmHost)
             {//実行クライアントがホストの場合のみ実行
-                if (GameStates.IsLobby && ModUpdater.hasUpdate && AmongUsClient.Instance.IsGamePublic)
+                if (GameStates.IsLobby && (ModUpdater.hasUpdate || ModUpdater.isBroken) && AmongUsClient.Instance.IsGamePublic)
                     AmongUsClient.Instance.ChangeGamePublic(false);
                 if (GameStates.IsInTask && CustomRoles.Vampire.IsEnable())
                 {

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -349,6 +349,7 @@ updateRestart,Update Finished!\nPlease restart the game.,アップデートが�
 updateFailed,Update failed.,アップデートに失敗しました。
 onSetPublicNoLatest,Public rooms cannot be made except for the latest version.\nPlease update.,最新版以外で公開ルームにはできません。\nアップデートをしてください。
 CanNotJoinPublicRoomNoLatest,Public rooms cannot join except for the latest version.\nPlease update.,最新版以外で公開ルームには参加できません。\nアップデートをしてください。
+ModBrokenMessage,The files comprising the MOD are corrupt.\nPlease re-install it again.,MODを構成するファイルが破損しています。\nもう一度導入しなおしてください。
 EnterVentToWin,Enter Vent to Win!!,ベントに入って勝利しろ!!
 FireworksPutPhase,Put {0} Fireworks,あと{0}個置け
 FireworksWaitPhase,Wait for that time...,時を待て...


### PR DESCRIPTION
MOD構成に問題がある場合、公開ルームの作成・参加が出来ないように処理を追加。
- オンライン画面にて再インストールを促す警告を表示。