### PR TITLE
Feature/EvilTracker

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -19,7 +19,8 @@ namespace TownOfHost
                 CustomRoles.TimeThief or
                 CustomRoles.Mafia or
                 CustomRoles.FireWorks or
-                CustomRoles.Sniper;
+                CustomRoles.Sniper or
+                CustomRoles.EvilTracker;
         }
         public static bool IsMadmate(this CustomRoles role)
         {

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -335,6 +335,13 @@ namespace TownOfHost
                         Main.AllPlayerKillCooldown[player.PlayerId] = Options.BHDefaultKillCooldown.GetFloat() / 2;//Mareのキルクールを÷2する
                     }
                     break;
+                case CustomRoles.EvilTracker:
+                    opt.RoleOptions.ShapeshifterDuration = 0.1f;
+                    if (Options.EvilTrackerCanSeeKillFlash.GetBool()) opt.KillFlashVision(player, PlayerState.isFlash[player.PlayerId]);
+                    break;
+                case CustomRoles.Seer:
+                    opt.KillFlashVision(player, PlayerState.isFlash[player.PlayerId]);
+                    break;
 
 
                 InfinityVent:

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -492,9 +492,10 @@ namespace TownOfHost
         {
             if (pc == null) return;
             int clientId = pc.GetClientId();
-
+            Logger.Info($"{pc}", "ReactorFlash");
             byte reactorId = 3;
             if (PlayerControl.GameOptions.MapId == 2) reactorId = 21;
+            float FlashDuration = Options.KillFlashDuration.GetFloat();
 
             new LateTask(() =>
             {
@@ -512,7 +513,7 @@ namespace TownOfHost
                 MessageExtensions.WriteNetObject(SabotageFixWriter, pc);
                 SabotageFixWriter.Write((byte)16);
                 AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
-            }, 0.4f + delay, "Fix Desync Reactor");
+            }, FlashDuration + delay, "Fix Desync Reactor");
 
             if (PlayerControl.GameOptions.MapId == 4) //Airship用
                 new LateTask(() =>
@@ -522,7 +523,7 @@ namespace TownOfHost
                     MessageExtensions.WriteNetObject(SabotageFixWriter, pc);
                     SabotageFixWriter.Write((byte)17);
                     AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
-                }, 0.4f + delay, "Fix Desync Reactor 2");
+                }, FlashDuration + delay, "Fix Desync Reactor 2");
         }
 
         public static string GetRealName(this PlayerControl player, bool isMeeting = false)

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -488,6 +488,42 @@ namespace TownOfHost
                     AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
                 }, 0.4f + delay, "Fix Desync Reactor 2");
         }
+        public static void ReactorFlash(this PlayerControl pc, float delay = 0f)
+        {
+            if (pc == null) return;
+            int clientId = pc.GetClientId();
+
+            byte reactorId = 3;
+            if (PlayerControl.GameOptions.MapId == 2) reactorId = 21;
+
+            new LateTask(() =>
+            {
+                MessageWriter SabotageWriter = AmongUsClient.Instance.StartRpcImmediately(ShipStatus.Instance.NetId, (byte)RpcCalls.RepairSystem, SendOption.Reliable, clientId);
+                SabotageWriter.Write(reactorId);
+                MessageExtensions.WriteNetObject(SabotageWriter, pc);
+                SabotageWriter.Write((byte)128);
+                AmongUsClient.Instance.FinishRpcImmediately(SabotageWriter);
+            }, 0f + delay, "Reactor Desync");
+
+            new LateTask(() =>
+            {
+                MessageWriter SabotageFixWriter = AmongUsClient.Instance.StartRpcImmediately(ShipStatus.Instance.NetId, (byte)RpcCalls.RepairSystem, SendOption.Reliable, clientId);
+                SabotageFixWriter.Write(reactorId);
+                MessageExtensions.WriteNetObject(SabotageFixWriter, pc);
+                SabotageFixWriter.Write((byte)16);
+                AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
+            }, 0.4f + delay, "Fix Desync Reactor");
+
+            if (PlayerControl.GameOptions.MapId == 4) //Airship用
+                new LateTask(() =>
+                {
+                    MessageWriter SabotageFixWriter = AmongUsClient.Instance.StartRpcImmediately(ShipStatus.Instance.NetId, (byte)RpcCalls.RepairSystem, SendOption.Reliable, clientId);
+                    SabotageFixWriter.Write(reactorId);
+                    MessageExtensions.WriteNetObject(SabotageFixWriter, pc);
+                    SabotageFixWriter.Write((byte)17);
+                    AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
+                }, 0.4f + delay, "Fix Desync Reactor 2");
+        }
 
         public static string GetRealName(this PlayerControl player, bool isMeeting = false)
         {

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -357,11 +357,11 @@ namespace TownOfHost
                     }
                     break;
                 case CustomRoles.EvilTracker:
