### PR TITLE
例外を修正

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -182,7 +182,7 @@ namespace TownOfHost
         }
         public static string GetProgressText(PlayerControl pc)
         {
-            if (!GetPlayerById(0).IsModClient()) return ""; //ホストがMODを入れていなければ未記入を返す
+            if (!Main.playerVersion.ContainsKey(0)) return ""; //ホストがMODを入れていなければ未記入を返す
             var taskState = pc.GetPlayerTaskState();
             var Comms = false;
             if (taskState.hasTasks)
@@ -198,7 +198,7 @@ namespace TownOfHost
         }
         public static string GetProgressText(byte playerId, bool comms = false)
         {
-            if (!GetPlayerById(0).IsModClient()) return ""; //ホストがMODを入れていなければ未記入を返す
+            if (!Main.playerVersion.ContainsKey(0)) return ""; //ホストがMODを入れていなければ未記入を返す
             string colorCode = "<color=#ffff00>";
             string closeCode = "</color>";
             if (!Main.AllPlayerCustomRoles.TryGetValue(playerId, out var role)) return $" {colorCode}Invalid{closeCode}";

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -212,6 +212,7 @@ namespace TownOfHost
     {
         public static void Postfix(EndGameManager __instance)
         {
+            if (!Main.playerVersion.ContainsKey(0)) return;
             //#######################################
             //          ==勝利陣営表示==
             //#######################################


### PR DESCRIPTION
IsModClientがアウトロで例外を吐くためGetProgressTextを使わないように変更
ついでにバニラがホストの際にアウトロを表示しないように変更