### PR TITLE
チャットの送信制限を改善

### DIFF
--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -417,7 +417,7 @@ namespace TownOfHost
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcSendChat))]
     class RpcSendChatPatch
     {
-        public static bool Prefix(PlayerControl __instance, string chatText, bool __result)
+        public static bool Prefix(PlayerControl __instance, string chatText, ref bool __result)
         {
             if (string.IsNullOrWhiteSpace(chatText))
             {

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -387,7 +387,7 @@ namespace TownOfHost
     {
         public static void Postfix(ChatController __instance)
         {
-            if (!AmongUsClient.Instance.AmHost || Main.MessagesToSend.Count < 1 || Main.MessageWait.Value > __instance.TimeSinceLastMessage) return;
+            if (!AmongUsClient.Instance.AmHost || Main.MessagesToSend.Count < 1 || (Main.MessagesToSend[0].Item2 == byte.MaxValue && Main.MessageWait.Value > __instance.TimeSinceLastMessage)) return;
             var player = PlayerControl.AllPlayerControls.ToArray().OrderBy(x => x.PlayerId).Where(x => !x.Data.IsDead).FirstOrDefault();
             (string msg, byte sendTo) = Main.MessagesToSend[0];
             Main.MessagesToSend.RemoveAt(0);

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -17,6 +17,7 @@ namespace TownOfHost
         public static bool Prefix(ChatController __instance)
         {
             if (__instance.TextArea.text == "") return false;
+            __instance.TimeSinceLastMessage = 3f;
             var text = __instance.TextArea.text;
             if (ChatHistory.Count == 0 || ChatHistory[^1] != text) ChatHistory.Add(text);
             ChatControllerUpdatePatch.CurrentHistorySelection = ChatHistory.Count;


### PR DESCRIPTION
他プレイヤーにコマンド送信中、待ち時間が発生するのでチャットの送信制限を改善
- 全体送信以外は0秒で送信
- RpcSendChatをBANされないように置き換え
- 手動送信時のチャットの待ち時間を撤廃