-                    opt.RoleOptions.ShapeshifterDuration = 0.1f;
-                    if (Options.EvilTrackerCanSeeKillFlash.GetBool()) opt.KillFlashVision(player, PlayerState.isFlash[player.PlayerId]);
+                    opt.RoleOptions.ShapeshifterDuration = 1f;
+                    if (Options.EvilTrackerCanSeeKillFlash.GetBool()) opt.BlackOut(player, PlayerState.IsBlackOut[player.PlayerId]);
                     break;
                 case CustomRoles.Seer:
-                    opt.KillFlashVision(player, PlayerState.isFlash[player.PlayerId]);
+                    opt.BlackOut(player, PlayerState.IsBlackOut[player.PlayerId]);
                     break;
 
 

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -15,7 +15,7 @@ namespace TownOfHost
         {
             players = new();
             isDead = new();
-            isFlash = new();
+            IsBlackOut = new();
             deathReasons = new();
             taskState = new();
 
@@ -23,7 +23,7 @@ namespace TownOfHost
             {
                 players.Add(p.PlayerId);
                 isDead.Add(p.PlayerId, false);
-                isFlash.Add(p.PlayerId, false);
+                IsBlackOut.Add(p.PlayerId, false);
                 deathReasons.Add(p.PlayerId, DeathReason.etc);
                 taskState.Add(p.PlayerId, new());
             }
@@ -33,7 +33,7 @@ namespace TownOfHost
         public static Dictionary<byte, bool> isDead = new();
         public static Dictionary<byte, DeathReason> deathReasons = new();
         public static Dictionary<byte, TaskState> taskState = new();
-        public static Dictionary<byte, bool> isFlash = new();
+        public static Dictionary<byte, bool> IsBlackOut = new();
         public static void SetDeathReason(byte p, DeathReason reason) { deathReasons[p] = reason; }
         public static DeathReason GetDeathReason(byte p) { return deathReasons.TryGetValue(p, out var reason) ? reason : DeathReason.etc; }
         public static void SetDead(byte p)

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -15,6 +15,7 @@ namespace TownOfHost
         {
             players = new();
             isDead = new();
+            isFlash = new();
             deathReasons = new();
             taskState = new();
 
@@ -22,6 +23,7 @@ namespace TownOfHost
             {
                 players.Add(p.PlayerId);
                 isDead.Add(p.PlayerId, false);
+                isFlash.Add(p.PlayerId, false);
                 deathReasons.Add(p.PlayerId, DeathReason.etc);
                 taskState.Add(p.PlayerId, new());
             }
@@ -31,6 +33,7 @@ namespace TownOfHost
         public static Dictionary<byte, bool> isDead = new();
         public static Dictionary<byte, DeathReason> deathReasons = new();
         public static Dictionary<byte, TaskState> taskState = new();
+        public static Dictionary<byte, bool> isFlash = new();
         public static void SetDeathReason(byte p, DeathReason reason) { deathReasons[p] = reason; }
         public static DeathReason GetDeathReason(byte p) { return deathReasons.TryGetValue(p, out var reason) ? reason : DeathReason.etc; }
         public static void SetDead(byte p)

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -113,6 +113,9 @@ namespace TownOfHost
         public static CustomOption SchrodingerCatExiledTeamChanges;
         public static CustomOption ExecutionerCanTargetImpostor;
         public static CustomOption ExecutionerChangeRolesAfterTargetKilled;
+        public static CustomOption EvilTrackerCanSeeKillFlash;
+        public static CustomOption EvilTrackerResetTargetAfterMeeting;
+        public static CustomOption KillFlashDuration;
 
         // HideAndSeek
         public static CustomOption AllowCloseDoors;
@@ -269,10 +272,14 @@ namespace TownOfHost
             SetupRoleOptions(2400, CustomRoles.TimeThief);
             TimeThiefDecreaseDiscussionTime = CustomOption.Create(2410, Color.white, "TimeThiefDecreaseDiscussionTime", 1, 0, 100, 1, CustomRoleSpawnChances[CustomRoles.TimeThief]);
             TimeThiefDecreaseVotingTime = CustomOption.Create(2411, Color.white, "TimeThiefDecreaseVotingTime", 1, 0, 100, 1, CustomRoleSpawnChances[CustomRoles.TimeThief]);
+            SetupRoleOptions(2900, CustomRoles.EvilTracker);
+            EvilTrackerCanSeeKillFlash = CustomOption.Create(2910, Color.white, "EvilTrackerCanSeeKillFlash", true, CustomRoleSpawnChances[CustomRoles.EvilTracker]);
+            EvilTrackerResetTargetAfterMeeting = CustomOption.Create(2910, Color.white, "EvilTrackerResetTargetAfterMeeting", true, CustomRoleSpawnChances[CustomRoles.EvilTracker]);
 
             BHDefaultKillCooldown = CustomOption.Create(5010, Color.white, "BHDefaultKillCooldown", 30, 1, 999, 1, null, true);
             DefaultShapeshiftCooldown = CustomOption.Create(5011, Color.white, "DefaultShapeshiftCooldown", 15, 5, 999, 5, null, true);
             CanMakeMadmateCount = CustomOption.Create(5012, Color.white, "CanMakeMadmateCount", 1, 0, 15, 1, null, true);
+            KillFlashDuration = CustomOption.Create(5013, Color.white, "KillFlashDuration", 0.2f, 0.05f, 0.45f, 0.05f, null, true);
 
             // Madmate
             SetupRoleOptions(10000, CustomRoles.Madmate);
@@ -332,6 +339,8 @@ namespace TownOfHost
             SetupRoleOptions(20800, CustomRoles.Trapper);
             TrapperBlockMoveTime = CustomOption.Create(20810, Color.white, "TrapperBlockMoveTime", 5f, 1f, 180, 1, CustomRoleSpawnChances[CustomRoles.Trapper]);
             SetupRoleOptions(20900, CustomRoles.Dictator);
+            SetupRoleOptions(21000, CustomRoles.Seer);
+
             // Neutral
             SetupRoleOptions(50500, CustomRoles.Arsonist);
             ArsonistDouseTime = CustomOption.Create(50510, Color.white, "ArsonistDouseTime", 3, 1, 10, 1, CustomRoleSpawnChances[CustomRoles.Arsonist]);

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -279,7 +279,7 @@ namespace TownOfHost
             BHDefaultKillCooldown = CustomOption.Create(5010, Color.white, "BHDefaultKillCooldown", 30, 1, 999, 1, null, true);
             DefaultShapeshiftCooldown = CustomOption.Create(5011, Color.white, "DefaultShapeshiftCooldown", 15, 5, 999, 5, null, true);
             CanMakeMadmateCount = CustomOption.Create(5012, Color.white, "CanMakeMadmateCount", 0, 0, 15, 1, null, true);
-            KillFlashDuration = CustomOption.Create(5013, Color.white, "KillFlashDuration", 0.2f, 0.05f, 0.45f, 0.05f, null, true);
+            KillFlashDuration = CustomOption.Create(5013, Color.white, "KillFlashDuration", 0.2f, 0.1f, 0.45f, 0.05f, null, true);
 
             // Madmate
             SetupRoleOptions(10000, CustomRoles.Madmate);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -65,24 +65,24 @@ namespace TownOfHost
         {
             // Logger.Info(player.GetRealName(), "KillFlash");
             // Logger.Info(ForImpVision ? "true" : "false", "ForImpVision");
-            PlayerState.isFlash[player.PlayerId] = true;
+            PlayerState.IsBlackOut[player.PlayerId] = true;
             ExtendedPlayerControl.CustomSyncSettings(player);
             int Duration = (int)Math.Ceiling(Options.KillFlashDuration.GetFloat() * 1000);
             await Task.Delay(Duration); //キルフラッシュの時間
-            PlayerState.isFlash[player.PlayerId] = false;
+            PlayerState.IsBlackOut[player.PlayerId] = false;
             ExtendedPlayerControl.CustomSyncSettings(player);
         }
-        public static void KillFlashVision(this GameOptionsData opt, PlayerControl player, bool IsFlash)
+        public static void BlackOut(this GameOptionsData opt, PlayerControl player, bool IsBlackOut)
         {
-            Logger.Info($"{opt.ImpostorLightMod}/{opt.CrewLightMod}", "before");
+            // Logger.Info($"{opt.ImpostorLightMod}/{opt.CrewLightMod}", "before");
             opt.ImpostorLightMod = Main.DefaultImpostorVision;
             opt.CrewLightMod = Main.DefaultCrewmateVision;
-            if (IsFlash)
+            if (IsBlackOut)
             {
                 opt.ImpostorLightMod = 0.0f;
-                opt.CrewLightMod = 0.0f; //5.0fだと落ちる
+                opt.CrewLightMod = 0.0f;
             }
-            Logger.Info($"{opt.ImpostorLightMod}/{opt.CrewLightMod}", "after");
+            // Logger.Info($"{opt.ImpostorLightMod}/{opt.CrewLightMod}", "after");
             return;
         }
         public static string GetOnOff(bool value) => value ? "ON" : "OFF";

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -66,6 +66,7 @@ namespace TownOfHost
             // Logger.Info(player.GetRealName(), "KillFlash");
             // Logger.Info(ForImpVision ? "true" : "false", "ForImpVision");
             PlayerState.IsBlackOut[player.PlayerId] = true;
+            player.ReactorFlash(0f);
             ExtendedPlayerControl.CustomSyncSettings(player);
             int Duration = (int)Math.Ceiling(Options.KillFlashDuration.GetFloat() * 1000);
             await Task.Delay(Duration); //キルフラッシュの時間

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -64,19 +64,6 @@ namespace TownOfHost
                 return;
             }
         }
