### PR TITLE
マッドメイトを作れる残り数を表示

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -674,6 +674,13 @@ namespace TownOfHost
             var count = Utils.getDousedPlayerCount(player.PlayerId);
             return count.Item1 == count.Item2;
         }
+        public static bool CanMakeMadmate(this PlayerControl player)
+        {
+            return Options.CanMakeMadmateCount.GetInt() > Main.SKMadmateNowCount
+                    && player != null
+                    && player.Data.Role.Role == RoleTypes.Shapeshifter
+                    && !player.Is(CustomRoles.Warlock) && !player.Is(CustomRoles.FireWorks) && !player.Is(CustomRoles.Sniper);
+        }
         public static void ResetThiefVotingTime(this PlayerControl thief)
         {
             for (var i = 0; i < Main.TimeThiefKillCount[thief.PlayerId]; i++)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -225,6 +225,7 @@ namespace TownOfHost
                     }
                     break;
             }
+            if (GetPlayerById(playerId).CanMakeMadmate()) ProgressText += $" [{Options.CanMakeMadmateCount.GetInt() - Main.SKMadmateNowCount}]";
 
             return ProgressText;
         }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -433,9 +433,8 @@ namespace TownOfHost
                     Main.CursedPlayers[shapeshifter.PlayerId] = null;
                 }
             }
-            var canMakeSKMadmateRoles = !shapeshifter.Is(CustomRoles.Warlock) && !shapeshifter.Is(CustomRoles.FireWorks) && !shapeshifter.Is(CustomRoles.Sniper);
 
-            if (Options.CanMakeMadmateCount.GetFloat() > Main.SKMadmateNowCount && canMakeSKMadmateRoles && shapeshifting)
+            if (shapeshifter.CanMakeMadmate() && shapeshifting)
             {//変身したとき一番近い人をマッドメイトにする処理
                 Vector2 shapeshifterPosition = shapeshifter.transform.position;//変身者の位置
                 Dictionary<PlayerControl, float> mpdistance = new();


### PR DESCRIPTION
ロールの横にマッドメイトを作れる残りの数を表示
- マッドメイトを作れるか確認するCanMakeMadmateを追加
- マッドメイトを作る処理をCanMakeMadmateに置換

このPRではSKMadmateNowCountの同期を行っていないのでMODクライアントはカウントが減りません。