### PR TITLE
メソッドを改名

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -224,7 +224,7 @@ namespace TownOfHost
 
             return ProgressText;
         }
-        public static void ShowActiveRoles()
+        public static void ShowActiveSettingsHelp()
         {
             SendMessage(GetString("CurrentActiveSettingsHelp") + ":");
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -315,7 +315,7 @@ namespace TownOfHost
             if (Options.NoGameEnd.GetBool()) text += String.Format("\n{0}:{1}", GetString("NoGameEnd"), GetOnOff(Options.NoGameEnd.GetBool()));
             SendMessage(text);
         }
-        public static void ShowLastRoles()
+        public static void ShowLastResult()
         {
             if (AmongUsClient.Instance.IsGameStarted)
             {

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -55,7 +55,7 @@ namespace TownOfHost
                     case "/l":
                     case "/lastresult":
                         canceled = true;
-                        Utils.ShowLastRoles();
+                        Utils.ShowLastResult();
                         break;
 
                     case "/r":

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -155,7 +155,7 @@ namespace TownOfHost
 
                             case "n":
                             case "now":
-                                Utils.ShowActiveRoles();
+                                Utils.ShowActiveSettingsHelp();
                                 break;
 
                             default:

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -62,7 +62,7 @@ namespace TownOfHost
             //現在の有効な設定を表示
             if (Input.GetKeyDown(KeyCode.N) && Input.GetKey(KeyCode.LeftControl))
             {
-                Utils.ShowActiveRoles();
+                Utils.ShowActiveSettingsHelp();
             }
 
             //--以下デバッグモード用コマンド--//

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -30,7 +30,7 @@ namespace TownOfHost
                     new LateTask(() =>
                     {
                         Main.isChatCommand = true;
-                        Utils.ShowLastRoles();
+                        Utils.ShowLastResult();
                     }
                         , 5f, "DisplayLastRoles");
                 }


### PR DESCRIPTION
名前と内容が一致しないメソッドを改名
- ShowActiveRolesをShowActiveSettingsHelpに改名
- ShowLastRolesをShowLastResultに改名