### PR TITLE
Fix/Sheriff-ResetPlayerCam

### DIFF
--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -382,8 +382,8 @@ namespace TownOfHost
                 roleOpt.SetRoleRate(RoleTypes.Shapeshifter, ShapeshifterNum, roleOpt.GetChancePerGame(RoleTypes.Shapeshifter));
             }
 
-            // ResetCamが必要なプレイヤーのリスト
-            Main.ResetCamPlayerList = PlayerControl.AllPlayerControls.ToArray().Where(p => p.GetCustomRole() is CustomRoles.Arsonist).Select(p => p.PlayerId).ToList();
+            // ResetCamが必要なプレイヤーのリストにクラス化が済んでいない役職のプレイヤーを追加
+            Main.ResetCamPlayerList.AddRange(PlayerControl.AllPlayerControls.ToArray().Where(p => p.GetCustomRole() is CustomRoles.Arsonist).Select(p => p.PlayerId));
             Utils.CountAliveImpostors();
             Utils.CustomSyncAllSettings();
             SetColorPatch.IsAntiGlitchDisabled = false;


### PR DESCRIPTION
https://discord.com/channels/931559416413687848/932221425245368340/1001408712084291675
Sheriff.Addで`ResetCamPlayerList`への追加はされていましたが、下のアーソニスト用の処理でリスト自体が上書きされていたので、結合に変更しました。

以下、修正後にシェリフとアーソニストを殺して会議を挟んだ後のスクリーンショット
![image](https://user-images.githubusercontent.com/51523918/181239064-8dee7698-72ec-4023-b1fd-9d7da3d5cc1c.png)
