### PR TITLE
EndGameに特殊勝利を集約

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -133,7 +133,7 @@ namespace TownOfHost
                     RPC.ArsonistWin(wonArsonist);
                     break;
                 case CustomRPC.EndGame:
-                    RPC.EndGame();
+                    RPC.ForceEndGame();
                     break;
                 case CustomRPC.PlaySound:
                     byte playerID = reader.ReadByte();
@@ -314,7 +314,7 @@ namespace TownOfHost
             Main.currentWinner = CustomWinner.Arsonist;
             CustomWinTrigger(arsonistID);
         }
-        public static void EndGame()
+        public static void ForceEndGame()
         {
             if (ShipStatus.Instance == null) return;
             Main.currentWinner = CustomWinner.Draw;

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -12,11 +12,6 @@ namespace TownOfHost
         VersionCheck = 60,
         SyncCustomSettings = 80,
         SetDeathReason,
-        TrollWin,
-        JesterExiled,
-        TerroristWin,
-        ExecutionerWin,
-        ArsonistWin,
         EndGame,
         PlaySound,
         SetCustomRole,
@@ -112,28 +107,8 @@ namespace TownOfHost
                 case CustomRPC.SetDeathReason:
                     RPC.GetDeathReason(reader);
                     break;
-                case CustomRPC.TrollWin:
-                    byte wonTroll = reader.ReadByte();
-                    RPC.TrollWin(wonTroll);
-                    break;
-                case CustomRPC.JesterExiled:
-                    byte exiledJester = reader.ReadByte();
-                    RPC.JesterExiled(exiledJester);
-                    break;
-                case CustomRPC.TerroristWin:
-                    byte wonTerrorist = reader.ReadByte();
-                    RPC.TerroristWin(wonTerrorist);
-                    break;
-                case CustomRPC.ExecutionerWin:
-                    byte wonExecutioner = reader.ReadByte();
-                    RPC.ExecutionerWin(wonExecutioner);
-                    break;
-                case CustomRPC.ArsonistWin:
-                    byte wonArsonist = reader.ReadByte();
-                    RPC.ArsonistWin(wonArsonist);
-                    break;
                 case CustomRPC.EndGame:
-                    RPC.ForceEndGame();
+                    RPC.EndGame(reader);
                     break;
                 case CustomRPC.PlaySound:
                     byte playerID = reader.ReadByte();
@@ -284,6 +259,43 @@ namespace TownOfHost
             PlayerState.isDead[playerId] = true;
         }
 
+        public static void EndGame(MessageReader reader)
+        {
+            try
+            {
+                List<byte> winner = new();
+                Main.currentWinner = (CustomWinner)reader.ReadByte();
+                while (reader.BytesRemaining > 0) winner.Add(reader.ReadByte());
+                switch (Main.currentWinner)
+                {
+                    case CustomWinner.Draw:
+                        ForceEndGame();
+                        break;
+                    case CustomWinner.Jester:
+                        JesterExiled(winner[0]);
+                        break;
+                    case CustomWinner.Terrorist:
+                        TerroristWin(winner[0]);
+                        break;
+                    case CustomWinner.Executioner:
+                        ExecutionerWin(winner[0]);
+                        break;
+                    case CustomWinner.Arsonist:
+                        ArsonistWin(winner[0]);
+                        break;
+                    case CustomWinner.HASTroll:
+                        TrollWin(winner[0]);
+                        break;
+                    default:
+                        Logger.Warn($"{Main.currentWinner}は無効なCustomWinnerです", "EndGame");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"正常にEndGameを行えませんでした。{ex}", "EndGame");
+            }
+        }
         public static void TrollWin(byte trollID)
         {
             Main.WonTrollID = trollID;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -399,7 +399,8 @@ namespace TownOfHost
                         PlayerState.SetDead(pc.PlayerId);
                     }
                 }
-                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TerroristWin, Hazel.SendOption.Reliable, -1);
+                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
+                writer.Write((byte)CustomWinner.Terrorist);
                 writer.Write(Terrorist.PlayerId);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
                 RPC.TerroristWin(Terrorist.PlayerId);

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -127,7 +127,8 @@ namespace TownOfHost
                 if (!hasRole) return false;
                 if (role == CustomRoles.HASTroll && pc.Data.IsDead)
                 {
-                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.TrollWin, Hazel.SendOption.Reliable, -1);
+                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
+                    writer.Write((byte)CustomWinner.HASTroll);
                     writer.Write(pc.PlayerId);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
                     RPC.TrollWin(pc.PlayerId);

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -41,7 +41,7 @@ namespace TownOfHost
             {
                 MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
-                RPC.EndGame();
+                RPC.ForceEndGame();
             }
             //ミーティングを強制終了
             if (Input.GetKeyDown(KeyCode.Return) && Input.GetKey(KeyCode.M) && Input.GetKey(KeyCode.LeftShift) && GameStates.IsMeeting)

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -33,7 +33,8 @@ namespace TownOfHost
                 var role = exiled.GetCustomRole();
                 if (role == CustomRoles.Jester && AmongUsClient.Instance.AmHost)
                 {
-                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.JesterExiled, Hazel.SendOption.Reliable, -1);
+                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
+                    writer.Write((byte)CustomWinner.Jester);
                     writer.Write(exiled.PlayerId);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
                     RPC.JesterExiled(exiled.PlayerId);
@@ -52,7 +53,8 @@ namespace TownOfHost
                     if (kvp.Value == exiled.PlayerId && AmongUsClient.Instance.AmHost && !DecidedWinner)
                     {
                         //RPC送信開始
-                        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.ExecutionerWin, Hazel.SendOption.Reliable, -1);
+                        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
+                        writer.Write((byte)CustomWinner.Executioner);
                         writer.Write(kvp.Key);
                         AmongUsClient.Instance.FinishRpcImmediately(writer); //終了
 

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -1162,7 +1162,8 @@ namespace TownOfHost
                                 RPC.PlaySoundRPC(pc.PlayerId, Sounds.KillSound);
                         }
                     }
-                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.ArsonistWin, Hazel.SendOption.Reliable, -1);
+                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
+                    writer.Write((byte)CustomWinner.Arsonist);
                     writer.Write(__instance.myPlayer.PlayerId);
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
                     RPC.ArsonistWin(__instance.myPlayer.PlayerId);


### PR DESCRIPTION
EndGameに特殊勝利を集約
- Draw・Jester・Terrorist・Troll・Arsonist・ExecutionerをEndGameに統一

単独勝利陣営が増えると無限にCustomRPCが汚染されるので統一させました。