### PR TITLE
Feature/ArsonistDousingFix

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -433,10 +433,17 @@ namespace TownOfHost
         }
         public static void SetCurrentDousingTarget(byte arsonistId, byte targetId)
         {
-            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetCurrentDousingTarget, Hazel.SendOption.Reliable, -1);
-            writer.Write(arsonistId);
-            writer.Write(targetId);
-            AmongUsClient.Instance.FinishRpcImmediately(writer);
+            if (PlayerControl.LocalPlayer.PlayerId == arsonistId)
+            {
+                Main.currentDousingTarget = targetId;
+            }
+            else
+            {
+                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetCurrentDousingTarget, Hazel.SendOption.Reliable, -1);
+                writer.Write(arsonistId);
+                writer.Write(targetId);
+                AmongUsClient.Instance.FinishRpcImmediately(writer);
+            }
         }
         public static void ResetCurrentDousingTarget(byte arsonistId) => SetCurrentDousingTarget(arsonistId, 255);
     }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -431,6 +431,14 @@ namespace TownOfHost
             writer.Write(Key);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
+        public static void SetCurrentDousingTarget(byte arsonistId, byte targetId)
+        {
+            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetCurrentDousingTarget, Hazel.SendOption.Reliable, -1);
+            writer.Write(arsonistId);
+            writer.Write(targetId);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+        }
+        public static void ResetCurrentDousingTarget(byte arsonistId) => SetCurrentDousingTarget(arsonistId, 255);
     }
     [HarmonyPatch(typeof(InnerNet.InnerNetClient), nameof(InnerNet.InnerNetClient.StartRpc))]
     class StartRpcPatch

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -35,6 +35,7 @@ namespace TownOfHost
         SetExecutionerTarget,
         RemoveExecutionerTarget,
         SendFireWorksState,
+        SetCurrentDousingTarget,
     }
     public enum Sounds
     {
@@ -206,6 +207,12 @@ namespace TownOfHost
                     break;
                 case CustomRPC.SendFireWorksState:
                     FireWorks.ReceiveRPC(reader);
+                    break;
+                case CustomRPC.SetCurrentDousingTarget:
+                    byte arsonistId = reader.ReadByte();
+                    byte dousingTargetId = reader.ReadByte();
+                    if (PlayerControl.LocalPlayer.PlayerId == arsonistId)
+                        Main.currentDousingTarget = dousingTargetId;
                     break;
             }
         }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -632,7 +632,8 @@ namespace TownOfHost
                             }
                             if (
                                 Main.ArsonistTimer.TryGetValue(seer.PlayerId, out var ar_kvp) && //seerがオイルを塗っている途中(現在進行)
-                                ar_kvp.Item1 == target //オイルを塗っている対象がtarget
+                                ar_kvp.Item1 == target && //オイルを塗っている対象がtarget
+                                ar_kvp.Item2 > 0.5f //0.5秒以上オイルを塗り続けている(負荷軽減)
                             )
                             {
                                 TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>...</color>";

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -632,8 +632,7 @@ namespace TownOfHost
                             }
                             if (
                                 Main.ArsonistTimer.TryGetValue(seer.PlayerId, out var ar_kvp) && //seerがオイルを塗っている途中(現在進行)
-                                ar_kvp.Item1 == target && //オイルを塗っている対象がtarget
-                                ar_kvp.Item2 > 0.5f //0.5秒以上オイルを塗り続けている(負荷軽減)
+                                ar_kvp.Item1 == target //オイルを塗っている対象がtarget
                             )
                             {
                                 TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>...</color>";

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -630,13 +630,6 @@ namespace TownOfHost
                             {
                                 TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
                             }
-                            if (
-                                Main.ArsonistTimer.TryGetValue(seer.PlayerId, out var ar_kvp) && //seerがオイルを塗っている途中(現在進行)
-                                ar_kvp.Item1 == target //オイルを塗っている対象がtarget
-                            )
-                            {
-                                TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>...</color>";
-                            }
                         }
                         if (seer.Is(CustomRoles.Puppeteer) &&
                         Main.PuppeteerList.ContainsValue(seer.PlayerId) &&

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -624,12 +624,9 @@ namespace TownOfHost
                             TargetMark += $"<color={GetRoleColorCode(CustomRoles.Lovers)}>♡</color>";
                         }
 
