### PR TITLE
翻訳のキーを改名

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -330,7 +330,7 @@ namespace TownOfHost
         {
             if (AmongUsClient.Instance.IsGameStarted)
             {
-                SendMessage(GetString("CantUse/lastroles"), PlayerId);
+                SendMessage(GetString("CantUse.lastroles"), PlayerId);
                 return;
             }
             var text = GetString("LastResult") + ":";

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -340,7 +340,7 @@ Command.h_modes,<ModeName> - Display About Mode,<モード名> - モードの説
 Command.dump,Output Log to Desktop,デスクトップにログを出力
 Command.h_args,Available Args (clipped),使用可能な引数 (略称)
 
-CantUse/lastroles,Can't use /lastroles in the game.,試合中に/lastrolesを使用することはできません。
+CantUse.lastroles,Can't use /lastroles in the game.,試合中に/lastrolesを使用することはできません。
 
 ## その他
 updateButton,Update\n<size=75%>TownOfHost</size>,アップデート\n<size=75%>TownOfHost</size>


### PR DESCRIPTION
CantUse/lastrolesをCantUse.lastrolesに改名