### PR TITLE
ルームコード自動貼り付けの条件を修正

### DIFF
--- a/Patches/JoinGameButtonPatch.cs
+++ b/Patches/JoinGameButtonPatch.cs
@@ -10,10 +10,10 @@ namespace TownOfHost
         public static void Prefix(JoinGameButton __instance)
         {
             if (__instance.GameIdText == null) return;
-            if (Regex.IsMatch(GUIUtility.systemCopyBuffer, @"[A-Z]{6}"))
+            if (__instance.GameIdText.text == "" && Regex.IsMatch(GUIUtility.systemCopyBuffer.Trim('\r', '\n'), @"^[A-Z]{6}$"))
             {
                 Logger.Info($"{GUIUtility.systemCopyBuffer}", "ClipBoard");
-                __instance.GameIdText.SetText(GUIUtility.systemCopyBuffer);
+                __instance.GameIdText.SetText(GUIUtility.systemCopyBuffer.Trim('\r', '\n'));
             }
         }
     }


### PR DESCRIPTION
ルームコード自動貼り付けの条件を修正
- 条件をを完全一致に変更
- 空欄の時のみ実行
- クリップボードから制御文字を削除