### PR TITLE
Feature/FindClosestTarget-Fix

### DIFF
--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -268,51 +268,6 @@ namespace TownOfHost
             }
         }
     }
-    [HarmonyPatch(typeof(CrewmateRole), nameof(CrewmateRole.FindClosestTarget))]
-    class FindClosestTargetPatch
-    {
-        public static bool Prefix(CrewmateRole __instance, ref PlayerControl __result)
-        {
-            var player = PlayerControl.LocalPlayer;
-            if (player == null || !player.AmOwner || !AmongUsClient.Instance.AmHost) return true;
-            if ((player.GetCustomRole() == CustomRoles.Sheriff || player.GetCustomRole() == CustomRoles.Arsonist) &&
-                __instance.Role != RoleTypes.GuardianAngel)
-            {
-                __result = OLD_FindClosestTarget(player);
-                return false;
-            }
-            return true;
-        }
-
-        private static PlayerControl OLD_FindClosestTarget(PlayerControl from)
-        {
-            PlayerControl closestTarget = null;
-            float num = GameOptionsData.KillDistances[Mathf.Clamp(PlayerControl.GameOptions.KillDistance, 0, 2)];
-            if (!(bool)(UnityEngine.Object)ShipStatus.Instance)
-                return (PlayerControl)null;
-            Vector2 truePosition = from.GetTruePosition();
-            GameData.PlayerInfo[] allPlayers = GameData.Instance.AllPlayers.ToArray();
-            for (int index = 0; index < allPlayers.Length; ++index)
-            {
-                GameData.PlayerInfo playerInfo = allPlayers[index];
-                if (playerInfo != null && !playerInfo.Disconnected && playerInfo.PlayerId != from.PlayerId && !playerInfo.IsDead && !playerInfo.Object.inVent)
-                {
-                    PlayerControl playerControl = playerInfo.Object;
-                    if ((bool)(UnityEngine.Object)playerControl && playerControl.Collider.enabled)
-                    {
-                        Vector2 vector2 = playerControl.GetTruePosition() - truePosition;
-                        float magnitude = vector2.magnitude;
-                        if ((double)magnitude <= (double)num && !PhysicsHelpers.AnyNonTriggersBetween(truePosition, vector2.normalized, magnitude, Constants.ShipAndObjectsMask))
-                        {
-                            closestTarget = playerControl;
-                            num = magnitude;
-                        }
-                    }
-                }
-            }
-            return closestTarget;
-        }
-    }
     [HarmonyPatch(typeof(HudManager), nameof(HudManager.SetHudActive))]
     class SetHudActivePatch
     {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -182,10 +182,14 @@ namespace TownOfHost
                         }
                         else
                         {
-                            //ホストは代わりに普通のクルーにする
-                            sheriff.SetRole(RoleTypes.Crewmate); //ホスト視点用
+                            //ホストは代わりに自視点守護天使, 他視点普通のクルーにする
+                            sheriff.SetRole(RoleTypes.GuardianAngel); //ホスト視点用
                             sender.RpcSetRole(sheriff, RoleTypes.Crewmate);
                             //sheriff.RpcSetRole(RoleTypes.Crewmate);
+
+                            //ただし、RoleBehaviourはGuardianAngelRole、RoleTypeはCrewmateという特殊な状態にする。
+                            //これにより、RoleTypeがGuardianEngelになったら本当に守護天使化したと判別できる。
+                            sheriff.Data.Role.Role = RoleTypes.Crewmate;
                         }
                         sheriff.Data.IsDead = true;
                     }
@@ -223,10 +227,14 @@ namespace TownOfHost
                         }
                         else
                         {
-                            //ホストは代わりに普通のクルーにする
-                            arsonist.SetRole(RoleTypes.Crewmate); //ホスト視点用
+                            //ホストは代わりに自視点守護天使, 他視点普通のクルーにする
+                            arsonist.SetRole(RoleTypes.GuardianAngel); //ホスト視点用
                             sender.RpcSetRole(arsonist, RoleTypes.Crewmate);
                             //arsonist.RpcSetRole(RoleTypes.Crewmate);
+
+                            //ただし、RoleBehaviourはGuardianAngelRole、RoleTypeはCrewmateという特殊な状態にする。
+                            //これにより、RoleTypeがGuardianEngelになったら本当に守護天使化したと判別できる。
+                            arsonist.Data.Role.Role = RoleTypes.Crewmate;
                         }
                         arsonist.Data.IsDead = true;
                     }


### PR DESCRIPTION
応急処置していたFindClosestTargetをいい感じに修正。
具体的に言うと、ホストシェリフのRoleBehaviourを以下のように変更
- 役職クラスをGuardianAngelにする
- ただし、RoleTypeは後付けでCrewmateにする
これにより、判定上はクルーだがターゲットの処理などは守護天使という状態を実現しました。

※シェリフと書いてある場所はアーソニストにも当てはまります。