### PR TITLE
Fix/Arsonist-Dictionaries

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -600,12 +600,12 @@ namespace TownOfHost
             Main.isDoused.TryGetValue((arsonist.PlayerId, target.PlayerId), out bool isDoused);
             return isDoused;
         }
-        public static void RpcSendDousedPlayerCount(this PlayerControl player)
+        public static void RpcSetDousedPlayer(this PlayerControl player, PlayerControl target, bool isDoused)
         {
-            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SendDousedPlayerCount, Hazel.SendOption.Reliable, -1);
+            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetDousedPlayer, SendOption.Reliable, -1);//RPCによる同期
             writer.Write(player.PlayerId);
-            writer.Write(Main.DousedPlayerCount[player.PlayerId].Item1);
-            writer.Write(Main.DousedPlayerCount[player.PlayerId].Item2);
+            writer.Write(target.PlayerId);
+            writer.Write(isDoused);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
         public static void ExiledSchrodingerCatTeamChange(this PlayerControl player)

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -667,8 +667,8 @@ namespace TownOfHost
         }
         public static bool IsDouseDone(this PlayerControl player)
         {
-            return Main.DousedPlayerCount.ContainsKey(player.PlayerId) &&
-                    Main.DousedPlayerCount.TryGetValue(player.PlayerId, out (int, int) count) && count.Item1 == count.Item2;
+            var count = Utils.getDousedPlayerCount(player.PlayerId);
+            return count.Item1 == count.Item2;
         }
         public static void ResetThiefVotingTime(this PlayerControl thief)
         {

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -676,30 +676,6 @@ namespace TownOfHost
                 Main.VotingTime += Options.TimeThiefDecreaseVotingTime.GetInt();
             Main.TimeThiefKillCount[thief.PlayerId] = 0; //初期化
         }
-        public static void RemoveDousePlayer(this PlayerControl target) //死亡時、切断時に呼ばれる
-        {
-            foreach (var arsonist in PlayerControl.AllPlayerControls)
-            {
-                if (target == arsonist || !Main.DousedPlayerCount.ContainsKey(arsonist.PlayerId) || arsonist.Data.IsDead) continue;
-                if (arsonist.Is(CustomRoles.Arsonist))
-                {
-                    Main.isDoused.TryGetValue((arsonist.PlayerId, target.PlayerId), out bool isDoused); //targetを塗っているかどうかを判定
-                    if (Main.DousedPlayerCount.TryGetValue(arsonist.PlayerId, out (int, int) count) && count.Item1 < count.Item2) //塗った人数より塗るべき人数のほうが多いとき
-                    {
-                        Main.isDeadDoused[target.PlayerId] = true;
-                        var ArsonistDic = Main.DousedPlayerCount[arsonist.PlayerId];
-                        var LeftPlayer = ArsonistDic.Item1; //塗った人数
-                        var RequireDouse = ArsonistDic.Item2; //塗るべき人数
-                        if (isDoused)
-                            LeftPlayer--;
-                        RequireDouse--;
-                        Main.DousedPlayerCount[arsonist.PlayerId] = (LeftPlayer, RequireDouse);
-                        Logger.Info($"{arsonist.GetRealName()} : {ArsonistDic}", "Arsonist");
-                        arsonist.RpcSendDousedPlayerCount(); //RPCで他クライアントと塗り状況を同期
-                    }
-                }
-            }
-        }
         public static void RpcExileV2(this PlayerControl player)
         {
             player.Exiled();

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -25,7 +25,6 @@ namespace TownOfHost
         SetSheriffShotLimit,
         SetTimeThiefKillCount,
         SetDousedPlayer,
-        SendDousedPlayerCount,
         AddNameColorData,
         RemoveNameColorData,
         ResetNameColorData,
@@ -163,12 +162,6 @@ namespace TownOfHost
                     bool doused = reader.ReadBoolean();
                     Main.isDoused[(ArsonistId, DousedId)] = doused;
                     Main.isDeadDoused[DousedId] = true;
-                    break;
-                case CustomRPC.SendDousedPlayerCount:
-                    ArsonistId = reader.ReadByte();
-                    int DousePlayer = reader.ReadInt32();
-                    int AllTargets = reader.ReadInt32();
-                    Main.DousedPlayerCount[ArsonistId] = (DousePlayer, AllTargets);
                     break;
                 case CustomRPC.AddNameColorData:
                     byte addSeerId = reader.ReadByte();

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -161,7 +161,6 @@ namespace TownOfHost
                     byte DousedId = reader.ReadByte();
                     bool doused = reader.ReadBoolean();
                     Main.isDoused[(ArsonistId, DousedId)] = doused;
-                    Main.isDeadDoused[DousedId] = true;
                     break;
                 case CustomRPC.AddNameColorData:
                     byte addSeerId = reader.ReadByte();

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -782,5 +782,25 @@ namespace TownOfHost
             if (PlayerControl.LocalPlayer != null)
                 HudManager.Instance?.Chat?.AddChat(PlayerControl.LocalPlayer, "デスクトップにログを保存しました。バグ報告チケットを作成してこのファイルを添付してください。");
         }
