### PR TITLE
TOHオプション画面でCtrl+Deleteを押すとすべてデフォルト値に

### DIFF
--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using HarmonyLib;
 using Hazel;
 using InnerNet;
@@ -63,6 +64,11 @@ namespace TownOfHost
             if (Input.GetKeyDown(KeyCode.N) && Input.GetKey(KeyCode.LeftControl))
             {
                 Utils.ShowActiveSettingsHelp();
+            }
+            //TOHオプションをデフォルトに設定
+            if (Input.GetKeyDown(KeyCode.Delete) && Input.GetKey(KeyCode.LeftControl) && GameObject.Find(GameOptionsMenuPatch.TownOfHostObjectName) != null)
+            {
+                CustomOption.Options.ToArray().Where(x => x.Id > 0).Do(x => x.UpdateSelection(x.DefaultSelection));
             }
 
             //--以下デバッグモード用コマンド--//

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -22,7 +22,7 @@ namespace TownOfHost
     [HarmonyPriority(Priority.First)]
     public static class GameOptionsMenuPatch
     {
-        private const string TownOfHostObjectName = "TOHSettings";
+        public const string TownOfHostObjectName = "TOHSettings";
 
         public static void Postfix(GameOptionsMenu __instance)
         {


### PR DESCRIPTION
TOHオプションすべてデフォルト値にするホットキーを追加
- TOHオプション画面でCtrl+Delete