### PR TITLE
NotifyRolesを修正

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -428,7 +428,7 @@ namespace TownOfHost
         {
             return PlayerControl.AllPlayerControls.ToArray().Where(pc => pc.PlayerId == PlayerId).FirstOrDefault();
         }
-        public static void NotifyRoles(bool isMeeting = false, PlayerControl SpecifySeer = null, bool NoCache = false)
+        public static void NotifyRoles(bool isMeeting = false, PlayerControl SpecifySeer = null, bool NoCache = false, bool ForceLoop = false)
         {
             if (!AmongUsClient.Instance.AmHost) return;
             if (PlayerControl.AllPlayerControls == null) return;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -574,7 +574,7 @@ namespace TownOfHost
                 if (!isMeeting) SelfName += "\r\n";
 
                 //適用
-                seer.RpcSetNamePrivate(SelfName, true, force: NoCache || isMeeting);
+                seer.RpcSetNamePrivate(SelfName, true, force: NoCache);
 
                 //seerが死んでいる場合など、必要なときのみ第二ループを実行する
                 if (seer.Data.IsDead //seerが死んでいる
@@ -701,7 +701,7 @@ namespace TownOfHost
                         string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetDeathReason}{TargetMark}";
 
                         //適用
-                        target.RpcSetNamePrivate(TargetName, true, seer, force: NoCache || isMeeting);
+                        target.RpcSetNamePrivate(TargetName, true, seer, force: NoCache);
 
                         TownOfHost.Logger.Info("NotifyRoles-Loop2-" + target.GetNameWithRole() + ":END", "NotifyRoles");
                     }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -590,6 +590,7 @@ namespace TownOfHost
                     || seer.Is(CustomRoles.Puppeteer)
                     || IsActive(SystemTypes.Electrical)
                     || NoCache
+                    || ForceLoop
                 )
                 {
                     foreach (var target in PlayerControl.AllPlayerControls)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -428,7 +428,7 @@ namespace TownOfHost
         {
             return PlayerControl.AllPlayerControls.ToArray().Where(pc => pc.PlayerId == PlayerId).FirstOrDefault();
         }
-        public static void NotifyRoles(bool isMeeting = false, PlayerControl SpecifySeer = null, bool force = false)
+        public static void NotifyRoles(bool isMeeting = false, PlayerControl SpecifySeer = null, bool NoCache = false)
         {
             if (!AmongUsClient.Instance.AmHost) return;
             if (PlayerControl.AllPlayerControls == null) return;
@@ -574,7 +574,7 @@ namespace TownOfHost
                 if (!isMeeting) SelfName += "\r\n";
 
                 //適用
-                seer.RpcSetNamePrivate(SelfName, true, force: force || isMeeting);
+                seer.RpcSetNamePrivate(SelfName, true, force: NoCache || isMeeting);
 
                 //seerが死んでいる場合など、必要なときのみ第二ループを実行する
                 if (seer.Data.IsDead //seerが死んでいる
@@ -589,7 +589,7 @@ namespace TownOfHost
                     || seer.Is(CustomRoles.Doctor) //seerがドクター
                     || seer.Is(CustomRoles.Puppeteer)
                     || IsActive(SystemTypes.Electrical)
-                    || force
+                    || NoCache
                 )
                 {
                     foreach (var target in PlayerControl.AllPlayerControls)
@@ -700,7 +700,7 @@ namespace TownOfHost
                         string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetDeathReason}{TargetMark}";
 
                         //適用
-                        target.RpcSetNamePrivate(TargetName, true, seer, force: force || isMeeting);
+                        target.RpcSetNamePrivate(TargetName, true, seer, force: NoCache || isMeeting);
 
                         TownOfHost.Logger.Info("NotifyRoles-Loop2-" + target.GetNameWithRole() + ":END", "NotifyRoles");
                     }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -194,7 +194,7 @@ namespace TownOfHost
         {
             Logger.Info("------------会議開始------------", "Phase");
             Main.witchMeeting = true;
-            Utils.NotifyRoles(isMeeting: true, NoCache: true);
+            Utils.NotifyRoles(isMeeting: true, ForceLoop: true);
             Main.witchMeeting = false;
         }
         public static void Postfix(MeetingHud __instance)

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -194,7 +194,7 @@ namespace TownOfHost
         {
             Logger.Info("------------会議開始------------", "Phase");
             Main.witchMeeting = true;
-            Utils.NotifyRoles(isMeeting: true, force: true);
+            Utils.NotifyRoles(isMeeting: true, NoCache: true);
             Main.witchMeeting = false;
         }
         public static void Postfix(MeetingHud __instance)

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -467,7 +467,7 @@ namespace TownOfHost
             {
                 new LateTask(() =>
                 {
-                    Utils.NotifyRoles(force: true);
+                    Utils.NotifyRoles(NoCache: true);
                 },
                 1.2f, "ShapeShiftNotify");
             }

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -177,7 +177,7 @@ namespace TownOfHost
                 () =>
                 {
                     if (!GameStates.IsMeeting)
-                        Utils.NotifyRoles();
+                        Utils.NotifyRoles(ForceLoop: true);
                 }, 0.1f, "RepairSystem NotifyRoles");
         }
         private static void CheckAndOpenDoorsRange(ShipStatus __instance, int amount, int min, int max)


### PR DESCRIPTION
NotifyRolesの負荷軽減と修正
- forceをNoCacheに変更
- 第二ループを強制するForceLoopを追加
- isMeetingがtrueでもキャッシュを使うように変更
- RepairSystem NotifyRolesで第二ループを強制
  - これにより停電明けのメアーの名前が赤いままのバグが修正