### PR TITLE
Fix/ライター、スピードブースターでタスク完了しても能力発動しない

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -1148,9 +1148,17 @@ namespace TownOfHost
     {
         public static void Postfix(PlayerControl __instance)
         {
-            Logger.Info($"TaskComplete:{__instance.PlayerId}", "CompleteTask");
-            PlayerState.UpdateTask(__instance);
+            var pc = __instance;
+            Logger.Info($"TaskComplete:{pc.PlayerId}", "CompleteTask");
+            PlayerState.UpdateTask(pc);
             Utils.NotifyRoles();
+            if (pc.GetPlayerTaskState().IsTaskFinished &&
+                pc.GetCustomRole() is CustomRoles.Lighter or CustomRoles.SpeedBooster or CustomRoles.Doctor)
+            {
+                //ライターもしくはスピードブースターもしくはドクターがいる試合のみタスク終了時にCustomSyncSettingsを実行する
+                pc.CustomSyncSettings();
+            }
+
         }
     }
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.ProtectPlayer))]

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -1155,8 +1155,8 @@ namespace TownOfHost
             if (pc.GetPlayerTaskState().IsTaskFinished &&
                 pc.GetCustomRole() is CustomRoles.Lighter or CustomRoles.SpeedBooster or CustomRoles.Doctor)
             {
-                //ライターもしくはスピードブースターもしくはドクターがいる試合のみタスク終了時にCustomSyncSettingsを実行する
-                pc.CustomSyncSettings();
+                //ライターもしくはスピードブースターもしくはドクターがいる試合のみタスク終了時にCustomSyncAllSettingsを実行する
+                Utils.CustomSyncAllSettings();
             }
 
         }

--- a/Patches/RecomputeTaskPatch.cs
+++ b/Patches/RecomputeTaskPatch.cs
@@ -36,12 +36,6 @@ namespace TownOfHost
     {
         public static void Postfix(GameData __instance)
         {
-            if (!AmongUsClient.Instance.AmHost) return;
-
-            Utils.NotifyRoles();
-            foreach (var p in __instance.AllPlayers)
-                if (p.Object.GetCustomRole() == CustomRoles.Lighter || p.Object.Is(CustomRoles.SpeedBooster) || p.Object.Is(CustomRoles.Doctor))
-                    Utils.CustomSyncAllSettings();//ライターもしくはスピードブースターもしくはドクターがいる試合のみタスク終了時にCustomSyncAllSettingsを実行する
         }
     }
 }


### PR DESCRIPTION
TaskStateのカウントタイミングの問題で発動できていない
PlayerControl.CompleteTaskの中でタスクカウントしてるのでGameData.CompleteTaskの段階ではまだコンプリート判定にならない
=>PlayerControl.CompleteTaskの中でCustomSyncAllSettingsを実行する。