### PR TITLE
Fix/ClashByInvite(プレイヤー招待時のBANの修正)

### DIFF
--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -256,7 +256,8 @@ namespace TownOfHost
         {
             if (PlayerControl.LocalPlayer == null ||
                AmongUsClient.Instance == null ||
-               !AmongUsClient.Instance.AmHost
+               !AmongUsClient.Instance.AmHost ||
+               !AmongUsClient.Instance.IsGameStarted
             ) return true;
 
             if (__instance.Player.Is(CustomRoles.Sheriff) || __instance.Player.Is(CustomRoles.Arsonist))

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -254,8 +254,11 @@ namespace TownOfHost
     {
         public static bool Prefix(CrewmateRole __instance, ref PlayerControl __result)
         {
-            if (PlayerControl.LocalPlayer == null || __instance == null || __instance.Player == null) return false;
-            if (!AmongUsClient.Instance.AmHost) return true;
+            if (PlayerControl.LocalPlayer == null ||
+               AmongUsClient.Instance == null ||
+               !AmongUsClient.Instance.AmHost
+            ) return true;
+
             if (__instance.Player.Is(CustomRoles.Sheriff) || __instance.Player.Is(CustomRoles.Arsonist))
             {
                 var targets = ((RoleBehaviour)__instance).GetPlayersInAbilityRangeSorted(RoleBehaviour.GetTempPlayerList());


### PR DESCRIPTION
`CrewmateRole.FindClosestTarget`へのパッチがなぜかタイトル画面で呼ばれた時の処理が原因でなぜかプレイヤー招待を送ったときにクラッシュしていたのを修正
主な変更は以下の通りです
- 不用意に`return false;`で元の処理をキャンセルしないよう変更
- パッチしない条件を調整