### PR TITLE
ウィッチがスペルモードでキルできてしまう問題を修正

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -543,7 +543,7 @@ namespace TownOfHost
             AmongUsClient.Instance.FinishRpcImmediately(writer);
             return target;
         }
-        public static bool GetKillOrSpell(this PlayerControl player)
+        public static bool IsSpellMode(this PlayerControl player)
         {
             if (!Main.KillOrSpell.TryGetValue(player.PlayerId, out var KillOrSpell))
             {
@@ -556,7 +556,7 @@ namespace TownOfHost
         {
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetKillOrSpell, SendOption.Reliable, -1);
             writer.Write(player.PlayerId);
-            writer.Write(player.GetKillOrSpell());
+            writer.Write(player.IsSpellMode());
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
         public static void RpcSetSheriffShotLimit(this PlayerControl player)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -538,8 +538,8 @@ namespace TownOfHost
                 }
                 if (seer.Is(CustomRoles.Witch))
                 {
-                    if (seer.GetKillOrSpell() == false) SelfSuffix = "Mode:" + GetString("WitchModeKill");
-                    if (seer.GetKillOrSpell() == true) SelfSuffix = "Mode:" + GetString("WitchModeSpell");
+                    if (seer.IsSpellMode() == false) SelfSuffix = "Mode:" + GetString("WitchModeKill");
+                    if (seer.IsSpellMode() == true) SelfSuffix = "Mode:" + GetString("WitchModeSpell");
                 }
 
                 //他人用の変数定義

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -538,8 +538,7 @@ namespace TownOfHost
                 }
                 if (seer.Is(CustomRoles.Witch))
                 {
-                    if (seer.IsSpellMode() == false) SelfSuffix = "Mode:" + GetString("WitchModeKill");
-                    if (seer.IsSpellMode() == true) SelfSuffix = "Mode:" + GetString("WitchModeSpell");
+                    SelfSuffix = seer.IsSpellMode() ? "Mode:" + GetString("WitchModeSpell") : "Mode:" + GetString("WitchModeKill");
                 }
 
                 //他人用の変数定義

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -66,7 +66,7 @@ namespace TownOfHost
                     }
                     break;
                 case CustomRoles.Witch:
-                    if (player.GetKillOrSpell())
+                    if (player.IsSpellMode())
                     {
                         __instance.KillButton.OverrideText($"{GetString("WitchSpellButtonText")}");
                     }
@@ -118,7 +118,7 @@ namespace TownOfHost
             else if (player.Is(CustomRoles.Witch))
             {
                 //魔女用処理
-                var ModeLang = player.GetKillOrSpell() ? "WitchModeSpell" : "WitchModeKill";
+                var ModeLang = player.IsSpellMode() ? "WitchModeSpell" : "WitchModeKill";
                 LowerInfoText.text = GetString("WitchCurrentMode") + ":" + GetString(ModeLang);
                 LowerInfoText.enabled = true;
             }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -250,14 +250,14 @@ namespace TownOfHost
                         if (Main.isCurseAndKill[killer.PlayerId]) killer.RpcGuardAndKill(target);
                         return false;
                     case CustomRoles.Witch:
-                        if (killer.GetKillOrSpell() && !Main.SpelledPlayer.Contains(target))
+                        if (killer.IsSpellMode() && !Main.SpelledPlayer.Contains(target))
                         {
                             killer.RpcGuardAndKill(target);
                             Main.SpelledPlayer.Add(target);
                             RPC.RpcDoSpell(target.PlayerId);
                             return false;
                         }
-                        Main.KillOrSpell[killer.PlayerId] = !killer.GetKillOrSpell();
+                        Main.KillOrSpell[killer.PlayerId] = !killer.IsSpellMode();
                         Utils.NotifyRoles();
                         killer.SyncKillOrSpell();
                         break;

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -255,11 +255,11 @@ namespace TownOfHost
                             killer.RpcGuardAndKill(target);
                             Main.SpelledPlayer.Add(target);
                             RPC.RpcDoSpell(target.PlayerId);
-                            return false;
                         }
                         Main.KillOrSpell[killer.PlayerId] = !killer.IsSpellMode();
                         Utils.NotifyRoles();
                         killer.SyncKillOrSpell();
+                        if (!killer.IsSpellMode()) return false;
                         break;
                     case CustomRoles.Puppeteer:
                         Main.PuppeteerList[target.PlayerId] = killer.PlayerId;

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -255,6 +255,7 @@ namespace TownOfHost
                             killer.RpcGuardAndKill(target);
                             Main.SpelledPlayer.Add(target);
                             RPC.RpcDoSpell(target.PlayerId);
+                            return false;
                         }
                         Main.KillOrSpell[killer.PlayerId] = !killer.GetKillOrSpell();
                         Utils.NotifyRoles();


### PR DESCRIPTION
ウィッチがスペルモードでキルできてしまう問題を修正
- スペルモードの時MurderPlayerを行わない
- 名前を取れる値があってないのでGetKillOrSpellをIsSpellModeに改名