### PR TITLE
ホストが死んでいると処刑コマンドを使えない問題を修正

### DIFF
--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -336,7 +336,7 @@ namespace TownOfHost
             if (!AmongUsClient.Instance.AmHost) return;
             if (Input.GetMouseButtonUp(1) && Input.GetKey(KeyCode.LeftControl))
             {
-                __instance.playerStates.DoIf(x => x.transform.Find("votePlayerBase/ControllerHighlight").GetComponent<SpriteRenderer>().enabled, x =>
+                __instance.playerStates.DoIf(x => x.HighlightedFX.enabled, x =>
                 {
                     var player = Utils.GetPlayerById(x.TargetPlayerId);
                     player.RpcExileV2();

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -347,6 +347,17 @@ namespace TownOfHost
             }
         }
     }
+    [HarmonyPatch(typeof(PlayerVoteArea), nameof(PlayerVoteArea.SetHighlighted))]
+    class SetHighlightedPatch
+    {
+        public static bool Prefix(PlayerVoteArea __instance, bool value)
+        {
+            if (!AmongUsClient.Instance.AmHost) return true;
+            if (!__instance.HighlightedFX) return false;
+            __instance.HighlightedFX.enabled = value;
+            return false;
+        }
+    }
     [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.OnDestroy))]
     class MeetingHudOnDestroyPatch
     {

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -342,6 +342,7 @@ namespace TownOfHost
                     player.RpcExileV2();
                     PlayerState.SetDeathReason(player.PlayerId, PlayerState.DeathReason.Execution);
                     PlayerState.SetDead(player.PlayerId);
+                    Utils.SendMessage($"{player.Data.PlayerName}を処刑しました");
                     Logger.Info($"{player.GetNameWithRole()}を処刑しました", "Execution");
                 });
             }


### PR DESCRIPTION
ホストが死んでいると処刑コマンドを使えない問題を修正
- ホストのみ死んでいてもハイライトを有効に