### PR TITLE
追放者がいない場合に例外を吐く問題を修正

### DIFF
--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -110,7 +110,7 @@ namespace TownOfHost
             new LateTask(() =>
             {
                 AntiBlackout.SendGameData();
-                exiled.Object?.RpcExileV2();
+                exiled?.Object?.RpcExileV2();
             }, 0.5f, "Restore IsDead Task");
             Logger.Info("タスクフェイズ開始", "Phase");
         }


### PR DESCRIPTION
追放者がいない場合にRestore IsDead Taskが例外を吐く問題を修正
- nullチェックを追加