+        public static (int, int) getDousedPlayerCount(byte playerId)
+        {
+            int doused = 0, all = 0; //学校で習った書き方
+            //多分この方がMain.isDousedでforeachするより他のアーソニストの分ループ数少なくて済む
+            foreach (var pc in PlayerControl.AllPlayerControls)
+            {
+                if (pc == null ||
+                    pc.Data.IsDead ||
+                    pc.Data.Disconnected ||
+                    pc.PlayerId == playerId
+                ) continue; //塗れない人は除外 (死んでたり切断済みだったり あとアーソニスト自身も)
+
+                all++;
+                if (Main.isDoused.TryGetValue((playerId, pc.PlayerId), out var isDoused) && isDoused)
+                    //塗れている場合
+                    doused++;
+            }
+
+            return (doused, all);
+        }
     }
 }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -202,8 +202,8 @@ namespace TownOfHost
             switch (role)
             {
                 case CustomRoles.Arsonist:
-                    ProgressText = Main.DousedPlayerCount.TryGetValue(playerId, out var doused) ?
-                        $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>({doused.Item1}/{doused.Item2})</color>" : "Invalid";
+                    var doused = Utils.getDousedPlayerCount(playerId);
+                    ProgressText = $"<color={GetRoleColorCode(CustomRoles.Arsonist)}>({doused.Item1}/{doused.Item2})</color>";
                     break;
                 case CustomRoles.Sheriff:
                     ProgressText += Main.SheriffShotLimit.TryGetValue(playerId, out var shotLimit) ? $" <color=#ffff00>({shotLimit})</color>" : "Invalid";
@@ -648,7 +648,10 @@ namespace TownOfHost
                         if (target.Is(CustomRoles.Sheriff))
                             TargetRoleText = seer.Data.IsDead && Options.GhostCanSeeOtherRoles.GetBool() ? $"<size={fontSize}><color={target.GetRoleColorCode()}>{target.GetRoleName()} ({Main.SheriffShotLimit[target.PlayerId]})</color>{TargetTaskText}</size>\r\n" : "";
                         else if (target.Is(CustomRoles.Arsonist))
-                            TargetRoleText = seer.Data.IsDead && Options.GhostCanSeeOtherRoles.GetBool() ? $"<size={fontSize}><color={target.GetRoleColorCode()}>{target.GetRoleName()} ({Main.DousedPlayerCount[target.PlayerId].Item1}/{Main.DousedPlayerCount[target.PlayerId].Item2})</color>{TargetTaskText}</size>\r\n" : "";
+                        {
+                            var dousedPlayerCount = Utils.getDousedPlayerCount(target.PlayerId);
+                            TargetRoleText = seer.Data.IsDead && Options.GhostCanSeeOtherRoles.GetBool() ? $"<size={fontSize}><color={target.GetRoleColorCode()}>{target.GetRoleName()} ({dousedPlayerCount.Item1}/{dousedPlayerCount.Item2})</color>{TargetTaskText}</size>\r\n" : "";
+                        }
                         else
                             TargetRoleText = seer.Data.IsDead && Options.GhostCanSeeOtherRoles.GetBool() ? $"<size={fontSize}><color={target.GetRoleColorCode()}>{target.GetRoleName()}</color>{TargetTaskText}</size>\r\n" : "";
 

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -719,7 +719,7 @@ namespace TownOfHost
                             player.RpcGuardAndKill(ar_target);//通知とクールリセット
                             Main.ArsonistTimer.Remove(player.PlayerId);//塗が完了したのでDictionaryから削除
                             Main.isDoused[(player.PlayerId, ar_target.PlayerId)] = true;//塗り完了
-                            player.RpcSetDousedPlayer();
+                            player.RpcSetDousedPlayer(ar_target, true);
                             Utils.NotifyRoles();//名前変更
                             RPC.ResetCurrentDousingTarget(player.PlayerId);
                         }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -719,12 +719,7 @@ namespace TownOfHost
                             player.RpcGuardAndKill(ar_target);//通知とクールリセット
                             Main.ArsonistTimer.Remove(player.PlayerId);//塗が完了したのでDictionaryから削除
                             Main.isDoused[(player.PlayerId, ar_target.PlayerId)] = true;//塗り完了
