### PR TITLE
configにキルクールを保存するように

### DIFF
--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -93,6 +93,7 @@ namespace TownOfHost
         public static void Prefix()
         {
             Options.DefaultKillCooldown = PlayerControl.GameOptions.KillCooldown;
+            Main.LastKillCooldown.Value = PlayerControl.GameOptions.KillCooldown;
             PlayerControl.GameOptions.KillCooldown = 0.1f;
             Main.RealOptionsData = PlayerControl.GameOptions.DeepCopy();
             PlayerControl.LocalPlayer.RpcSyncSettings(Main.RealOptionsData);

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -16,6 +16,8 @@ namespace TownOfHost
 
             NameColorManager.Begin();
             Options.Load();
+            if (PlayerControl.GameOptions.killCooldown == 0.1f)
+                PlayerControl.GameOptions.killCooldown = Main.LastKillCooldown.Value;
         }
     }
     [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerJoined))]

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -16,8 +16,11 @@ namespace TownOfHost
 
             NameColorManager.Begin();
             Options.Load();
-            if (PlayerControl.GameOptions.killCooldown == 0.1f)
-                PlayerControl.GameOptions.killCooldown = Main.LastKillCooldown.Value;
+            if (AmongUsClient.Instance.AmHost) //以下、ホストのみ実行
+            {
+                if (PlayerControl.GameOptions.killCooldown == 0.1f)
+                    PlayerControl.GameOptions.killCooldown = Main.LastKillCooldown.Value;
+            }
         }
     }
     [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerJoined))]

--- a/main.cs
+++ b/main.cs
@@ -39,6 +39,7 @@ namespace TownOfHost
         //Other Configs
         public static ConfigEntry<bool> IgnoreWinnerCommand { get; private set; }
         public static ConfigEntry<string> WebhookURL { get; private set; }
+        public static ConfigEntry<float> LastKillCooldown { get; private set; }
         public static CustomWinner currentWinner;
         public static HashSet<AdditionalWinners> additionalwinners = new();
         public static GameOptionsData RealOptionsData;
@@ -154,6 +155,7 @@ namespace TownOfHost
             AmDebugger = Config.Bind("Other", "AmDebugger", false);
             ShowPopUpVersion = Config.Bind("Other", "ShowPopUpVersion", "0");
             MessageWait = Config.Bind("Other", "MessageWait", 1);
+            LastKillCooldown = Config.Bind("Other", "LastKillCooldown", (float)30);
 
             NameColorManager.Begin();
 


### PR DESCRIPTION
キルクールを開始時に0.1秒にする => 試合中にゲームから落ちる => キルクールが0.1秒になったまま

になるバグを修正