### PR TITLE
Feature/AntiBlackout

### DIFF
--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -13,6 +13,10 @@ namespace TownOfHost
     public static class AntiBlackout
     {
         ///<summary>
+        ///追放処理を上書きするかどうか
+        ///</summary>
+        public static bool OverrideExiledPlayer => IsRequred && (IsSingleImpostor || Diff_CrewImp == 1);
+        ///<summary>
         ///インポスターが一人しか存在しない設定かどうか
         ///</summary>
         public static bool IsSingleImpostor => Main.RealOptionsData != null ? Main.RealOptionsData.NumImpostors == 1 : PlayerControl.GameOptions.NumImpostors == 1;
@@ -20,6 +24,23 @@ namespace TownOfHost
         ///AntiBlackout内の処理が必要であるかどうか
         ///</summary>
         public static bool IsRequred => false;
+        ///<summary>
+        ///インポスター以外の人数とインポスターの人数の差
+        ///</summary>
+        public static int Diff_CrewImp
+        {
+            get
+            {
+                int numImpostors = 0;
+                int numCrewmates = 0;
+                foreach (var pc in PlayerControl.AllPlayerControls)
+                {
+                    if (pc.Data.Role.IsImpostor) numImpostors++;
+                    else numCrewmates++;
+                }
+                return numCrewmates - numImpostors;
+            }
+        }
         private static Dictionary<byte, bool> isDeadCache = new();
 
         public static void SetIsDead(bool doSend = true)

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -23,7 +23,6 @@ namespace TownOfHost
                 isDeadCache[info.PlayerId] = info.IsDead;
                 info.IsDead = false;
             }
-            //GameDataSerializePatch.hasUpdate = true;
             SendGameData();
         }
         public static void RestoreIsDead()
@@ -34,7 +33,6 @@ namespace TownOfHost
                 if (isDeadCache.TryGetValue(info.PlayerId, out bool val)) info.IsDead = val;
             }
             isDeadCache.Clear();
-            //GameDataSerializePatch.hasUpdate = true;
             SendGameData();
         }
 
@@ -45,21 +43,6 @@ namespace TownOfHost
             writer.WritePacked(GameData.Instance.NetId);
             GameData.Instance.Serialize(writer, true);
             writer.EndMessage();
-        }
-
-        [HarmonyPatch(typeof(GameData), nameof(GameData.Serialize))]
-        public static class GameDataSerializePatch
-        {
-            public static bool hasUpdate = false;
-            public static void Prefix(GameData __instance, [HarmonyArgument(0)] MessageWriter writer, [HarmonyArgument(1)] ref bool initialState)
-            {
-                if (hasUpdate) initialState = true;
-                hasUpdate = false;
-            }
-            public static void Postfix(GameData __instance, ref bool __result)
-            {
-                if (__result) Logger.Info("GameDataが送信されました。", "GameDataSerializePatch");
-            }
         }
     }
 }

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Hazel;
+using HarmonyLib;
 using UnityEngine;
 
 namespace TownOfHost
@@ -28,6 +29,15 @@ namespace TownOfHost
             {
                 if (info == null) continue;
                 if (isDeadCache.TryGetValue(info.PlayerId, out bool val)) info.IsDead = val;
+            }
+        }
+
+        [HarmonyPatch(typeof(GameData), nameof(GameData.Serialize))]
+        public static class GameDataSerializePatch
+        {
+            public static void Postfix(GameData __instance, ref bool __result)
+            {
+                if (__result) Logger.Info("GameDataが送信されました。", "GameDataSerializePatch");
             }
         }
     }

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -1,12 +1,5 @@
-using System.Text.RegularExpressions;
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using Hazel;
-using HarmonyLib;
-using UnityEngine;
 
 namespace TownOfHost
 {

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -12,5 +12,23 @@ namespace TownOfHost
     public static class AntiBlackout
     {
         private static Dictionary<byte, bool> isDeadCache;
+
+        public static void SetIsDead()
+        {
+            foreach (var info in GameData.Instance.AllPlayers)
+            {
+                if (info == null) continue;
+                isDeadCache[info.PlayerId] = info.IsDead;
+                info.IsDead = false;
+            }
+        }
+        public static void RestoreIsDead()
+        {
+            foreach (var info in GameData.Instance.AllPlayers)
+            {
+                if (info == null) continue;
+                if (isDeadCache.TryGetValue(info.PlayerId, out bool val)) info.IsDead = val;
+            }
+        }
     }
 }

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -23,6 +23,7 @@ namespace TownOfHost
                 isDeadCache[info.PlayerId] = info.IsDead;
                 info.IsDead = false;
             }