-        public static bool KillFlashCheck(PlayerControl killer, PlayerControl target, PlayerControl seer, PlayerState.DeathReason deathReason)
-        {
-            if (seer.Data.IsDead || killer == seer || target == seer) return false;
-            switch (seer.GetCustomRole())
-            {
-                case CustomRoles.EvilTracker:
-                    return Options.EvilTrackerCanSeeKillFlash.GetBool();
-                case CustomRoles.Seer:
-                    return true;
-                default:
-                    return false;
-            }
-        }
         //誰かが死亡したときのメソッド
         public static void TargetDies(PlayerControl killer, PlayerControl target, PlayerState.DeathReason deathReason)
         {
@@ -89,6 +76,19 @@ namespace TownOfHost
             {
                 if (KillFlashCheck(killer, target, seer, deathReason) == false) continue;
                 Main.RealOptionsData.DeepCopy().KillFlash(seer);
+            }
+        }
+        public static bool KillFlashCheck(PlayerControl killer, PlayerControl target, PlayerControl seer, PlayerState.DeathReason deathReason)
+        {
+            if (seer.Data.IsDead || killer == seer || target == seer) return false;
+            switch (seer.GetCustomRole())
+            {
+                case CustomRoles.EvilTracker:
+                    return Options.EvilTrackerCanSeeKillFlash.GetBool();
+                case CustomRoles.Seer:
+                    return true;
+                default:
+                    return false;
             }
         }
         public static async void KillFlash(this GameOptionsData opt, PlayerControl player)

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -184,6 +184,7 @@ namespace TownOfHost
                 //Impostor役職
                 { (CustomRoles)(-1),"== Impostor ==" }, //区切り用
                 { CustomRoles.BountyHunter,"bo" },
