### PR TITLE
Change/find closest targets 2nd fix

### DIFF
--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -249,6 +249,22 @@ namespace TownOfHost
             }
         }
     }
+    [HarmonyPatch(typeof(CrewmateRole), nameof(CrewmateRole.FindClosestTarget))]
+    class FindClosestTarget_Crewmate
+    {
+        public static bool Prefix(CrewmateRole __instance, ref PlayerControl __result)
+        {
+            if (PlayerControl.LocalPlayer == null || __instance == null || __instance.Player == null) return false;
+            if (!AmongUsClient.Instance.AmHost) return true;
+            if (__instance.Player.Is(CustomRoles.Sheriff) || __instance.Player.Is(CustomRoles.Arsonist))
+            {
+                var targets = ((RoleBehaviour)__instance).GetPlayersInAbilityRangeSorted(RoleBehaviour.GetTempPlayerList());
+                __result = targets.Count <= 0 ? null : targets[0];
+                return false;
+            }
+            return true;
+        }
+    }
     [HarmonyPatch(typeof(HudManager), nameof(HudManager.SetHudActive))]
     class SetHudActivePatch
     {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -182,14 +182,9 @@ namespace TownOfHost
                         }
                         else
                         {
-                            //ホストは代わりに自視点守護天使, 他視点普通のクルーにする
-                            sheriff.SetRole(RoleTypes.GuardianAngel); //ホスト視点用
+                            //ホストは代わりに普通のクルーにする
+                            sheriff.SetRole(RoleTypes.Crewmate); //ホスト視点用
                             sender.RpcSetRole(sheriff, RoleTypes.Crewmate);
-                            //sheriff.RpcSetRole(RoleTypes.Crewmate);
-
-                            //ただし、RoleBehaviourはGuardianAngelRole、RoleTypeはCrewmateという特殊な状態にする。
-                            //これにより、RoleTypeがGuardianEngelになったら本当に守護天使化したと判別できる。
-                            sheriff.Data.Role.Role = RoleTypes.Crewmate;
                         }
                         sheriff.Data.IsDead = true;
                     }
@@ -227,14 +222,9 @@ namespace TownOfHost
                         }
                         else
                         {
-                            //ホストは代わりに自視点守護天使, 他視点普通のクルーにする
-                            arsonist.SetRole(RoleTypes.GuardianAngel); //ホスト視点用
+                            //ホストは代わりに普通のクルーにする
+                            arsonist.SetRole(RoleTypes.Crewmate); //ホスト視点用
                             sender.RpcSetRole(arsonist, RoleTypes.Crewmate);
-                            //arsonist.RpcSetRole(RoleTypes.Crewmate);
-
-                            //ただし、RoleBehaviourはGuardianAngelRole、RoleTypeはCrewmateという特殊な状態にする。
-                            //これにより、RoleTypeがGuardianEngelになったら本当に守護天使化したと判別できる。
-                            arsonist.Data.Role.Role = RoleTypes.Crewmate;
                         }
                         arsonist.Data.IsDead = true;
                     }


### PR DESCRIPTION
前回の修正でホストシェリフのキル処理を守護天使と共通にしていたせいで起きていたバグを修正。
ちゃんとコードを見て、インポスターと同じような処理を行うように変更しました。
以下のバグが直っていることを確認しました。
- キル判定が壁を抜ける
- クルーに優先してターゲットが向かう