+            GameDataSerializePatch.hasUpdate = true;
         }
         public static void RestoreIsDead()
         {
@@ -32,11 +33,18 @@ namespace TownOfHost
                 if (isDeadCache.TryGetValue(info.PlayerId, out bool val)) info.IsDead = val;
             }
             isDeadCache.Clear();
+            GameDataSerializePatch.hasUpdate = true;
         }
 
         [HarmonyPatch(typeof(GameData), nameof(GameData.Serialize))]
         public static class GameDataSerializePatch
         {
+            public static bool hasUpdate = false;
+            public static void Prefix(GameData __instance, [HarmonyArgument(0)] MessageWriter writer, [HarmonyArgument(1)] ref bool initialState)
+            {
+                if (hasUpdate) initialState = true;
+                hasUpdate = false;
+            }
             public static void Postfix(GameData __instance, ref bool __result)
             {
                 if (__result) Logger.Info("GameDataが送信されました。", "GameDataSerializePatch");

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -23,7 +23,8 @@ namespace TownOfHost
                 isDeadCache[info.PlayerId] = info.IsDead;
                 info.IsDead = false;
             }
-            GameDataSerializePatch.hasUpdate = true;
+            //GameDataSerializePatch.hasUpdate = true;
+            SendGameData();
         }
         public static void RestoreIsDead()
         {
@@ -33,7 +34,8 @@ namespace TownOfHost
                 if (isDeadCache.TryGetValue(info.PlayerId, out bool val)) info.IsDead = val;
             }
             isDeadCache.Clear();
-            GameDataSerializePatch.hasUpdate = true;
+            //GameDataSerializePatch.hasUpdate = true;
+            SendGameData();
         }
 
         public static void SendGameData()

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -14,7 +14,7 @@ namespace TownOfHost
     {
         private static Dictionary<byte, bool> isDeadCache = new();
 
-        public static void SetIsDead()
+        public static void SetIsDead(bool doSend = true)
         {
             isDeadCache.Clear();
             foreach (var info in GameData.Instance.AllPlayers)
@@ -23,9 +23,9 @@ namespace TownOfHost
                 isDeadCache[info.PlayerId] = info.IsDead;
                 info.IsDead = false;
             }
-            SendGameData();
+            if (doSend) SendGameData();
         }
