### PR TITLE
/now rolesでバニラ役職が表示できない問題を修正

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -85,6 +85,26 @@ namespace TownOfHost
                 return Options.GetRoleCount(role);
             }
         }
+        public static float GetChance(this CustomRoles role)
+        {
+            if (role.IsVanilla())
+            {
+                RoleOptionsData roleOpt = PlayerControl.GameOptions.RoleOptions;
+                return role switch
+                {
+                    CustomRoles.Engineer => roleOpt.GetChancePerGame(RoleTypes.Engineer),
+                    CustomRoles.Scientist => roleOpt.GetChancePerGame(RoleTypes.Scientist),
+                    CustomRoles.Shapeshifter => roleOpt.GetChancePerGame(RoleTypes.Shapeshifter),
+                    CustomRoles.GuardianAngel => roleOpt.GetChancePerGame(RoleTypes.GuardianAngel),
+                    CustomRoles.Crewmate => roleOpt.GetChancePerGame(RoleTypes.Crewmate),
+                    _ => 0
+                } / 100f;
+            }
+            else
+            {
+                return Options.GetRoleChance(role);
+            }
+        }
         public static bool IsEnable(this CustomRoles role) => role.GetCount() > 0;
     }
     public enum RoleType

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -233,6 +233,11 @@ namespace TownOfHost
             var chance = CustomRoleSpawnChances.TryGetValue(role, out var sc) ? sc.GetSelection() : 0;
             return chance == 0 ? 0 : CustomRoleCounts.TryGetValue(role, out var option) ? (int)option.GetFloat() : roleCounts[role];
         }
+
+        public static float GetRoleChance(CustomRoles role)
+        {
+            return CustomRoleSpawnChances.TryGetValue(role, out var option) ? option.GetSelection() / 10 : roleSpawnChances[role];
+        }
         public static void Load()
         {
             if (IsLoaded) return;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -321,7 +321,7 @@ namespace TownOfHost
             foreach (CustomRoles role in Enum.GetValues(typeof(CustomRoles)))
             {
                 if (role is CustomRoles.HASFox or CustomRoles.HASTroll) continue;
-                if (role.IsEnable()) text += string.Format("\n{0}:{1}x{2}", GetRoleName(role), Options.CustomRoleSpawnChances[role].GetString(), role.GetCount());
+                if (role.IsEnable()) text += string.Format("\n{0}:{1}x{2}", GetRoleName(role), $"{role.GetChance() * 100}%", role.GetCount());
             }
             SendMessage(text, PlayerId);
         }


### PR DESCRIPTION
/now rolesでバニラ役職が表示できない問題を修正
- メソッドの追加
  - GetChance
  - GetRoleChance
- 割り当て取得をGetChanceメソッドに置き換え