### PR TITLE
バニラクライアントでコマンドを実行する機能

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -57,6 +57,11 @@ namespace TownOfHost
                     Logger.Info("名前変更:" + __instance.GetNameWithRole() + " => " + name, "SetName");
                     if (subReader.BytesRemaining > 0 && subReader.ReadBoolean()) return false;
                     break;
+                case RpcCalls.SendChat:
+                    var text = subReader.ReadString();
+                    Logger.Info($"{__instance.GetNameWithRole()}:{text}", "SendChat");
+                    ChatCommands.OnReceiveChat(__instance, text);
+                    break;
                 case RpcCalls.StartMeeting:
                     var p = Utils.GetPlayerById(subReader.ReadByte());
                     Logger.Info($"{__instance.GetNameWithRole()} => {p?.GetNameWithRole() ?? "null"}", "StartMeeting");

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -315,11 +315,11 @@ namespace TownOfHost
             if (Options.NoGameEnd.GetBool()) text += String.Format("\n{0}:{1}", GetString("NoGameEnd"), GetOnOff(Options.NoGameEnd.GetBool()));
             SendMessage(text, PlayerId);
         }
-        public static void ShowLastResult()
+        public static void ShowLastResult(byte PlayerId = byte.MaxValue)
         {
             if (AmongUsClient.Instance.IsGameStarted)
             {
-                SendMessage(GetString("CantUse/lastroles"));
+                SendMessage(GetString("CantUse/lastroles"), PlayerId);
                 return;
             }
             var text = GetString("LastResult") + ":";
@@ -336,7 +336,7 @@ namespace TownOfHost
                 text += $"\n　 {Main.AllPlayerNames[id]}:{GetRoleName(Main.AllPlayerCustomRoles[id])}{GetShowLastSubRolesText(id)}";
                 text += $" {GetVitalText(id)}";
             }
-            SendMessage(text);
+            SendMessage(text, PlayerId);
         }
 
         public static string GetShowLastSubRolesText(byte id)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -247,14 +247,14 @@ namespace TownOfHost
             }
             if (Options.NoGameEnd.GetBool()) { SendMessage(GetString("NoGameEndInfo")); }
         }
-        public static void ShowActiveSettings()
+        public static void ShowActiveSettings(byte PlayerId = byte.MaxValue)
         {
             var text = GetString("Roles") + ":";
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
             {
                 if (CustomRoles.HASFox.IsEnable()) text += String.Format("\n{0}:{1}", GetRoleName(CustomRoles.HASFox), CustomRoles.HASFox.GetCount());
                 if (CustomRoles.HASTroll.IsEnable()) text += String.Format("\n{0}:{1}", GetRoleName(CustomRoles.HASTroll), CustomRoles.HASTroll.GetCount());
-                SendMessage(text);
+                SendMessage(text, PlayerId);
                 text = GetString("Settings") + ":";
                 text += GetString("HideAndSeek");
             }
@@ -265,13 +265,13 @@ namespace TownOfHost
                     if (role is CustomRoles.HASFox or CustomRoles.HASTroll) continue;
                     if (role.IsEnable()) text += String.Format("\n{0}:{1}", GetRoleName(role), role.GetCount());
                 }
-                SendMessage(text);
+                SendMessage(text, PlayerId);
                 text = GetString("Attributes") + ":";
                 if (Options.EnableLastImpostor.GetBool())
                 {
                     text += String.Format("\n{0}:{1}", GetString("LastImpostor"), Options.EnableLastImpostor.GetString());
                 }
-                SendMessage(text);
+                SendMessage(text, PlayerId);
                 text = GetString("Settings") + ":";
                 foreach (var role in Options.CustomRoleCounts)
                 {
@@ -313,7 +313,7 @@ namespace TownOfHost
             }
             if (Options.StandardHAS.GetBool()) text += String.Format("\n{0}:{1}", GetString("StandardHAS"), GetOnOff(Options.StandardHAS.GetBool()));
             if (Options.NoGameEnd.GetBool()) text += String.Format("\n{0}:{1}", GetString("NoGameEnd"), GetOnOff(Options.NoGameEnd.GetBool()));
-            SendMessage(text);
+            SendMessage(text, PlayerId);
         }
         public static void ShowLastResult()
         {

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -306,7 +306,8 @@ namespace TownOfHost
             Main.MessagesToSend.RemoveAt(0);
             int clientId = sendTo == byte.MaxValue ? -1 : Utils.GetPlayerById(sendTo).GetClientId();
             if (clientId == -1) DestroyableSingleton<HudManager>.Instance.Chat.AddChat(PlayerControl.LocalPlayer, msg);
-            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)RpcCalls.SendChat, SendOption.None, clientId);
+            MessageWriter writer = clientId == -1 ? AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)RpcCalls.SendChat, SendOption.None, clientId)
+                                                : AmongUsClient.Instance.StartRpcImmediately(Utils.GetPlayerById(sendTo).NetId, (byte)RpcCalls.SendChat, SendOption.None, clientId);
             writer.Write(msg);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -300,6 +300,11 @@ namespace TownOfHost
             if (!AmongUsClient.Instance.AmHost) return;
             switch (text)
             {
+                case "/l":
+                case "/lastresult":
+                    Utils.ShowLastResult(player.PlayerId);
+                    break;
+
                 case "/n":
                 case "/now":
                     Utils.ShowActiveSettings(player.PlayerId);

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -300,6 +300,11 @@ namespace TownOfHost
             if (!AmongUsClient.Instance.AmHost) return;
             switch (text)
             {
+                case "/n":
+                case "/now":
+                    Utils.ShowActiveSettings(player.PlayerId);
+                    break;
+
                 default:
                     break;
             }

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -295,6 +295,15 @@ namespace TownOfHost
                 HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, $"「{str}」に該当するメッセージが見つかりませんでした。\n{str}:内容\nのようにtemplate.txtに追記してください。");
             else for (int i = 0; i < sendList.Count; i++) Utils.SendMessage(sendList[i]);
         }
+        public static void OnReceiveChat(PlayerControl player, string text)
+        {
+            if (!AmongUsClient.Instance.AmHost) return;
+            switch (text)
+            {
+                default:
+                    break;
+            }
+        }
     }
     [HarmonyPatch(typeof(ChatController), nameof(ChatController.Update))]
     class ChatUpdatePatch


### PR DESCRIPTION
バニラでもコマンドが使えるように機能追加
- メソッドを個別送信に対応
  - ShowActiveSettings
  - ShowLastResult
- 個別送信は送信先名義で表示させる（ホストが死んでいても表示させるため）
- コマンドを追加
  - /now
  - /lastresult

ホスト以外が実行した場合実行者本人にのみ送信されます。