### PR TITLE
Hotfix/FindClosestTarget

### DIFF
--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -274,6 +274,7 @@ namespace TownOfHost
         public static bool Prefix(CrewmateRole __instance, ref PlayerControl __result)
         {
             var player = PlayerControl.LocalPlayer;
+            if (!player.AmOwner || !AmongUsClient.Instance.AmHost) return true;
             if ((player.GetCustomRole() == CustomRoles.Sheriff || player.GetCustomRole() == CustomRoles.Arsonist) &&
                 __instance.Role != RoleTypes.GuardianAngel)
             {

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -268,10 +268,10 @@ namespace TownOfHost
             }
         }
     }
-    [HarmonyPatch(typeof(RoleBehaviour), nameof(RoleBehaviour.FindClosestTarget))]
+    [HarmonyPatch(typeof(CrewmateRole), nameof(CrewmateRole.FindClosestTarget))]
     class FindClosestTargetPatch
     {
-        public static bool Prefix(RoleBehaviour __instance, ref PlayerControl __result)
+        public static bool Prefix(CrewmateRole __instance, ref PlayerControl __result)
         {
             var player = PlayerControl.LocalPlayer;
             if ((player.GetCustomRole() == CustomRoles.Sheriff || player.GetCustomRole() == CustomRoles.Arsonist) &&

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -271,13 +271,16 @@ namespace TownOfHost
     [HarmonyPatch(typeof(RoleBehaviour), nameof(RoleBehaviour.FindClosestTarget))]
     class FindClosestTargetPatch
     {
-        public static void Prefix(RoleBehaviour __instance)
+        public static bool Prefix(RoleBehaviour __instance, ref PlayerControl __result)
         {
             var player = PlayerControl.LocalPlayer;
             if ((player.GetCustomRole() == CustomRoles.Sheriff || player.GetCustomRole() == CustomRoles.Arsonist) &&
                 __instance.Role != RoleTypes.GuardianAngel)
             {
+                __result = OLD_FindClosestTarget(player);
+                return false;
             }
+            return true;
         }
 
         private static PlayerControl OLD_FindClosestTarget(PlayerControl from)

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -266,19 +266,18 @@ namespace TownOfHost
             }
         }
     }
-    // [HarmonyPatch(typeof(RoleBehaviour), nameof(RoleBehaviour.FindClosestTarget))]
-    // class FindClosestTargetPatch
-    // {
-    //     public static void Prefix(PlayerControl __instance, [HarmonyArgument(0)] ref bool protecting)
-    //     {
-    //         var player = PlayerControl.LocalPlayer;
-    //         if ((player.GetCustomRole() == CustomRoles.Sheriff || player.GetCustomRole() == CustomRoles.Arsonist) &&
-    //             __instance.Data.Role.Role != RoleTypes.GuardianAngel)
-    //         {
-    //             protecting = true;
-    //         }
-    //     }
-    // }
+    [HarmonyPatch(typeof(RoleBehaviour), nameof(RoleBehaviour.FindClosestTarget))]
+    class FindClosestTargetPatch
+    {
+        public static void Prefix(RoleBehaviour __instance)
+        {
+            var player = PlayerControl.LocalPlayer;
+            if ((player.GetCustomRole() == CustomRoles.Sheriff || player.GetCustomRole() == CustomRoles.Arsonist) &&
+                __instance.Role != RoleTypes.GuardianAngel)
+            {
+            }
+        }
+    }
     [HarmonyPatch(typeof(HudManager), nameof(HudManager.SetHudActive))]
     class SetHudActivePatch
     {


### PR DESCRIPTION
ホストのSheriff・Arsonistが誰も切れない・塗れない状態になっていたのを修正
バニラのFindClosestTargetの中身がわからないため、応急処置として旧バージョンのFindClosestTargetを持ってきています。