-        public static void RestoreIsDead()
+        public static void RestoreIsDead(bool doSend = true)
         {
             foreach (var info in GameData.Instance.AllPlayers)
             {
@@ -33,7 +33,7 @@ namespace TownOfHost
                 if (isDeadCache.TryGetValue(info.PlayerId, out bool val)) info.IsDead = val;
             }
             isDeadCache.Clear();
-            SendGameData();
+            if (doSend) SendGameData();
         }
 
         public static void SendGameData()

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -12,6 +12,14 @@ namespace TownOfHost
 {
     public static class AntiBlackout
     {
+        ///<summary>
+        ///インポスターが一人しか存在しない設定かどうか
+        ///</summary>
+        public static bool IsSingleImpostor => Main.RealOptionsData != null ? Main.RealOptionsData.NumImpostors == 1 : PlayerControl.GameOptions.NumImpostors == 1;
+        ///<summary>
+        ///AntiBlackout内の処理が必要であるかどうか
+        ///</summary>
+        public static bool IsRequred => false;
         private static Dictionary<byte, bool> isDeadCache = new();
 
         public static void SetIsDead(bool doSend = true)

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -36,6 +36,15 @@ namespace TownOfHost
             GameDataSerializePatch.hasUpdate = true;
         }
 
+        public static void SendGameData()
+        {
+            MessageWriter writer = AmongUsClient.Instance.Streams[(int)SendOption.Reliable];
+            writer.StartMessage(1);
+            writer.WritePacked(GameData.Instance.NetId);
+            GameData.Instance.Serialize(writer, true);
+            writer.EndMessage();
+        }
+
         [HarmonyPatch(typeof(GameData), nameof(GameData.Serialize))]
         public static class GameDataSerializePatch
         {

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -1,0 +1,16 @@
+using System.Text.RegularExpressions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Hazel;
+using UnityEngine;
+
+namespace TownOfHost
+{
+    public static class AntiBlackout
+    {
+        private static Dictionary<byte, bool> isDeadCache;
+    }
+}

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -23,7 +23,7 @@ namespace TownOfHost
         ///<summary>
         ///AntiBlackout内の処理が必要であるかどうか
         ///</summary>
-        public static bool IsRequred => false;
+        public static bool IsRequred => Options.NoGameEnd.GetBool();
         ///<summary>
         ///インポスター以外の人数とインポスターの人数の差
         ///</summary>

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -12,10 +12,11 @@ namespace TownOfHost
 {
     public static class AntiBlackout
     {
-        private static Dictionary<byte, bool> isDeadCache;
+        private static Dictionary<byte, bool> isDeadCache = new();
 
         public static void SetIsDead()
         {
+            isDeadCache.Clear();
             foreach (var info in GameData.Instance.AllPlayers)
             {
                 if (info == null) continue;
@@ -30,6 +31,7 @@ namespace TownOfHost
                 if (info == null) continue;
                 if (isDeadCache.TryGetValue(info.PlayerId, out bool val)) info.IsDead = val;
             }
+            isDeadCache.Clear();
         }
 
         [HarmonyPatch(typeof(GameData), nameof(GameData.Serialize))]

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -15,8 +15,6 @@ namespace TownOfHost
         static int resolutionIndex = 0;
         public static void Postfix(ControllerManager __instance)
         {
-            if (Input.GetKeyDown(KeyCode.Alpha1)) AntiBlackout.SetIsDead();
-            if (Input.GetKeyDown(KeyCode.Alpha2)) AntiBlackout.RestoreIsDead();
             //カスタム設定切り替え
             if (Input.GetKeyDown(KeyCode.Tab) && GameStates.IsLobby)
             {

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -15,6 +15,8 @@ namespace TownOfHost
         static int resolutionIndex = 0;
         public static void Postfix(ControllerManager __instance)
         {
+            if (Input.GetKeyDown(KeyCode.Alpha1)) AntiBlackout.SetIsDead();
+            if (Input.GetKeyDown(KeyCode.Alpha2)) AntiBlackout.RestoreIsDead();
             //カスタム設定切り替え
             if (Input.GetKeyDown(KeyCode.Tab) && GameStates.IsLobby)
             {

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -27,6 +27,7 @@ namespace TownOfHost
             Main.witchMeeting = false;
             bool DecidedWinner = false;
             if (!AmongUsClient.Instance.AmHost) return; //ホスト以外はこれ以降の処理を実行しません
+            AntiBlackout.RestoreIsDead(doSend: false);
             if (exiled != null)
             {
                 PlayerState.SetDeathReason(exiled.PlayerId, PlayerState.DeathReason.Vote);
@@ -99,7 +100,7 @@ namespace TownOfHost
             Utils.AfterMeetingTasks();
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();
-            new LateTask(() => AntiBlackout.RestoreIsDead(), 0.5f, "Restore IsDead Task");
+            new LateTask(() => AntiBlackout.SendGameData(), 0.5f, "Restore IsDead Task");
             Logger.Info("タスクフェイズ開始", "Phase");
         }
     }

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -25,7 +25,10 @@ namespace TownOfHost
         }
         static void WrapUpPostfix(GameData.PlayerInfo exiled)
         {
-            if (AntiBlackout.OverrideExiledPlayer) exiled = AntiBlackout_LastExiled;
+            if (AntiBlackout.OverrideExiledPlayer)
+            {
+                exiled = AntiBlackout_LastExiled;
+            }
 
             Main.witchMeeting = false;
             bool DecidedWinner = false;
@@ -104,7 +107,11 @@ namespace TownOfHost
             Utils.AfterMeetingTasks();
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();
-            new LateTask(() => AntiBlackout.SendGameData(), 0.5f, "Restore IsDead Task");
+            new LateTask(() =>
+            {
+                AntiBlackout.SendGameData();
+                exiled.Object?.RpcExileV2();
+            }, 0.5f, "Restore IsDead Task");
             Logger.Info("タスクフェイズ開始", "Phase");
         }
     }

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -5,6 +5,7 @@ namespace TownOfHost
 {
     class ExileControllerWrapUpPatch
     {
+        public static GameData.PlayerInfo AntiBlackout_LastExiled;
         [HarmonyPatch(typeof(ExileController), nameof(ExileController.WrapUp))]
         class BaseExileControllerPatch
         {
@@ -24,6 +25,8 @@ namespace TownOfHost
         }
         static void WrapUpPostfix(GameData.PlayerInfo exiled)
         {
+            if (AntiBlackout.OverrideExiledPlayer) exiled = AntiBlackout_LastExiled;
+
             Main.witchMeeting = false;
             bool DecidedWinner = false;
             if (!AmongUsClient.Instance.AmHost) return; //ホスト以外はこれ以降の処理を実行しません

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -30,6 +30,7 @@ namespace TownOfHost
             AntiBlackout.RestoreIsDead(doSend: false);
             if (exiled != null)
             {
+                exiled.IsDead = true;
                 PlayerState.SetDeathReason(exiled.PlayerId, PlayerState.DeathReason.Vote);
                 var role = exiled.GetCustomRole();
                 if (role == CustomRoles.Jester && AmongUsClient.Instance.AmHost)

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -99,6 +99,7 @@ namespace TownOfHost
             Utils.AfterMeetingTasks();
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();
+            new LateTask(() => AntiBlackout.RestoreIsDead(), 0.5f, "Restore IsDead Task");
             Logger.Info("タスクフェイズ開始", "Phase");
         }
     }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -136,7 +136,15 @@ namespace TownOfHost
                 Logger.Info($"追放者決定: {exileId}({Utils.GetVoteName(exileId)})", "Vote");
                 exiledPlayer = GameData.Instance.AllPlayers.ToArray().FirstOrDefault(info => !tie && info.PlayerId == exileId);
 
-                __instance.RpcVotingComplete(states, exiledPlayer, tie); //RPC
+                //RPC
+                if (AntiBlackout.IsSingleImpostor && AntiBlackout.IsRequred)
+                {
+                    __instance.RpcVotingComplete(states, null, true);
+                    exiledPlayer.Object?.RpcExileV2();
+                    exiledPlayer.IsDead = true;
+                    AntiBlackout.SendGameData();
+                }
+                else __instance.RpcVotingComplete(states, exiledPlayer, tie); //通常処理
                 if (!Utils.GetPlayerById(exileId).Is(CustomRoles.Witch))
                 {
                     foreach (var p in Main.SpelledPlayer)

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -140,9 +140,6 @@ namespace TownOfHost
                 if (AntiBlackout.OverrideExiledPlayer)
                 {
                     __instance.RpcVotingComplete(states, null, true);
-                    exiledPlayer.Object?.RpcExileV2();
-                    exiledPlayer.IsDead = true;
-                    AntiBlackout.SendGameData();
                     ExileControllerWrapUpPatch.AntiBlackout_LastExiled = exiledPlayer;
                 }
                 else __instance.RpcVotingComplete(states, exiledPlayer, tie); //通常処理

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -365,6 +365,7 @@ namespace TownOfHost
         public static void Postfix()
         {
             Logger.Info("------------会議終了------------", "Phase");
+            AntiBlackout.SetIsDead();
         }
     }
 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -238,6 +238,10 @@ namespace TownOfHost
                 Utils.SendMessage("緊急会議ボタンはあと" + (Options.SyncedButtonCount.GetFloat() - Options.UsedButtonCount) + "回使用可能です。");
                 Logger.Info("緊急会議ボタンはあと" + (Options.SyncedButtonCount.GetFloat() - Options.UsedButtonCount) + "回使用可能です。", "SyncButtonMode");
             }
+            if (AntiBlackout.OverrideExiledPlayer)
+            {
+                Utils.SendMessage(Translator.GetString("Warning.OverrideExiledPlayer"));
+            }
 
             if (AmongUsClient.Instance.AmHost)
             {

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -153,7 +153,7 @@ namespace TownOfHost
                 //霊界用暗転バグ対処
                 foreach (var pc in PlayerControl.AllPlayerControls)
                 {
-                    if (Main.ResetCamPlayerList.Contains(pc.PlayerId) && (pc.Data.IsDead || pc.PlayerId == exiledPlayer?.PlayerId)) pc.ResetPlayerCam(19f);
+                    if (Main.ResetCamPlayerList.Contains(pc.PlayerId) && (pc.PlayerId == exiledPlayer?.PlayerId)) pc.ResetPlayerCam(19f);
                 }
 
                 return false;

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -159,10 +159,11 @@ namespace TownOfHost
                 }
 
                 //霊界用暗転バグ対処
-                foreach (var pc in PlayerControl.AllPlayerControls)
-                {
-                    if (Main.ResetCamPlayerList.Contains(pc.PlayerId) && (pc.PlayerId == exiledPlayer?.PlayerId)) pc.ResetPlayerCam(19f);
-                }
+                if (!(AntiBlackout.IsSingleImpostor && AntiBlackout.IsRequred))
+                    foreach (var pc in PlayerControl.AllPlayerControls)
+                    {
+                        if (Main.ResetCamPlayerList.Contains(pc.PlayerId) && (pc.PlayerId == exiledPlayer?.PlayerId)) pc.ResetPlayerCam(19f);
+                    }
 
                 return false;
             }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -137,7 +137,7 @@ namespace TownOfHost
                 exiledPlayer = GameData.Instance.AllPlayers.ToArray().FirstOrDefault(info => !tie && info.PlayerId == exileId);
 
                 //RPC
-                if (AntiBlackout.IsSingleImpostor && AntiBlackout.IsRequred)
+                if (AntiBlackout.OverrideExiledPlayer)
                 {
                     __instance.RpcVotingComplete(states, null, true);
                     exiledPlayer.Object?.RpcExileV2();
@@ -159,7 +159,7 @@ namespace TownOfHost
                 }
 
                 //霊界用暗転バグ対処
-                if (!(AntiBlackout.IsSingleImpostor && AntiBlackout.IsRequred))
+                if (!AntiBlackout.OverrideExiledPlayer)
                     foreach (var pc in PlayerControl.AllPlayerControls)
                     {
                         if (Main.ResetCamPlayerList.Contains(pc.PlayerId) && (pc.PlayerId == exiledPlayer?.PlayerId)) pc.ResetPlayerCam(19f);

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -365,7 +365,8 @@ namespace TownOfHost
         public static void Postfix()
         {
             Logger.Info("------------会議終了------------", "Phase");
-            AntiBlackout.SetIsDead();
+            if (AmongUsClient.Instance.AmHost)
+                AntiBlackout.SetIsDead();
         }
     }
 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -143,6 +143,7 @@ namespace TownOfHost
                     exiledPlayer.Object?.RpcExileV2();
                     exiledPlayer.IsDead = true;
                     AntiBlackout.SendGameData();
+                    ExileControllerWrapUpPatch.AntiBlackout_LastExiled = exiledPlayer;
                 }
                 else __instance.RpcVotingComplete(states, exiledPlayer, tie); //通常処理
                 if (!Utils.GetPlayerById(exileId).Is(CustomRoles.Witch))

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -157,11 +157,8 @@ namespace TownOfHost
                 }
 
                 //霊界用暗転バグ対処
-                if (!AntiBlackout.OverrideExiledPlayer)
-                    foreach (var pc in PlayerControl.AllPlayerControls)
-                    {
-                        if (Main.ResetCamPlayerList.Contains(pc.PlayerId) && (pc.PlayerId == exiledPlayer?.PlayerId)) pc.ResetPlayerCam(19f);
-                    }
+                if (!AntiBlackout.OverrideExiledPlayer && exiledPlayer != null && Main.ResetCamPlayerList.Contains(exiledPlayer.PlayerId))
+                    exiledPlayer.Object?.ResetPlayerCam(19f);
 
                 return false;
             }

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -354,6 +354,7 @@ CantUse.lastroles,Can't use /lastroles in the game.,試合中に/lastrolesを使
 
 ## 警告
 Warning.EgoistCannotWin,Egoist cannot win!,エゴイストが勝利できません
+Warning.OverrideExiledPlayer,All ejects will be displayed as tie because the total number of impostors is 1.,合計インポスター数が1のため、追放はすべて同数投票として表示されます。
 
 ## その他
 ForceEnd,Force Terminated,廃村


### PR DESCRIPTION
# 定義
- DesyncImpostor : 他視点ではクルーだが、自視点のみ自分インポスター、他クルーとなっている役職のプレイヤー。シェリフ・アーソニスト・ジャッカルが当てはまる。
- DeImp : この文章内でのDesyncImpostorの略

# 前提知識
- `GameData.AllPlayers`に保存されている`PlayerInfo`はRPC以外の通信で同期される。
- `GameData.PlayerInfo`クラス内に`RoleType`という変数が定義されており、さらに同期もされるが、悲しいことにどこからも参照されない。
- `ShipStatus.IsGameOverDueToDeath`の判定は`GameData.AllPlayers`を使って行われる。その時、陣営の判定は`RoleBehaviour`を参照する。
- 追放されたプレイヤーは各クライアントの`ExileController.WrapUp`関数内で`PlayerInfo.IsDead`が`true`に書き換えられる。
その直後に遅延なしで`ShipStatus.IsGameOverDueToDeath`による判定が行われるため、各会議で追放されたプレイヤーの`IsDead`は`true`以外にすることは不可能。

# 基本的な仕組み
1. 会議終了後、一時的に全プレイヤーを生きている判定にして同期する。
2. 全員が生きている判定で暗転の判定が行われる(例外あり)ため、ほぼ確実に暗転しない。
3. 少し待ってから生存判定を本来のものに戻す。

# 処理内容
## バニラならインポスターが勝利するはずの盤面で試合が終わらない可能性がある and (インポスターが1人しかいない or インポスター以外の人数-インポスターの人数 が1)
### 処理の意図
- バニラならインポスターが勝利するはずの盤面で試合が終わらない可能性がない場合、暗転してもすぐ試合が終わるので問題ない。
- インポスターが1人しかいない場合、そのインポスターが吊られた直後は`IsDead`が`true`固定になるため、インポスター全滅判定で暗転が発生する。
- インポスター以外の人数-インポスターの人数 が1の場合、クルーが吊られた直後は`IsDead`が`true`固定になるため、インポスターとクルーが同数判定で暗転が発生する。

### 処理の流れ
1. 投票が完了する。
2. 本来送信される`VotingCompleteRpc`を同数投票となるものに書き換える。
3. 本来追放されるはずだったプレイヤーを`ExileRpc`で強制追放する。 この場合は`ExileController.WrapUp`関数内で`IsDead`が書き換えられないため、[処理の意図](#処理の意図)の2,3のような暗転は発生しない。
4. 本来追放されるはずだったプレイヤーの`PlayerInfo`を保存しておく。`WrapUpPostfix`で使用。誰も追放されない場合は`null`を代入する。
5. ResetPlayerCamは実行しない。

6. `MeetingHud.OnDestroy`が呼び出される。(おそらくタブレットが消えたタイミング)
7. 全プレイヤーの`IsDead`を退避し、すべてfalseにして同期。

8. `WrapUpPostfix`が呼び出される。
9. `exiled`引数に4で保存した`PlayerInfo`を代入する。 3の処理で追放対象を書き換えたため、`exiled`が常時`null`となっているため。
10. 退避した`IsDead`を適用する。
11. `exiled`が`null`でない場合、`IsDead`を`true`に変更する。
12. `WrapUpPostfix`の最後からさらに0.5秒待ってから、`IsDead`を同期する。

### その他
- この処理を実行する場合、各会議の最初に警告(翻訳ID:`Warning.OverrideExiledPlayer`)が表示されます。
- おそらくこの手法なら、最初から暗転条件を満たしていない限りすべての暗転問題を解決できます。

## 上の条件に当てはまらない場合
### 処理の意図
- バニラならインポスターが勝利するはずの盤面で試合が終わらない可能性がない場合、この処理が無くても成り立つが、DeImpのResetPlayerCamの実行回数を0~1回まで減らすことができるので使う。
- インポスターが1人しかいない場合でも、相方のIsDeadは固定されないので暗転は発生しない。
- DeImpは自視点のみインポスターが自分のみという判定なので、追放された場合は`IsDead`が固定され、インポスター全滅判定で暗転する。この場合、ResetPlayerCamで暗転を解除する。

### 処理の流れ
1. 投票が完了する。
5. DeImpが追放された場合、ResetPlayerCamを実行する。

6. `MeetingHud.OnDestroy`が呼び出される。(おそらくタブレットが消えたタイミング)
7. 全プレイヤーの`IsDead`を退避し、すべてfalseにして同期。

8. `WrapUpPostfix`が呼び出される。
9. `exiled`引数に4で保存した`PlayerInfo`を代入する。
10. 退避した`IsDead`を適用する。
11. `exiled`が`null`でない場合、`IsDead`を`true`に変更する。退避した時点では追放によってIsDeadが書き換わっていないため。
12. `WrapUpPostfix`の最後からさらに0.5秒待ってから、`IsDead`を同期する。

### その他
- DeImpのResetPlayerCamは最大でも追放された直後の一回のみに軽減されます。