### PR TITLE
推奨設定を復活&調整

### DIFF
--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -38,21 +38,6 @@ namespace TownOfHost
                     case StringNames.GameKillCooldown:
                         ob.Cast<NumberOption>().ValidRange = new FloatRange(0, 180);
                         break;
-                    case StringNames.GameRecommendedSettings:
-                        ob.enabled = false;
-                        ob.gameObject.SetActive(false);
-                        break;
-                    /* case StringNames.GameMapName:
-                        var options = new Il2CppSystem.Collections.Generic.List<Il2CppSystem.Collections.Generic.KeyValuePair<string, int>>();
-                        for (int i = 0; i < Constants.MapNames.Length; i++)
-                        {
-                            var kvp = new Il2CppSystem.Collections.Generic.KeyValuePair<string, int>();
-                            kvp.key = Constants.MapNames[i];
-                            kvp.value = i;
-                            options.Add(kvp);
-                        }
-                        ob.GetComponent<KeyValueOption>().Values = options;
-                        break; */
                     default:
                         break;
                 }

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -326,6 +326,17 @@ namespace TownOfHost
                 __instance.NumShortTasks = 10;
                 __instance.KillCooldown = 10f;
             }
+            if (Options.CurrentGameMode == CustomGameMode.Standard && Options.StandardHAS.GetBool()) //StandardHAS
+            {
+                __instance.PlayerSpeedMod = 1.75f;
+                __instance.CrewLightMod = 1f;
+                __instance.ImpostorLightMod = 1f;
+                __instance.NumImpostors = 1;
+                __instance.NumCommonTasks = 0;
+                __instance.NumLongTasks = 0;
+                __instance.NumShortTasks = 10;
+                __instance.KillCooldown = 10f;
+            }
             return false;
         }
     }

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -282,4 +282,40 @@ namespace TownOfHost
             }
         }
     }
+    [HarmonyPatch(typeof(GameOptionsData), nameof(GameOptionsData.SetRecommendations))]
+    public static class SetRecommendationsPatch
+    {
+        public static bool Prefix(GameOptionsData __instance, int numPlayers, GameModes modes)
+        {
+            numPlayers = Mathf.Clamp(numPlayers, 4, 15);
+            __instance.PlayerSpeedMod = __instance.MapId == 4 ? 1.25f : 1f; //AirShipなら1.25、それ以外は1
+            __instance.CrewLightMod = 0.5f;
+            __instance.ImpostorLightMod = 1.75f;
+            __instance.KillCooldown = GameOptionsData.RecommendedKillCooldown[numPlayers];
+            __instance.NumCommonTasks = 2;
+            __instance.NumLongTasks = 3;
+            __instance.NumShortTasks = 5;
+            __instance.NumEmergencyMeetings = 1;
+            if (modes != GameModes.OnlineGame)
+                __instance.NumImpostors = GameOptionsData.RecommendedImpostors[numPlayers];
+            __instance.KillDistance = 0;
+            __instance.DiscussionTime = 0;
+            __instance.VotingTime = 150;
+            __instance.isDefaults = true;
+            __instance.ConfirmImpostor = false;
+            __instance.VisualTasks = false;
+            __instance.EmergencyCooldown = (int)__instance.killCooldown - 5; //キルクールより5秒短く
+            __instance.RoleOptions.ShapeshifterCooldown = 10f;
+            __instance.RoleOptions.ShapeshifterDuration = 30f;
+            __instance.RoleOptions.ShapeshifterLeaveSkin = false;
+            __instance.RoleOptions.ImpostorsCanSeeProtect = false;
+            __instance.RoleOptions.ScientistCooldown = 15f;
+            __instance.RoleOptions.ScientistBatteryCharge = 5f;
+            __instance.RoleOptions.GuardianAngelCooldown = 60f;
+            __instance.RoleOptions.ProtectionDurationSeconds = 10f;
+            __instance.RoleOptions.EngineerCooldown = 30f;
+            __instance.RoleOptions.EngineerInVentMaxTime = 15f;
+            return false;
+        }
+    }
 }

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -315,6 +315,17 @@ namespace TownOfHost
             __instance.RoleOptions.ProtectionDurationSeconds = 10f;
             __instance.RoleOptions.EngineerCooldown = 30f;
             __instance.RoleOptions.EngineerInVentMaxTime = 15f;
+            if (Options.CurrentGameMode == CustomGameMode.HideAndSeek) //HideAndSeek
+            {
+                __instance.PlayerSpeedMod = 1.75f;
+                __instance.CrewLightMod = 5f;
+                __instance.ImpostorLightMod = 0.25f;
+                __instance.NumImpostors = 1;
+                __instance.NumCommonTasks = 0;
+                __instance.NumLongTasks = 0;
+                __instance.NumShortTasks = 10;
+                __instance.KillCooldown = 10f;
+            }
             return false;
         }
     }


### PR DESCRIPTION
誤爆するとして推奨設定を無効化していましたが、現在一般的な設定に沿うように調整を入れて復活させました。
また、HAS用の設定を追加することで利便性を向上させました。

従来からの変更点
- AirShipの時の速度を1.25
- クルー視界を0.5
- インポスター視界を1.75
- タスクをC2, L3 , S5
- キルの距離をショート
- 会議時間を0に
- 追放確認をオフ
- ビジュアルタスクをオフ
- 緊急会議ボタンのクールダウンをキルクールより5秒短く

HAS用設定
- プレイヤー速度を1.75
- クルー視界を5
- インポスター視界を0.25
- インポスター人数を1
- タスクをC0, L0, S10
- キルクールを10秒

StandardHAS用 
- プレイヤー速度を1.75
- クルー視界を1
- インポスター視界を1
- インポスター人数を1
- タスクをC0, L0, S10
- キルクールを10秒