### PR TITLE
RpcVersionCheckで稀にキックされる問題を修正

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -262,7 +262,7 @@ namespace TownOfHost
         }
         public static async void RpcVersionCheck()
         {
-            while (PlayerControl.LocalPlayer == null) await Task.Delay(1);
+            while (PlayerControl.LocalPlayer == null) await Task.Delay(500);
             MessageWriter writer = AmongUsClient.Instance.StartRpc(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.VersionCheck, SendOption.Reliable);
             writer.Write(Main.PluginVersion);
             writer.Write($"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})");


### PR DESCRIPTION
RpcVersionCheckが早すぎると稀にパケットが欠落して不正なRPCとしてキックされる問題を修正（恐らく）
- RPCを500ms待機