### PR TITLE
JapaneseRoleNameのデフォルト値をtrueに変更

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -117,9 +117,9 @@ namespace TownOfHost
             //Client Options
             HideCodes = Config.Bind("Client Options", "Hide Game Codes", false);
             HideName = Config.Bind("Client Options", "Hide Game Code Name", "Town Of Host");
-            HideColor = Config.Bind("Client Options", "Hide Game Code Color", $"{Main.modColor}");
+            HideColor = Config.Bind("Client Options", "Hide Game Code Color", $"{modColor}");
             ForceJapanese = Config.Bind("Client Options", "Force Japanese", false);
-            JapaneseRoleName = Config.Bind("Client Options", "Japanese Role Name", false);
+            JapaneseRoleName = Config.Bind("Client Options", "Japanese Role Name", true);
             Logger = BepInEx.Logging.Logger.CreateLogSource("TownOfHost");
             TownOfHost.Logger.Enable();
             TownOfHost.Logger.Disable("NotifyRoles");


### PR DESCRIPTION
作った理由としましては、
- ユーザーの大半が日本人である
- クライアントの言語が英語の時には強制的に英語になるからなにも困らない
- *JapaneseRoleNameが読めない人がいるかもしれない*
- *そもそも設定に気づかない人がいるかも*

です