### PR TITLE
公開ルーム&ホスト時に名前に〔TOH〕を付与

### DIFF
--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -9,10 +9,9 @@ namespace TownOfHost
     {
         public static bool Prefix(GameStartManager __instance)
         {
-            bool NameIncludeTOH = SaveManager.PlayerName.ToUpper().Contains("TOH");
-            if (ModUpdater.isBroken || ModUpdater.hasUpdate || !NameIncludeTOH)
+            if (ModUpdater.isBroken || ModUpdater.hasUpdate)
             {
-                var message = GetString("NameIncludeTOH");
+                var message = "";
                 if (ModUpdater.isBroken) message = GetString("ModBrokenMessage");
                 if (ModUpdater.hasUpdate) message = GetString("CanNotJoinPublicRoomNoLatest");
                 Logger.Info(message, "MakePublicPatch");

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -40,9 +40,7 @@ namespace TownOfHost
                         : $"<color={Main.modColor}>{Main.HideName.Value}</color>";
 
                 // Make Public Button
-                bool NameIncludeMod = SaveManager.PlayerName.ToLower().Contains("mod");
-                bool NameIncludeTOH = SaveManager.PlayerName.ToUpper().Contains("TOH");
-                if (ModUpdater.isBroken || ModUpdater.hasUpdate || (NameIncludeMod && !NameIncludeTOH))
+                if (ModUpdater.isBroken || ModUpdater.hasUpdate)
                 {
                     __instance.MakePublicButton.color = Palette.DisabledClear;
                     __instance.privatePublicText.color = Palette.DisabledClear;

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -68,6 +68,16 @@ namespace TownOfHost
                 }
                 if (!AmongUsClient.Instance.AmHost || !GameData.Instance || AmongUsClient.Instance.GameMode == GameModes.LocalGame) return; // Not host or no instance or LocalGame
                 update = GameData.Instance.PlayerCount != __instance.LastPlayerCount;
+
+                string playerName = SaveManager.PlayerName;
+                if (AmongUsClient.Instance.AmHost && AmongUsClient.Instance.IsGamePublic)
+                {
+                    if (!playerName.ToUpper().Contains("TOH")) SaveManager.PlayerName = "〔TOH〕" + playerName;
+                }
+                else if (SaveManager.PlayerName.StartsWith("〔TOH〕"))
+                {
+                    SaveManager.PlayerName = playerName[5..];
+                }
             }
             public static void Postfix(GameStartManager __instance)
             {

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -382,7 +382,6 @@ updateFailed,Update failed.,アップデートに失敗しました。
 onSetPublicNoLatest,Public rooms is prohibited except for the latest version.\nPlease update.,最新版以外で公開ルームにはできません。\nアップデートをしてください。
 CanNotJoinPublicRoomNoLatest,You can't join public rooms except for the latest version.\nPlease update.,最新版以外で公開ルームには参加できません。\nアップデートをしてください。
 ModBrokenMessage,The MOD file is broken.\nPlease re-install it again.,MODを構成するファイルが破損しています。\nもう一度導入しなおしてください。
-NameIncludeTOH,"You cannot make public rooms unless "TOH" is included in your name.",""TOH"が名前に含まれていない状態では公開部屋にすることはできません。"
 EnterVentToWin,Enter Vent to Win!!,ベントに入って勝利しろ!!
 FireworksPutPhase,Put {0} Fireworks,あと{0}個置け
 FireworksWaitPhase,Wait for time...,時を待て...


### PR DESCRIPTION
M0D、ｍｏｄ等で回避する人が出てきたので対策。
- 公開ルーム&ホスト&名前にTOHが含まれていない際に名前の先頭に`〔TOH〕`を付与
- 非公開ルーム・非ホストで名前に`〔TOH〕`がついている場合削除
- 名前にTOHが含まれていない場合に公開ルームにできない処理を削除