### PR TITLE
アーソニストがタスクを終えたMadGuardianをキルしようとしたときに名前が赤くなる問題を修正

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -165,6 +165,11 @@ namespace TownOfHost
 
                 //==========マッドメイト系役職==========//
                 case CustomRoles.MadGuardian:
+                    //killerがキルできないインポスター判定役職の場合はスキップ
+                    if (killer.Is(CustomRoles.Arsonist) //アーソニスト
+                    ) break;
+
+                    //MadGuardianを切れるかの判定処理
                     var taskState = target.GetPlayerTaskState();
                     if (taskState.IsTaskFinished)
                     {


### PR DESCRIPTION
バグ報告ticket-0208の修正
アーソニストがタスクを終えたMadGuardianに塗ろうとしたときに、MadGuardianを切れるかの処理が入って塗れない&アーソニスト視点でMadGuardianの名前が赤くなる という問題を修正