### PR TITLE
Witchのキルボタンの名前を修正

### DIFF
--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -45,16 +45,16 @@ namespace TownOfHost
             {
                 case CustomRoles.Sniper:
                     __instance.AbilityButton.OverrideText($"{GetString("SniperSnipeButtonText")}");
-                break;
+                    break;
                 case CustomRoles.FireWorks:
                     if (FireWorks.nowFireWorksCount[player.PlayerId] == 0)
                         __instance.AbilityButton.OverrideText($"{GetString("FireWorksExplosionButtonText")}");
                     else
                         __instance.AbilityButton.OverrideText($"{GetString("FireWorksInstallAtionButtonText")}");
-                break;
+                    break;
                 case CustomRoles.SerialKiller:
                     __instance.AbilityButton.OverrideText($"{GetString("SerialKillerSuicideButtonText")}");
-                break;
+                    break;
                 case CustomRoles.Warlock:
                     if (!Main.CheckShapeshift[player.PlayerId] && !Main.isCurseAndKill[player.PlayerId])
                     {
@@ -64,25 +64,29 @@ namespace TownOfHost
                     {
                         __instance.KillButton.OverrideText($"{GetString("KillButtonText")}");
                     }
-                break;
+                    break;
                 case CustomRoles.Witch:
                     if (player.GetKillOrSpell())
                     {
                         __instance.KillButton.OverrideText($"{GetString("WitchSpellButtonText")}");
                     }
-                break;
+                    else
+                    {
+                        __instance.KillButton.OverrideText($"{GetString("KillButtonText")}");
+                    }
+                    break;
                 case CustomRoles.Vampire:
                     __instance.KillButton.OverrideText($"{GetString("VampireBiteButtonText")}");
-                break;
+                    break;
                 case CustomRoles.Arsonist:
                     __instance.KillButton.OverrideText($"{GetString("ArsonistDouseButtonText")}");
-                break;
+                    break;
                 case CustomRoles.Puppeteer:
                     __instance.KillButton.OverrideText($"{GetString("PuppeteerOperateButtonText")}");
-                break;
+                    break;
                 case CustomRoles.BountyHunter:
                     __instance.AbilityButton.OverrideText($"{GetString("BountyHunterChangeButtonText")}");
-                break;
+                    break;
             }
 
             __instance.GameSettings.text = OptionShower.GetText();
@@ -166,12 +170,12 @@ namespace TownOfHost
                         __instance.KillButton.SetDisabled();
                         __instance.KillButton.ToggleVisible(false);
                     }
-                break;
+                    break;
                 case CustomRoles.SKMadmate:
                     TaskTextPrefix += FakeTasksText;
                     __instance.KillButton.SetDisabled();
                     __instance.KillButton.ToggleVisible(false);
-                break;
+                    break;
                 case CustomRoles.Sheriff:
                     if (Main.SheriffShotLimit[player.PlayerId] == 0)
                     {


### PR DESCRIPTION
MODクライアントにてWitchのキルボタンがスペルから戻らない問題を修正