### PR TITLE
キルクールが勝手に0秒になる問題を修正

### DIFF
--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -15,6 +15,7 @@ namespace TownOfHost
             GameStates.InGame = false;
 
             Logger.Info("-----------ゲーム終了-----------", "Phase");
+            PlayerControl.GameOptions = Main.RealOptionsData;
             //winnerListリセット
             TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
             Main.additionalwinners = new HashSet<AdditionalWinners>();


### PR DESCRIPTION
キルクールが勝手に0秒になる問題を修正
- ゲーム終了時に基本設定をリストア