### PR TITLE
PSやXbox等でウェルカムメッセージが届かない問題を改善

### DIFF
--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -41,7 +41,7 @@ namespace TownOfHost
                 new LateTask(() =>
                 {
                     if (client.Character != null) ChatCommands.SendTemplate("welcome", client.Character.PlayerId, true);
-                }, 1f, "Welcome Message");
+                }, 3f, "Welcome Message");
             }
         }
     }

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -36,10 +36,13 @@ namespace TownOfHost
             }
             Main.playerVersion = new Dictionary<byte, PlayerVersion>();
             RPC.RpcVersionCheck();
-            new LateTask(() =>
+            if (AmongUsClient.Instance.AmHost)
             {
-                if (client.Character != null) ChatCommands.SendTemplate("welcome", client.Character.PlayerId, true);
-            }, 1f, "Welcome Message");
+                new LateTask(() =>
+                {
+                    if (client.Character != null) ChatCommands.SendTemplate("welcome", client.Character.PlayerId, true);
+                }, 1f, "Welcome Message");
+            }
         }
     }
     [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerLeft))]


### PR DESCRIPTION
PlaystationやXbox等でウェルカムメッセージが届かないことがある問題を改善。
恐らく入室に時間がかかりチャットを受け取れてないと推測。
- ウェルカムメッセージの遅延を3秒に延長