-                        if (seer.Is(CustomRoles.Arsonist))//seerがアーソニストの時
+                        if (seer.Is(CustomRoles.Arsonist) && seer.IsDousedPlayer(target))
                         {
-                            if (seer.IsDousedPlayer(target)) //seerがtargetに既にオイルを塗っている(完了)
-                            {
-                                TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
-                            }
+                            TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
                         }
                         if (seer.Is(CustomRoles.Puppeteer) &&
                         Main.PuppeteerList.ContainsValue(seer.PlayerId) &&

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -624,9 +624,19 @@ namespace TownOfHost
                             TargetMark += $"<color={GetRoleColorCode(CustomRoles.Lovers)}>♡</color>";
                         }
 
-                        if (seer.Is(CustomRoles.Arsonist) && seer.IsDousedPlayer(target))
+                        if (seer.Is(CustomRoles.Arsonist))//seerがアーソニストの時
                         {
-                            TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
+                            if (seer.IsDousedPlayer(target)) //seerがtargetに既にオイルを塗っている(完了)
+                            {
+                                TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
+                            }
+                            if (
+                                Main.ArsonistTimer.TryGetValue(seer.PlayerId, out var ar_kvp) && //seerがオイルを塗っている途中(現在進行)
+                                ar_kvp.Item1 == target //オイルを塗っている対象がtarget
+                            )
+                            {
+                                TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>...</color>";
+                            }
                         }
                         if (seer.Is(CustomRoles.Puppeteer) &&
                         Main.PuppeteerList.ContainsValue(seer.PlayerId) &&

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -635,7 +635,7 @@ namespace TownOfHost
                                 ar_kvp.Item1 == target //オイルを塗っている対象がtarget
                             )
                             {
-                                TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>...</color>";
+                                TargetMark += $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>△</color>";
                             }
                         }
                         if (seer.Is(CustomRoles.Puppeteer) &&

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -904,7 +904,7 @@ namespace TownOfHost
                         {
                             Mark += $"<color={Utils.GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
                         }
-                        if (
+                        else if (
                             Main.currentDousingTarget != 255 &&
                             Main.currentDousingTarget == target.PlayerId
                         )

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -900,7 +900,7 @@ namespace TownOfHost
                             Mark += $"<color={Utils.GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
                         }
                         if (
-                            false//条件式
+                            Main.currentDousingTarget == target.PlayerId
                         )
                         {
                             Mark += $"<color={Utils.GetRoleColorCode(CustomRoles.Arsonist)}>△</color>";

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -277,7 +277,7 @@ namespace TownOfHost
                         Main.AllPlayerKillCooldown[killer.PlayerId] = 10f;
                         Utils.CustomSyncAllSettings();
                         Main.BlockKilling[killer.PlayerId] = false;
-                        if (!Main.isDoused[(killer.PlayerId, target.PlayerId)])
+                        if (!Main.isDoused[(killer.PlayerId, target.PlayerId)] && !Main.ArsonistTimer.ContainsKey(killer.PlayerId))
                         {
                             Main.ArsonistTimer.Add(killer.PlayerId, (target, 0f));
                             Utils.NotifyRoles(SpecifySeer: killer);

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -280,7 +280,6 @@ namespace TownOfHost
                         if (!Main.isDoused[(killer.PlayerId, target.PlayerId)] && !Main.ArsonistTimer.ContainsKey(killer.PlayerId))
                         {
                             Main.ArsonistTimer.Add(killer.PlayerId, (target, 0f));
-                            Utils.NotifyRoles(SpecifySeer: killer);
                         }
                         return false;
 
@@ -710,7 +709,6 @@ namespace TownOfHost
                         else//それ以外は削除
                         {
                             Main.ArsonistTimer.Remove(__instance.PlayerId);
-                            Utils.NotifyRoles(SpecifySeer: __instance);
 
                             Logger.Info($"Canceled: {__instance.GetNameWithRole()}", "Arsonist");
                         }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -900,6 +900,7 @@ namespace TownOfHost
                             Mark += $"<color={Utils.GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
                         }
                         if (
+                            Main.currentDousingTarget != 255 &&
                             Main.currentDousingTarget == target.PlayerId
                         )
                         {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -280,6 +280,7 @@ namespace TownOfHost
                         if (!Main.isDoused[(killer.PlayerId, target.PlayerId)] && !Main.ArsonistTimer.ContainsKey(killer.PlayerId))
                         {
                             Main.ArsonistTimer.Add(killer.PlayerId, (target, 0f));
+                            Utils.NotifyRoles(SpecifySeer: __instance);
                         }
                         return false;
 
@@ -741,6 +742,7 @@ namespace TownOfHost
                             else//それ以外は削除
                             {
                                 Main.ArsonistTimer.Remove(player.PlayerId);
+                                Utils.NotifyRoles(SpecifySeer: __instance);
 
                                 Logger.Info($"Canceled: {__instance.GetNameWithRole()}", "Arsonist");
                             }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -277,7 +277,11 @@ namespace TownOfHost
                         Main.AllPlayerKillCooldown[killer.PlayerId] = 10f;
                         Utils.CustomSyncAllSettings();
                         Main.BlockKilling[killer.PlayerId] = false;
-                        if (!Main.isDoused[(killer.PlayerId, target.PlayerId)]) Main.ArsonistTimer.Add(killer.PlayerId, (target, 0f));
+                        if (!Main.isDoused[(killer.PlayerId, target.PlayerId)])
+                        {
+                            Main.ArsonistTimer.Add(killer.PlayerId, (target, 0f));
+                            Utils.NotifyRoles();
+                        }
                         return false;
 
                     //==========クルー役職==========//
@@ -706,6 +710,8 @@ namespace TownOfHost
                         else//それ以外は削除
                         {
                             Main.ArsonistTimer.Remove(__instance.PlayerId);
+                            Utils.NotifyRoles();
+
                             Logger.Info($"Canceled: {__instance.GetNameWithRole()}", "Arsonist");
                         }
                     }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -733,6 +733,7 @@ namespace TownOfHost
                             writer.Write(true);
                             AmongUsClient.Instance.FinishRpcImmediately(writer);
                             Utils.NotifyRoles();//名前変更
+                            RPC.ResetCurrentDousingTarget(player.PlayerId);
                         }
                         else
                         {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -281,6 +281,7 @@ namespace TownOfHost
                         {
                             Main.ArsonistTimer.Add(killer.PlayerId, (target, 0f));
                             Utils.NotifyRoles(SpecifySeer: __instance);
+                            RPC.SetCurrentDousingTarget(killer.PlayerId, target.PlayerId);
                         }
                         return false;
 
@@ -743,6 +744,7 @@ namespace TownOfHost
                             {
                                 Main.ArsonistTimer.Remove(player.PlayerId);
                                 Utils.NotifyRoles(SpecifySeer: __instance);
+                                RPC.ResetCurrentDousingTarget(player.PlayerId);
 
                                 Logger.Info($"Canceled: {__instance.GetNameWithRole()}", "Arsonist");
                             }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -276,7 +276,6 @@ namespace TownOfHost
                     case CustomRoles.Arsonist:
                         Main.AllPlayerKillCooldown[killer.PlayerId] = 10f;
                         Utils.CustomSyncAllSettings();
-                        killer.RpcGuardAndKill(target);
                         if (!Main.isDoused[(killer.PlayerId, target.PlayerId)]) Main.ArsonistTimer.Add(killer.PlayerId, (target, 0f));
                         return false;
 

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -893,9 +893,18 @@ namespace TownOfHost
                     {
                         Mark += $"<color={Utils.GetRoleColorCode(CustomRoles.Snitch)}>★</color>"; //Snitch警告をつける
                     }
-                    if (seer.Is(CustomRoles.Arsonist) && seer.IsDousedPlayer(target))
+                    if (seer.Is(CustomRoles.Arsonist))
                     {
-                        Mark += $"<color={Utils.GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
+                        if (seer.IsDousedPlayer(target))
+                        {
+                            Mark += $"<color={Utils.GetRoleColorCode(CustomRoles.Arsonist)}>▲</color>";
+                        }
+                        if (
+                            false//条件式
+                        )
+                        {
+                            Mark += $"<color={Utils.GetRoleColorCode(CustomRoles.Arsonist)}>△</color>";
+                        }
                     }
                     foreach (var ExecutionerTarget in Main.ExecutionerTarget)
                     {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -280,7 +280,7 @@ namespace TownOfHost
                         if (!Main.isDoused[(killer.PlayerId, target.PlayerId)])
                         {
                             Main.ArsonistTimer.Add(killer.PlayerId, (target, 0f));
-                            Utils.NotifyRoles();
+                            Utils.NotifyRoles(SpecifySeer: killer);
                         }
                         return false;
 
@@ -710,7 +710,7 @@ namespace TownOfHost
                         else//それ以外は削除
                         {
                             Main.ArsonistTimer.Remove(__instance.PlayerId);
-                            Utils.NotifyRoles();
+                            Utils.NotifyRoles(SpecifySeer: __instance);
 
                             Logger.Info($"Canceled: {__instance.GetNameWithRole()}", "Arsonist");
                         }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -705,6 +705,8 @@ namespace TownOfHost
                     if (!player.IsAlive())
                     {
                         Main.ArsonistTimer.Remove(player.PlayerId);
+                        Utils.NotifyRoles(SpecifySeer: __instance);
+                        RPC.ResetCurrentDousingTarget(player.PlayerId);
                     }
                     else
                     {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -705,6 +705,7 @@ namespace TownOfHost
                         else//それ以外は削除
                         {
                             Main.ArsonistTimer.Remove(__instance.PlayerId);
+                            Logger.Info($"Canceled: {__instance.GetNameWithRole()}", "Arsonist");
                         }
                     }
                 }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -276,6 +276,7 @@ namespace TownOfHost
                     case CustomRoles.Arsonist:
                         Main.AllPlayerKillCooldown[killer.PlayerId] = 10f;
                         Utils.CustomSyncAllSettings();
+                        Main.BlockKilling[killer.PlayerId] = false;
                         if (!Main.isDoused[(killer.PlayerId, target.PlayerId)]) Main.ArsonistTimer.Add(killer.PlayerId, (target, 0f));
                         return false;
 

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -61,6 +61,8 @@ namespace TownOfHost
 
             NameColorManager.Instance.RpcReset();
             Main.LastNotifyNames = new();
+
+            Main.currentDousingTarget = 255;
             //名前の記録
             Main.AllPlayerNames = new();
             foreach (var p in PlayerControl.AllPlayerControls)

--- a/main.cs
+++ b/main.cs
@@ -104,6 +104,7 @@ namespace TownOfHost
         public static bool introDestroyed = false;
         public static int DiscussionTime;
         public static int VotingTime;
+        public static byte currentDousingTarget;
 
         public static Main Instance;
 
@@ -150,6 +151,7 @@ namespace TownOfHost
             winnerList = new();
             VisibleTasksCount = false;
             MessagesToSend = new List<(string, byte)>();
+            currentDousingTarget = 255;
 
             IgnoreWinnerCommand = Config.Bind("Other", "IgnoreWinnerCommand", true);
             WebhookURL = Config.Bind("Other", "WebhookURL", "none");


### PR DESCRIPTION
アーソニストのGuardAndKillを塗り完了時のみ実行するよう変更
これにより、キル連打によるGuardAndKill貫通が無くなります。