### PR TITLE
AfterMeetingTasksで辞書重複の例外を修正

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -721,12 +721,12 @@ namespace TownOfHost
                 if (pc.Is(CustomRoles.SerialKiller))
                 {
                     pc.RpcResetAbilityCooldown();
-                    Main.SerialKillerTimer.Add(pc.PlayerId, 0f);
+                    Main.SerialKillerTimer.TryAdd(pc.PlayerId, 0f);
                 }
                 if (pc.Is(CustomRoles.BountyHunter))
                 {
                     pc.RpcResetAbilityCooldown();
-                    Main.BountyTimer.Add(pc.PlayerId, 0f);
+                    Main.BountyTimer.TryAdd(pc.PlayerId, 0f);
                 }
             }
         }


### PR DESCRIPTION
AfterMeetingTasksで辞書重複の例外を修正
- AddをTryAddに変更