### PR TITLE
Feature/NumCommonTasks

### DIFF
--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -475,7 +475,7 @@ namespace TownOfHost
             public CustomRoles Role { get; private set; }
             public int IdStart { get; private set; }
             public CustomOption doOverride;
-            public CustomOption assignCommonTasks;
+            public CustomOption numCommonTasks;
             public CustomOption numLongTasks;
             public CustomOption numShortTasks;
 
@@ -485,7 +485,7 @@ namespace TownOfHost
                 this.Role = role;
                 Dictionary<string, string> replacementDic = new() { { "%role%", Utils.GetRoleName(role) } };
                 doOverride = CustomOption.Create(idStart++, Color.white, "doOverride", false, CustomRoleSpawnChances[role], false, false, "", replacementDic);
-                assignCommonTasks = CustomOption.Create(idStart++, Color.white, "assignCommonTasks", true, doOverride, false, false, "", replacementDic);
+                numCommonTasks = CustomOption.Create(idStart++, Color.white, "roleCommonTasksNum", 2, 0, 99, 1, doOverride, false, false, "", replacementDic);
                 numLongTasks = CustomOption.Create(idStart++, Color.white, "roleLongTasksNum", 3, 0, 99, 1, doOverride, false, false, "", replacementDic);
                 numShortTasks = CustomOption.Create(idStart++, Color.white, "roleShortTasksNum", 3, 0, 99, 1, doOverride, false, false, "", replacementDic);
 

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -394,6 +394,6 @@ GameMode,GameMode,ゲームモード
 PressTabToNextPage,Press Tab To Next Page...,Tabキーを押して次のページへ...
 RoleSummaryText,"Players and roles at the end of the game:",ゲーム終了時の役職一覧:
 doOverride,Override %role%'s Tasks,%role%のタスクを上書きする
-assignCommonTasks,Assign Common Tasks For %role%,%role%に通常タスクを割り当てる
+roleCommonTasksNum,Amount Of Common Tasks For %role%,%role%の通常タスクの数
 roleLongTasksNum,Amount Of Long Tasks For %role%,%role%のロングタスクの数
 roleShortTasksNum,Amount Of Short Tasks For %role%,%role%のショートタスクの数


### PR DESCRIPTION
スニッチ、テロリストなどのタスク数の上書き設定で、通常タスクもショートやロングと同様に数を設定できるようにしました。
タスク表示や能力のトリガーなどの問題は確認していません。