### PR TITLE
FindClosestTargetで例外が出る問題を修正

### DIFF
--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -274,7 +274,7 @@ namespace TownOfHost
         public static bool Prefix(CrewmateRole __instance, ref PlayerControl __result)
         {
             var player = PlayerControl.LocalPlayer;
-            if (!player.AmOwner || !AmongUsClient.Instance.AmHost) return true;
+            if (player == null || !player.AmOwner || !AmongUsClient.Instance.AmHost) return true;
             if ((player.GetCustomRole() == CustomRoles.Sheriff || player.GetCustomRole() == CustomRoles.Arsonist) &&
                 __instance.Role != RoleTypes.GuardianAngel)
             {


### PR DESCRIPTION
FindClosestTargetで例外が出る問題を修正
- PlayerControl.LocalPlayerにnullチェックを追加