+                { CustomRoles.EvilTracker,"et" },
                 { CustomRoles.FireWorks,"fw" },
                 { CustomRoles.Mafia,"mf" },
                 { CustomRoles.SerialKiller,"sk" },
@@ -211,6 +212,7 @@ namespace TownOfHost
                 { CustomRoles.Lighter,"li" },
                 { CustomRoles.Mayor,"my" },
                 { CustomRoles.SabotageMaster,"sa" },
+                { CustomRoles.Seer,"se" },
                 { CustomRoles.Sheriff,"sh" },
                 { CustomRoles.Snitch,"sn" },
                 { CustomRoles.SpeedBooster,"sb" },

--- a/Patches/TaskAdderPatch.cs
+++ b/Patches/TaskAdderPatch.cs
@@ -107,6 +107,7 @@ namespace TownOfHost
             { CustomRoles.Mare, RoleTypes.Impostor },
             { CustomRoles.Doctor, RoleTypes.Scientist },
             { CustomRoles.TimeThief, RoleTypes.Impostor },
+            { CustomRoles.EvilTracker, RoleTypes.Shapeshifter },
         };
         public static bool Prefix(TaskAddButton __instance)
         {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -58,6 +58,8 @@ namespace TownOfHost
 
             Main.DiscussionTime = Main.RealOptionsData.DiscussionTime;
             Main.VotingTime = Main.RealOptionsData.VotingTime;
+            Main.DefaultCrewmateVision = Main.RealOptionsData.CrewLightMod;
+            Main.DefaultImpostorVision = Main.RealOptionsData.ImpostorLightMod;
 
             NameColorManager.Instance.RpcReset();
             Main.LastNotifyNames = new();
@@ -127,7 +129,7 @@ namespace TownOfHost
                 roleOpt.SetRoleRate(RoleTypes.Engineer, EngineerNum + AdditionalEngineerNum, AdditionalEngineerNum > 0 ? 100 : roleOpt.GetChancePerGame(RoleTypes.Engineer));
 
                 int ShapeshifterNum = roleOpt.GetNumPerGame(RoleTypes.Shapeshifter);
-                int AdditionalShapeshifterNum = CustomRoles.Mafia.GetCount() + CustomRoles.SerialKiller.GetCount() + CustomRoles.BountyHunter.GetCount() + CustomRoles.Warlock.GetCount() + CustomRoles.ShapeMaster.GetCount() + CustomRoles.FireWorks.GetCount() + CustomRoles.Sniper.GetCount();//- ShapeshifterNum;
+                int AdditionalShapeshifterNum = CustomRoles.Mafia.GetCount() + CustomRoles.SerialKiller.GetCount() + CustomRoles.BountyHunter.GetCount() + CustomRoles.Warlock.GetCount() + CustomRoles.ShapeMaster.GetCount() + CustomRoles.FireWorks.GetCount() + CustomRoles.Sniper.GetCount() + CustomRoles.EvilTracker.GetCount();//- ShapeshifterNum;
                 if (Main.RealOptionsData.NumImpostors > 1)
                     AdditionalShapeshifterNum += CustomRoles.Egoist.GetCount();
                 roleOpt.SetRoleRate(RoleTypes.Shapeshifter, ShapeshifterNum + AdditionalShapeshifterNum, AdditionalShapeshifterNum > 0 ? 100 : roleOpt.GetChancePerGame(RoleTypes.Shapeshifter));
@@ -307,6 +309,8 @@ namespace TownOfHost
                 AssignCustomRolesFromList(CustomRoles.Doctor, Scientists);
                 AssignCustomRolesFromList(CustomRoles.Puppeteer, Impostors);
                 AssignCustomRolesFromList(CustomRoles.TimeThief, Impostors);
+                AssignCustomRolesFromList(CustomRoles.EvilTracker, Shapeshifters);
+                AssignCustomRolesFromList(CustomRoles.Seer, Crewmates);
 
                 //RPCによる同期
                 foreach (var pc in PlayerControl.AllPlayerControls)
@@ -419,7 +423,7 @@ namespace TownOfHost
                 roleOpt.SetRoleRate(RoleTypes.Engineer, EngineerNum, roleOpt.GetChancePerGame(RoleTypes.Engineer));
 
                 int ShapeshifterNum = roleOpt.GetNumPerGame(RoleTypes.Shapeshifter);
-                ShapeshifterNum -= CustomRoles.Mafia.GetCount() + CustomRoles.SerialKiller.GetCount() + CustomRoles.BountyHunter.GetCount() + CustomRoles.Warlock.GetCount() + CustomRoles.ShapeMaster.GetCount() + CustomRoles.FireWorks.GetCount() + CustomRoles.Sniper.GetCount();
+                ShapeshifterNum -= CustomRoles.Mafia.GetCount() + CustomRoles.SerialKiller.GetCount() + CustomRoles.BountyHunter.GetCount() + CustomRoles.Warlock.GetCount() + CustomRoles.ShapeMaster.GetCount() + CustomRoles.FireWorks.GetCount() + CustomRoles.Sniper.GetCount() + CustomRoles.EvilTracker.GetCount();
                 if (Main.RealOptionsData.NumImpostors > 1)
                     ShapeshifterNum -= CustomRoles.Egoist.GetCount();
                 roleOpt.SetRoleRate(RoleTypes.Shapeshifter, ShapeshifterNum, roleOpt.GetChancePerGame(RoleTypes.Shapeshifter));

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -26,6 +26,7 @@ EvilWatcher,Evil Watcher,イビルウォッチャー
 Puppeteer,Puppeteer,パペッティア
 TimeThief,TimeThief,タイムシーフ
 Sniper,Sniper,スナイパー
+EvilTracker,EvilTracker,イビルトラッカー
 
 # マッドメイト系役職
 Madmate,Madmate,マッドメイト
@@ -49,6 +50,7 @@ SpeedBooster,SpeedBooster,スピードブースター
 Doctor,Doctor,ドクター
 Trapper,Trapper,トラッパー
 Dictator,Dictator,ディクテーター
+Seer,Seer,シーア
 
 # 第三陣営役職
 Jester,Jester,ジェスター
@@ -90,6 +92,7 @@ AfterMafiaInfo,Kill all Crewmates,サボを活用して皆殺しにしよう
 PuppeteerInfo,Manipulate your enemies and kill all Crewmates,敵を操って皆殺しにしよう
 TimeThiefInfo,Let's kill the enemies and take away meeting time,敵を殺し、会議時間を奪おう
 SniperInfo,I'll shoot,狙い撃つぜ
+EvilTrackerInfo,Track Players,追跡せよ
 
 # マッドメイト系役職
 MadmateInfo,Help the Impostors,インポスターの援助をしよう
@@ -111,6 +114,7 @@ SpeedBoosterInfo,Let's them run.,走らせろ
 DoctorInfo,Thus They Died,斯くして奴は死んだ
 TrapperInfo,Trap your enemies,敵を罠にはめよう
 DictatorInfo,Let's have a dictatorship,独裁政治をしよう
+SeerInfo,You Will See Players Die.,死が見える
 
 # 第三陣営役職
 ArsonistInfo,Let them burn,燃やせ
@@ -145,6 +149,7 @@ MafiaInfoLong,"(Impostors):\nInitially, the kill is blocked.\nAfter all of his f
 PuppeteerInfoLong,"(Impostors):\nIt allows the target of the kill to kill the next Crewmate that the target approaches.\nIf the target is the one that is triggered at the moment the target is killed, the effect is reflected on the target.\nIt is not possible to perform a normal kill.",(インポスター陣営):\nキルした対象に、対象が次に近づいたクルーをキルさせる事ができる。\n対象がキルした相手がキルされた瞬間に発動するものであった場合、対象にその効果が反映される。\n普通のキルを行うことはできない。
 TimeThiefInfoLong,"(Impostors):\nEach kill decreases the meeting time.\nIf the time thief is exiled or killed, the lost meeting time is returned.",(インポスター陣営):\nキルを行うと会議時間が減少する。\nタイムシーフが追放または殺害されると、失われた会議時間が返ってきます。
 SniperInfoLong,"(Impostors):\nSniper distant enemies.\nShoot one enemy on the extension of the point released from the shapeshifted point.\nYou can't kill until you shoot all bullet.",(インポスター陣営):\n遠くの敵を狙撃できるインポスター。\nシェイプシフトした地点から解除した地点の延長線上の敵を一人撃ち抜く。\n撃ちきるまで通常キル出来ない。
+EvilTrackerInfoLong,"(Impostors):\nSniper distant enemies.\nShoot one enemy on the extension of the point released from the shapeshifted point.\nYou can't kill until you shoot all bullet.",(インポスター陣営):\n遠くの敵を狙撃できるインポスター。\nシェイプシフトした地点から解除した地点の延長線上の敵を一人撃ち抜く。\n撃ちきるまで通常キル出来ない。
 
 # マッドメイト系役職
 MadmateInfoLong,"(Impostors):\nCrewmate, but they take the side of the Impostor.\nImpostor and are unrecognizable to each other. Can use vent, no tasks.",(インポスター陣営):\nクルーだがインポスターの味方をする。\nインポスターと互いに認識できない。\nベントが使え、タスクはない。
@@ -167,6 +172,7 @@ SpeedBoosterInfoLong,"(Crewmates):Finishing the task can speed up a random alive
 DoctorInfoLong,"(Crewmates):\nYou can know why players died.\nAnd you can use vitals anywhere with gadget charges.",(クルーメイト陣営):\nプレイヤーの死因を知ることができる。\nまた、充電がある限りどこでもバイタルを確認できる。
 TrapperInfoLong,"(Crewmates):\nIf you killed, the killed player can be immobile for a few seconds. (with settings)",(クルーメイト陣営):\nキルされると、キルした人を数秒間移動不可にすることができる。(設定有)
 DictatorInfoLong,"(Crewmates):\nIf you vote for someone during the meeting, you can force the meeting to end and hang the person you are voting for.\nThe dictator dies at the time of the vote.",(クルーメイト陣営):\n会議中に誰かに投票をすると、会議を強制終了させて投票先を吊る事ができる。\n投票したタイミングでディクテーターは死ぬ。
+SeerInfoLong,,
 
 # 第三陣営役職
 ArsonistInfoLong,"(Neutrals):\nWhen Arsonist tries to use kill button, he varnish oil to crewmates. \nWhen he finish varnishing to all crewmates, he burn the ship and win.",(第三陣営):\nキルボタンを使おうとすると、ターゲットに油を塗れる。\nすべてのクルーに油を塗ったら船を燃やして勝利する。
@@ -291,6 +297,9 @@ SniperPrecisionShooting,Sniper Precision Shooting,スナイパー精密射撃モ
 NumberOfLovers,"Number Of Lovers(x2members)",ラバーズの組数(x2人数)
 TimeThiefDecreaseDiscussionTime,TimeThief Decrease DiscussionTime,減少する議論タイム
 TimeThiefDecreaseVotingTime,TimeThief Decrease VotingTime,減少する投票タイム
+EvilTrackerCanSeeKillFlash,EvilTracker Can See KillFlash,キルフラッシュを見ることができる
+EvilTrackerResetTargetAfterMeeting,EvilTracker Reset Target After Meeting,会議後に再度ターゲットを設定できる
+KillFlashDuration,KillFlash Duration(s),キルフラッシュの長さ(秒)
 
 ## かくれんぼ設定
 HideAndSeekOptions,HideAndSeek Options,かくれんぼの設定

--- a/main.cs
+++ b/main.cs
@@ -86,6 +86,7 @@ namespace TownOfHost
         public static Dictionary<byte, byte> SpeedBoostTarget = new();
         public static Dictionary<byte, int> MayorUsedButtonCount = new();
         public static Dictionary<byte, int> TimeThiefKillCount = new();
+        public static Dictionary<byte, PlayerControl> EvilTrackerTarget;
         public static int AliveImpostorCount;
         public static int SKMadmateNowCount;
         public static bool witchMeeting;
@@ -104,6 +105,8 @@ namespace TownOfHost
         public static bool introDestroyed = false;
         public static int DiscussionTime;
         public static int VotingTime;
+        public static float DefaultCrewmateVision;
+        public static float DefaultImpostorVision;
 
         public static Main Instance;
 
@@ -147,6 +150,7 @@ namespace TownOfHost
             ArsonistTimer = new Dictionary<byte, (PlayerControl, float)>();
             ExecutionerTarget = new Dictionary<byte, byte>();
             MayorUsedButtonCount = new Dictionary<byte, int>();
+            EvilTrackerTarget = new Dictionary<byte, PlayerControl>();
             winnerList = new();
             VisibleTasksCount = false;
             MessagesToSend = new List<(string, byte)>();
@@ -191,6 +195,7 @@ namespace TownOfHost
                 {CustomRoles.FireWorks, "#ff0000"},
                 {CustomRoles.TimeThief, "#ff0000"},
                 {CustomRoles.Sniper, "#ff0000"},
+                {CustomRoles.EvilTracker, "#ff0000"},
                 //マッドメイト系役職
                 {CustomRoles.Madmate, "#ff0000"},
                 {CustomRoles.SKMadmate, "#ff0000"},
@@ -212,6 +217,8 @@ namespace TownOfHost
                 {CustomRoles.Trapper, "#5a8fd0"},
                 {CustomRoles.Dictator, "#df9b00"},
                 {CustomRoles.CSchrodingerCat, "#ffffff"}, //シュレディンガーの猫の派生
+                {CustomRoles.Seer, "#3CB564"},
+
                 //第三陣営役職
                 {CustomRoles.Arsonist, "#ff6633"},
                 {CustomRoles.Jester, "#ec62a5"},
@@ -279,6 +286,7 @@ namespace TownOfHost
         Mare,
         Puppeteer,
         TimeThief,
+        EvilTracker,
         //Madmate
         MadGuardian,
         Madmate,
@@ -303,6 +311,7 @@ namespace TownOfHost
         Trapper,
         Dictator,
         Doctor,
+        Seer,
         CSchrodingerCat,//クルー陣営のシュレディンガーの猫
         //Neutral
         Arsonist,


### PR DESCRIPTION
インポスター役職　EvilTracker/イビルトラッカー

・シェイプシフター判定
・能力
　①味方インポスターの方向が常に分かる
　②味方インポスターによるキルのキルフラッシュが見える
　③シェイプシフトで選んだ相手の方向が分かる

②の「味方インポスターによるキル」条件と③はまだ作ってませんが、キルフラッシュのメソッドを作ったので共有も兼ねて送ります。
キルフラッシュはタスクフェーズ中に第三者が死んだ時に、設定した時間(0.1~0.4秒)だけ視界が0になり(ブラックアウト)、リアクター中でなければブラックアウトと同時に同じ時間だけリアクターが鳴る(リアクターフラッシュ)仕様にしています。

キルフラッシュ検証のため、キルフラッシュが見えるクルー役職として「Seer/シーア」を作っています。