### PR TITLE
[Not Merge]開発者へのリンクの変更

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -766,7 +766,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 - [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/c/TAKUGG))
 - [Soukun](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Dev), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [Mii](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
-- [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
+- [Tampopo](https://github.com/tampopo-dandelion)([Twitter](https://twitter.com/2nomotokaicho),  [Youtube](https://www.youtube.com/channel/UC8EwQ5gu-qyxVxek0jZw1Tg), [ニコニコ](https://www.nicovideo.jp/user/124305243))
 - [Kou](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->
 - [Ykundesu](https://github.com/ykundesu) <!--([Twitter](https://twitter.com/))-->
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -760,7 +760,6 @@ If the client language is English, this setting is meaningless unless `Force Jap
 
 ## Developers
 - [EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
-- [Integral](https://github.com/integral6174) ([Twitter](https://twitter.com/integral6174), [Youtube](https://www.youtube.com/channel/UCpmUUYF6qvmsPzisn5gN7KQ))
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [Shu-](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->

--- a/README-EN.md
+++ b/README-EN.md
@@ -758,6 +758,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 [Jester](#Jester) and [Madmate](#Madmate) roles : https://au.libhalt.net<br>
 [Terrorist](#Terrorist)(Trickstar + Joker) : https://github.com/MengTube/Foolers-Mod<br>
 
+## Developers
 Twitter : https://twitter.com/XenonBottle<br>
 
 Translated with https://www.deepl.com<br>

--- a/README-EN.md
+++ b/README-EN.md
@@ -760,7 +760,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 
 ## Developers
 - [EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
-- [Integral](https://github.com/integral6174) <!--([Twitter](https://twitter.com/))-->
+- [Integral](https://github.com/integral6174) ([Twitter](https://twitter.com/integral6174)) ([Youtube](https://www.youtube.com/channel/UCpmUUYF6qvmsPzisn5gN7KQ))
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [Shu-](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->

--- a/README-EN.md
+++ b/README-EN.md
@@ -764,7 +764,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 - [Shu-](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
 - [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/c/TAKUGG))
-- [Soukunsandesu](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
+- [Soukun](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [Mii](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
 - [Kou](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->

--- a/README-EN.md
+++ b/README-EN.md
@@ -765,7 +765,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 - [Shu-](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
 - [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
-- [Soukunsandesu](https://github.com/soukunsandesu) <!--([Twitter](https://twitter.com/))-->
+- [Soukunsandesu](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte))
 - [Mii](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
 - [Kou](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->

--- a/README-EN.md
+++ b/README-EN.md
@@ -764,7 +764,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 - [Shu-](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
 - [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/c/TAKUGG))
-- [Soukun](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
+- [Soukun](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Dev), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [Mii](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
 - [Kou](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->

--- a/README-EN.md
+++ b/README-EN.md
@@ -760,7 +760,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 
 ## Developers
 - [EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
-- [Integral](https://github.com/integral6174) ([Twitter](https://twitter.com/integral6174)) ([Youtube](https://www.youtube.com/channel/UCpmUUYF6qvmsPzisn5gN7KQ))
+- [Integral](https://github.com/integral6174) ([Twitter](https://twitter.com/integral6174), [Youtube](https://www.youtube.com/channel/UCpmUUYF6qvmsPzisn5gN7KQ))
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [Shu-](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->

--- a/README-EN.md
+++ b/README-EN.md
@@ -764,7 +764,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [Shu-](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
-- [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/channel/UCJ_y7_ld0IR7qjp2ScRs6xg))
+- [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/c/TAKUGG))
 - [Soukunsandesu](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [Mii](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->

--- a/README-EN.md
+++ b/README-EN.md
@@ -764,7 +764,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [Shu-](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
-- [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
+- [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/channel/UCJ_y7_ld0IR7qjp2ScRs6xg))
 - [Soukunsandesu](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [Mii](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->

--- a/README-EN.md
+++ b/README-EN.md
@@ -769,5 +769,6 @@ If the client language is English, this setting is meaningless unless `Force Jap
 - [Tampopo](https://github.com/tampopo-dandelion)([Twitter](https://twitter.com/2nomotokaicho),  [Youtube](https://www.youtube.com/channel/UC8EwQ5gu-qyxVxek0jZw1Tg), [ニコニコ](https://www.nicovideo.jp/user/124305243))
 - [Kou](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->
 - [Ykundesu](https://github.com/ykundesu) <!--([Twitter](https://twitter.com/))-->
+- [Yurino](https://github.com/yurinakira) <!--([Twitter](https://twitter.com/))-->
 
 Translated with https://www.deepl.com<br>

--- a/README-EN.md
+++ b/README-EN.md
@@ -765,7 +765,7 @@ If the client language is English, this setting is meaningless unless `Force Jap
 - [Shu-](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
 - [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
-- [Soukunsandesu](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte))
+- [Soukunsandesu](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [Mii](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
 - [Kou](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->

--- a/README-EN.md
+++ b/README-EN.md
@@ -759,6 +759,16 @@ If the client language is English, this setting is meaningless unless `Force Jap
 [Terrorist](#Terrorist)(Trickstar + Joker) : https://github.com/MengTube/Foolers-Mod<br>
 
 ## Developers
-Twitter : https://twitter.com/XenonBottle<br>
+- [EmptyBottle(空き瓶)](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
+- [Integral](https://github.com/integral6174) <!--([Twitter](https://twitter.com/))-->
+- [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
+- [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
+- [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
+- [Soukunsandesu](https://github.com/soukunsandesu) <!--([Twitter](https://twitter.com/))-->
+- [Shu](https://github.com/shu-TownofHost) <!--([Twitter](https://twitter.com/))-->
+- [Kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
+- [Mii](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
+- [Kou](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->
+- [ykundesu](https://github.com/ykundesu) <!--([Twitter](https://twitter.com/))-->
 
 Translated with https://www.deepl.com<br>

--- a/README-EN.md
+++ b/README-EN.md
@@ -759,16 +759,16 @@ If the client language is English, this setting is meaningless unless `Force Jap
 [Terrorist](#Terrorist)(Trickstar + Joker) : https://github.com/MengTube/Foolers-Mod<br>
 
 ## Developers
-- [EmptyBottle(空き瓶)](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
+- [EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
 - [Integral](https://github.com/integral6174) <!--([Twitter](https://twitter.com/))-->
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
-- [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
+- [Shu](https://github.com/shu-TownofHost) <!--([Twitter](https://twitter.com/))-->
+- [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
 - [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
 - [Soukunsandesu](https://github.com/soukunsandesu) <!--([Twitter](https://twitter.com/))-->
-- [Shu](https://github.com/shu-TownofHost) <!--([Twitter](https://twitter.com/))-->
-- [Kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
 - [Mii](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
+- [Tampopo](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
 - [Kou](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->
-- [ykundesu](https://github.com/ykundesu) <!--([Twitter](https://twitter.com/))-->
+- [Ykundesu](https://github.com/ykundesu) <!--([Twitter](https://twitter.com/))-->
 
 Translated with https://www.deepl.com<br>

--- a/README-EN.md
+++ b/README-EN.md
@@ -868,8 +868,6 @@ More tips to modding and [BountyHunter](#BountyHunter),[Mafia](#Mafia),[Vampire]
 [Lovers](#lovers) : [Town-Of-Us-R](https://github.com/eDonnes124/Town-Of-Us-R)<br>
 Translate-Chinese : fivefirex, ZeMingOH233<br>
 
-Twitter : https://twitter.com/XenonBottle<br>
-
 Translated with https://www.deepl.com<br>
 
 ## Developers

--- a/README.md
+++ b/README.md
@@ -758,11 +758,11 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 - [空き瓶/EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
 - [Integral](https://github.com/integral6174) <!--([Twitter](https://twitter.com/))-->
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
-- [たんぽぽ](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
-- [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
-- [そうくんさんです](https://github.com/soukunsandesu) <!--([Twitter](https://twitter.com/))-->
 - [しゅー](https://github.com/shu-TownofHost) <!--([Twitter](https://twitter.com/))-->
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
+- [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
+- [そうくんさんです](https://github.com/soukunsandesu) <!--([Twitter](https://twitter.com/))-->
 - [みぃー](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
+- [たんぽぽ](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
 - [こう。](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->
 - [よっキング](https://github.com/ykundesu) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -748,4 +748,5 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 [ジェスター](#Jester/ジェスター)(てるてる)と[マッドメイト](#Madmate/マッドメイト)の役職 : https://au.libhalt.net<br>
 [テロリスト](#Terrorist/テロリスト)(Trickstar + Joker) : https://github.com/MengTube/Foolers-Mod<br>
 
+## 開発者
 作者の Twitter : https://twitter.com/XenonBottle<br>

--- a/README.md
+++ b/README.md
@@ -749,4 +749,17 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 [テロリスト](#Terrorist/テロリスト)(Trickstar + Joker) : https://github.com/MengTube/Foolers-Mod<br>
 
 ## 開発者
-作者の Twitter : https://twitter.com/XenonBottle<br>
+<!--
+- [名前]([Githubのリンク](https://github.com/)) ([Twitter](https://twitter.com/))
+-->
+- [空き瓶/EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
+- [Integral](https://github.com/integral6174) <!--([Twitter](https://twitter.com/))-->
+- [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
+- [たんぽぽ](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
+- [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
+- [そうくんさんです](https://github.com/soukunsandesu) <!--([Twitter](https://twitter.com/))-->
+- [しゅー](https://github.com/shu-TownofHost) <!--([Twitter](https://twitter.com/))-->
+- [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
+- [みぃー](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
+- [こう。](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->
+- [よっキング](https://github.com/ykundesu) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [しゅー](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
-- [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
+- [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/channel/UCJ_y7_ld0IR7qjp2ScRs6xg))
 - [そうくんさんです](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [みぃー](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [たんぽぽ](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 - [しゅー](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
 - [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/c/TAKUGG))
-- [そうくんさんです](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
+- [そうくん](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Dev), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [みぃー](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [たんぽぽ](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
 - [こう。](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 注：README-ENへの追記を忘れないでください。
 -->
 - [空き瓶/EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
-- [Integral](https://github.com/integral6174) ([Twitter](https://twitter.com/integral6174)) ([Youtube](https://www.youtube.com/channel/UCpmUUYF6qvmsPzisn5gN7KQ))
+- [Integral](https://github.com/integral6174) ([Twitter](https://twitter.com/integral6174), [Youtube](https://www.youtube.com/channel/UCpmUUYF6qvmsPzisn5gN7KQ))
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [しゅー](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [しゅー](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
-- [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/channel/UCJ_y7_ld0IR7qjp2ScRs6xg))
+- [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/c/TAKUGG))
 - [そうくんさんです](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [みぃー](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [たんぽぽ](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 - [しゅー](https://github.com/shu-TownofHost) <!--([Twitter](https://twitter.com/))-->
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
 - [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
-- [そうくんさんです](https://github.com/soukunsandesu) <!--([Twitter](https://twitter.com/))-->
+- [そうくんさんです](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte))
 - [みぃー](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [たんぽぽ](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
 - [こう。](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -757,7 +757,6 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 注：README-ENへの追記を忘れないでください。
 -->
 - [空き瓶/EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
-- [Integral](https://github.com/integral6174) ([Twitter](https://twitter.com/integral6174), [Youtube](https://www.youtube.com/channel/UCpmUUYF6qvmsPzisn5gN7KQ))
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [しゅー](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 - [しゅー](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->
 - [TAKU_GG](https://github.com/TAKUGG) <!--([Twitter](https://twitter.com/))-->
-- [そうくんさんです](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte))
+- [そうくんさんです](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Palpunte), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [みぃー](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
 - [たんぽぽ](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
 - [こう。](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 注：README-ENへの追記を忘れないでください。
 -->
 - [空き瓶/EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
-- [Integral](https://github.com/integral6174) <!--([Twitter](https://twitter.com/))-->
+- [Integral](https://github.com/integral6174) ([Twitter](https://twitter.com/integral6174)) ([Youtube](https://www.youtube.com/channel/UCpmUUYF6qvmsPzisn5gN7KQ))
 - [Tanakarina](https://github.com/tanakanira0118) <!--([Twitter](https://twitter.com/))-->
 - [しゅー](https://github.com/shu-TownofHost) ([Twitter](https://twitter.com/Shu_kundayo))
 - [kihi](https://github.com/Kihi1120) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -763,6 +763,6 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 - [TAKU_GG](https://github.com/TAKUGG) ([Twitter](https://twitter.com/TAKUGGYouTube1), [Youtube](https://www.youtube.com/c/TAKUGG))
 - [そうくん](https://github.com/soukunsandesu) ([Twitter](https://twitter.com/Soukun_Dev), [Youtube](https://www.youtube.com/channel/UCsCOqxmXBVT-BD_UKaXpUPw))
 - [みぃー](https://github.com/mii-47) <!--([Twitter](https://twitter.com/))-->
-- [たんぽぽ](https://github.com/tampopo-dandelion) <!--([Twitter](https://twitter.com/))-->
+- [たんぽぽ](https://github.com/tampopo-dandelion)([Twitter](https://twitter.com/2nomotokaicho),  [Youtube](https://www.youtube.com/channel/UC8EwQ5gu-qyxVxek0jZw1Tg), [ニコニコ](https://www.nicovideo.jp/user/124305243))
 - [こう。](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->
 - [よっキング](https://github.com/ykundesu) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -766,3 +766,4 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 - [たんぽぽ](https://github.com/tampopo-dandelion)([Twitter](https://twitter.com/2nomotokaicho),  [Youtube](https://www.youtube.com/channel/UC8EwQ5gu-qyxVxek0jZw1Tg), [ニコニコ](https://www.nicovideo.jp/user/124305243))
 - [こう。](https://github.com/kou-hetare) <!--([Twitter](https://twitter.com/))-->
 - [よっキング](https://github.com/ykundesu) <!--([Twitter](https://twitter.com/))-->
+- [ゆりの](https://github.com/yurinakira) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -750,7 +750,10 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 
 ## 開発者
 <!--
-- [名前]([Githubのリンク](https://github.com/)) ([Twitter](https://twitter.com/))
+- 開発者になった順番で記載する
+- [テンプレ](https://github.com/) ([Twitter](https://twitter.com/))
+- [Twitter以外のページでも可](https://github.com/) ([Twitter](https://twitter.com/), [TheOtherPages](https://example.com/))
+- [何もなくていい場合は消してOK](https://github.com/)
 -->
 - [空き瓶/EmptyBottle](https://github.com/tukasa0001) ([Twitter](https://twitter.com/XenonBottle))
 - [Integral](https://github.com/integral6174) <!--([Twitter](https://twitter.com/))-->

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 
 ## 開発者
 <!--
-開発者になった順番で記載する
+開発者用チャンネルでの一番最初の発言が早い順に記載する。
 - [テンプレ](https://github.com/) ([Twitter](https://twitter.com/))
 - [Twitter以外のページでも可](https://github.com/) ([Twitter](https://twitter.com/), [TheOtherPages](https://example.com/))
 - [何もなくていい場合は消してOK](https://github.com/)


### PR DESCRIPTION
自分のTwitterだけ作者のTwitterとして記載されているのもおかしいような気がしたので。
# 変更点
- READMEに「開発者」という項目を作り、そこに全開発者の名前を記載するよう変更
- 名前はそれぞれのGithubのユーザーページへのリンクになっている。
- Twitterなどのリンクは名前の後のかっこの中に記載(任意)

# 追記のお願い
現時点で名前のみの記載となっているので、任意でTwitterなどのリンクを追記してください。
その際にプルリクエストは作らず、`doc/DevelopersLink`ブランチに直接Pushしてください。
その際、他の行への変更を行わないようお願いします。
並び替えのミスなどはマージ直前に修正します。