### PR TITLE
Fix/FindClosestTarget_4th

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Hazel;
@@ -732,6 +733,29 @@ namespace TownOfHost
             reporter.RpcStartMeeting(target);
         }
         public static bool IsModClient(this PlayerControl player) => Main.playerVersion.ContainsKey(player.PlayerId);
+        ///<summary>
+        ///プレイヤーのRoleBehaviourのGetPlayersInAbilityRangeSortedを実行し、戻り値を返します。
+        ///</summary>
+        ///<param name="ignoreColliders">trueにすると、壁の向こう側のプレイヤーが含まれるようになります。守護天使用</param>
+        ///<returns>GetPlayersInAbilityRangeSortedの戻り値</returns>
+        public static List<PlayerControl> GetPlayersInAbilityRangeSorted(this PlayerControl player, bool ignoreColliders = false) => GetPlayersInAbilityRangeSorted(player, pc => true, ignoreColliders);
+        ///<summary>
+        ///プレイヤーのRoleBehaviourのGetPlayersInAbilityRangeSortedを実行し、predicateの条件に合わないものを除外して返します。
+        ///</summary>
+        ///<param name="predicate">リストに入れるプレイヤーの条件 このpredicateに入れてfalseを返すプレイヤーは除外されます。</param>
+        ///<param name="ignoreColliders">trueにすると、壁の向こう側のプレイヤーが含まれるようになります。守護天使用</param>
+        ///<returns>GetPlayersInAbilityRangeSortedの戻り値から条件に合わないプレイヤーを除外したもの。</returns>
+        public static List<PlayerControl> GetPlayersInAbilityRangeSorted(this PlayerControl player, Predicate<PlayerControl> predicate, bool ignoreColliders = false)
+        {
+            var rangePlayersIL = RoleBehaviour.GetTempPlayerList();
+            List<PlayerControl> rangePlayers = new();
+            player.Data.Role.GetPlayersInAbilityRangeSorted(rangePlayersIL, ignoreColliders);
+            foreach (var pc in rangePlayersIL)
+            {
+                if (predicate(pc)) rangePlayers.Add(pc);
+            }
+            return rangePlayers;
+        }
 
         //汎用
         public static bool Is(this PlayerControl target, CustomRoles role) =>

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -249,26 +249,6 @@ namespace TownOfHost
             }
         }
     }
-    [HarmonyPatch(typeof(CrewmateRole), nameof(CrewmateRole.FindClosestTarget))]
-    class FindClosestTarget_Crewmate
-    {
-        public static bool Prefix(CrewmateRole __instance, ref PlayerControl __result)
-        {
-            if (PlayerControl.LocalPlayer == null ||
-               AmongUsClient.Instance == null ||
-               !AmongUsClient.Instance.AmHost ||
-               !AmongUsClient.Instance.IsGameStarted
-            ) return true;
-
-            if (PlayerControl.LocalPlayer.Is(CustomRoles.Sheriff) || PlayerControl.LocalPlayer.Is(CustomRoles.Arsonist))
-            {
-                var targets = ((RoleBehaviour)__instance).GetPlayersInAbilityRangeSorted(RoleBehaviour.GetTempPlayerList());
-                __result = targets.Count <= 0 ? null : targets[0];
-                return false;
-            }
-            return true;
-        }
-    }
     [HarmonyPatch(typeof(HudManager), nameof(HudManager.SetHudActive))]
     class SetHudActivePatch
     {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -790,6 +790,17 @@ namespace TownOfHost
 
                 if (__instance.AmOwner) Utils.ApplySuffix();
             }
+            //LocalPlayer専用
+            if (__instance.AmOwner)
+            {
+                //キルターゲットの上書き処理
+                if ((__instance.Is(CustomRoles.Sheriff) || __instance.Is(CustomRoles.Arsonist)) && !__instance.Data.IsDead)
+                {
+                    var players = __instance.GetPlayersInAbilityRangeSorted(false);
+                    PlayerControl closest = players.Count <= 0 ? null : players[0];
+                    HudManager.Instance.KillButton.SetTarget(closest);
+                }
+            }
 
             //役職テキストの表示
             var RoleTextTransform = __instance.cosmetics.nameText.transform.Find("RoleText");


### PR DESCRIPTION
- CrewmateRole.FindClosestTargetへのPatchを廃止
- 代わりにPlayerControl.FixedUpdateのPatchでキルボタンのターゲットを上書きするよう変更

これにより、以下のバグが修正されます。
- ホストSheriffがキルを起こした時にクラッシュする