### PR TITLE
バウンティでターゲットが連続で同じになる問題を改善

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -520,6 +520,7 @@ namespace TownOfHost
                     cTargets.Add(pc);
                 }
             }
+            if (cTargets.Count >= 2 && Main.BountyTargets.TryGetValue(player.PlayerId, out var p)) cTargets.RemoveAll(x => x.PlayerId == p.PlayerId);
 
             var rand = new System.Random();
             if (cTargets.Count <= 0)


### PR DESCRIPTION
バウンティで前回のターゲットと同じになる問題を改善
- 2つ以上候補がある場合、前回のターゲットをリストから除外