-                            player.RpcSendDousedPlayerCount();
-                            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetDousedPlayer, SendOption.Reliable, -1);//RPCによる同期
-                            writer.Write(player.PlayerId);
-                            writer.Write(ar_target.PlayerId);
-                            writer.Write(true);
-                            AmongUsClient.Instance.FinishRpcImmediately(writer);
+                            player.RpcSetDousedPlayer();
                             Utils.NotifyRoles();//名前変更
                             RPC.ResetCurrentDousingTarget(player.PlayerId);
                         }

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -51,8 +51,6 @@ namespace TownOfHost
                     Main.ExecutionerTarget.Remove(data.Character.PlayerId);
                     RPC.RemoveExecutionerKey(data.Character.PlayerId);
                 }
-                if (Main.isDeadDoused.TryGetValue(data.Character.PlayerId, out bool value) && !value)
-                    data.Character.RemoveDousePlayer();
                 if (PlayerState.GetDeathReason(data.Character.PlayerId) == PlayerState.DeathReason.etc) //死因が設定されていなかったら
                 {
                     PlayerState.SetDeathReason(data.Character.PlayerId, PlayerState.DeathReason.Disconnected);

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -23,7 +23,6 @@ namespace TownOfHost
             Main.WarlockTimer = new Dictionary<byte, float>();
             Main.BountyTimer = new Dictionary<byte, float>();
             Main.isDoused = new Dictionary<(byte, byte), bool>();
-            Main.isDeadDoused = new Dictionary<byte, bool>();
             Main.ArsonistTimer = new Dictionary<byte, (PlayerControl, float)>();
             Main.BountyTargets = new Dictionary<byte, PlayerControl>();
             Main.isTargetKilled = new Dictionary<byte, bool>();
@@ -333,7 +332,6 @@ namespace TownOfHost
                 Main.BountyTimer = new Dictionary<byte, float>();
                 foreach (var pc in PlayerControl.AllPlayerControls)
                 {
-                    Main.isDeadDoused[pc.PlayerId] = false;
                     pc.ResetKillCooldown();
                     if (pc.Is(CustomRoles.Sheriff))
                     {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -359,7 +359,6 @@ namespace TownOfHost
                         {
                             Main.isDoused.Add((pc.PlayerId, ar.PlayerId), false);
                         }
-                        //TODO: isDousedを送信する必要があるかも
                     }
                     if (pc.Is(CustomRoles.TimeThief))
                     {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -23,7 +23,6 @@ namespace TownOfHost
             Main.WarlockTimer = new Dictionary<byte, float>();
             Main.BountyTimer = new Dictionary<byte, float>();
             Main.isDoused = new Dictionary<(byte, byte), bool>();
-            Main.DousedPlayerCount = new Dictionary<byte, (int, int)>();
             Main.isDeadDoused = new Dictionary<byte, bool>();
             Main.ArsonistTimer = new Dictionary<byte, (PlayerControl, float)>();
             Main.BountyTargets = new Dictionary<byte, PlayerControl>();
@@ -358,13 +357,11 @@ namespace TownOfHost
                     if (pc.Data.Role.Role == RoleTypes.Shapeshifter) Main.CheckShapeshift.Add(pc.PlayerId, false);
                     if (pc.Is(CustomRoles.Arsonist))
                     {
-                        var targetPlayerCount = PlayerControl.AllPlayerControls.Count - 1;
-                        Main.DousedPlayerCount[pc.PlayerId] = (0, targetPlayerCount);
-                        pc.RpcSendDousedPlayerCount();
                         foreach (var ar in PlayerControl.AllPlayerControls)
                         {
                             Main.isDoused.Add((pc.PlayerId, ar.PlayerId), false);
                         }
+                        //TODO: isDousedを送信する必要があるかも
                     }
                     if (pc.Is(CustomRoles.TimeThief))
                     {

--- a/main.cs
+++ b/main.cs
@@ -77,7 +77,6 @@ namespace TownOfHost
         public static Dictionary<byte, bool> KillOrSpell = new();
         public static Dictionary<byte, bool> isCurseAndKill = new();
         public static Dictionary<(byte, byte), bool> isDoused = new();
-        public static Dictionary<byte, bool> isDeadDoused = new();
         public static Dictionary<byte, (PlayerControl, float)> ArsonistTimer = new();
         public static Dictionary<byte, float> AirshipMeetingTimer = new();
         public static Dictionary<byte, byte> ExecutionerTarget = new(); //Key : Executioner, Value : target
@@ -142,7 +141,6 @@ namespace TownOfHost
             CursedPlayers = new Dictionary<byte, PlayerControl>();
             SpelledPlayer = new List<PlayerControl>();
             isDoused = new Dictionary<(byte, byte), bool>();
-            isDeadDoused = new Dictionary<byte, bool>();
             ArsonistTimer = new Dictionary<byte, (PlayerControl, float)>();
             ExecutionerTarget = new Dictionary<byte, byte>();
             MayorUsedButtonCount = new Dictionary<byte, int>();

--- a/main.cs
+++ b/main.cs
@@ -77,7 +77,6 @@ namespace TownOfHost
         public static Dictionary<byte, bool> KillOrSpell = new();
         public static Dictionary<byte, bool> isCurseAndKill = new();
         public static Dictionary<(byte, byte), bool> isDoused = new();
-        public static Dictionary<byte, (int, int)> DousedPlayerCount = new();
         public static Dictionary<byte, bool> isDeadDoused = new();
         public static Dictionary<byte, (PlayerControl, float)> ArsonistTimer = new();
         public static Dictionary<byte, float> AirshipMeetingTimer = new();
@@ -143,7 +142,6 @@ namespace TownOfHost
             CursedPlayers = new Dictionary<byte, PlayerControl>();
             SpelledPlayer = new List<PlayerControl>();
             isDoused = new Dictionary<(byte, byte), bool>();
-            DousedPlayerCount = new Dictionary<byte, (int, int)>();
             isDeadDoused = new Dictionary<byte, bool>();
             ArsonistTimer = new Dictionary<byte, (PlayerControl, float)>();
             ExecutionerTarget = new Dictionary<byte, byte>();


### PR DESCRIPTION
# 変更点
- DousedPlayerCountを廃止し、必要な時に計算するよう変更。
これにより、死亡時にDousedPlayerCountを書き換え忘れることが原因のバグを消すことができます。
- SetDousedPlayerの送信処理を関数化
- isDeadDousedを削除  不要になった処理を消したら代入処理以外消えてたので

# 動作テスト
環境：同一PC上でのローカルプレイ
## 塗った人数の表示
| 種類 | 結果 |
| ---- | ---- |
| ホスト | OK |
| バニラ | OK |
| mod入り | OK |
## 勝利判定
| 種類 | 結果 |
| ---- | ---- |
| ホスト | OK |
| バニラ | OK |
| mod入り | OK |

追記：RPCを削除しているため互換性は切れます。