### PR TITLE
fix/AntiBlackout-1

### DIFF
--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using Hazel;
 
@@ -37,8 +38,9 @@ namespace TownOfHost
         public static bool IsCached { get; private set; } = false;
         private static Dictionary<byte, bool> isDeadCache = new();
 
-        public static void SetIsDead(bool doSend = true)
+        public static void SetIsDead(bool doSend = true, [CallerMemberName] string callerMethodName = "")
         {
+            Logger.Info($"SetIsDead is called from {callerMethodName}", "AntiBlackout");
             if (IsCached)
             {
                 Logger.Info("再度SetIsDeadを実行する前に、RestoreIsDeadを実行してください。", "AntiBlackout.Error");
@@ -54,8 +56,9 @@ namespace TownOfHost
             IsCached = true;
             if (doSend) SendGameData();
         }
-        public static void RestoreIsDead(bool doSend = true)
+        public static void RestoreIsDead(bool doSend = true, [CallerMemberName] string callerMethodName = "")
         {
+            Logger.Info($"RestoreIsDead is called from {callerMethodName}", "AntiBlackout");
             foreach (var info in GameData.Instance.AllPlayers)
             {
                 if (info == null) continue;
@@ -66,8 +69,9 @@ namespace TownOfHost
             if (doSend) SendGameData();
         }
 
-        public static void SendGameData()
+        public static void SendGameData([CallerMemberName] string callerMethodName = "")
         {
+            Logger.Info($"SendGameData is called from {callerMethodName}", "AntiBlackout");
             MessageWriter writer = AmongUsClient.Instance.Streams[(int)SendOption.Reliable];
             writer.StartMessage(1);
             writer.WritePacked(GameData.Instance.NetId);

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -35,9 +35,15 @@ namespace TownOfHost
             }
         }
         private static Dictionary<byte, bool> isDeadCache = new();
+        private static bool isCached = false;
 
         public static void SetIsDead(bool doSend = true)
         {
+            if (isCached)
+            {
+                Logger.Info("再度SetIsDeadを実行する前に、RestoreIsDeadを実行してください。", "AntiBlackout.Error");
+                return;
+            }
             isDeadCache.Clear();
             foreach (var info in GameData.Instance.AllPlayers)
             {
@@ -45,6 +51,7 @@ namespace TownOfHost
                 isDeadCache[info.PlayerId] = info.IsDead;
                 info.IsDead = false;
             }
+            isCached = true;
             if (doSend) SendGameData();
         }
         public static void RestoreIsDead(bool doSend = true)
@@ -55,6 +62,7 @@ namespace TownOfHost
                 if (isDeadCache.TryGetValue(info.PlayerId, out bool val)) info.IsDead = val;
             }
             isDeadCache.Clear();
+            isCached = false;
             if (doSend) SendGameData();
         }
 

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -34,12 +34,12 @@ namespace TownOfHost
                 return numCrewmates - numImpostors;
             }
         }
+        public static bool IsCached { get; private set; } = false;
         private static Dictionary<byte, bool> isDeadCache = new();
-        private static bool isCached = false;
 
         public static void SetIsDead(bool doSend = true)
         {
-            if (isCached)
+            if (IsCached)
             {
                 Logger.Info("再度SetIsDeadを実行する前に、RestoreIsDeadを実行してください。", "AntiBlackout.Error");
                 return;
@@ -51,7 +51,7 @@ namespace TownOfHost
                 isDeadCache[info.PlayerId] = info.IsDead;
                 info.IsDead = false;
             }
-            isCached = true;
+            IsCached = true;
             if (doSend) SendGameData();
         }
         public static void RestoreIsDead(bool doSend = true)
@@ -62,7 +62,7 @@ namespace TownOfHost
                 if (isDeadCache.TryGetValue(info.PlayerId, out bool val)) info.IsDead = val;
             }
             isDeadCache.Clear();
-            isCached = false;
+            IsCached = false;
             if (doSend) SendGameData();
         }
 

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -1,3 +1,4 @@
+using System;
 using HarmonyLib;
 using Hazel;
 
@@ -11,7 +12,14 @@ namespace TownOfHost
         {
             public static void Postfix(ExileController __instance)
             {
-                WrapUpPostfix(__instance.exiled);
+                try
+                {
+                    WrapUpPostfix(__instance.exiled);
+                }
+                finally
+                {
+                    WrapUpFinalizer(__instance.exiled);
+                }
             }
         }
 
@@ -20,7 +28,14 @@ namespace TownOfHost
         {
             public static void Postfix(AirshipExileController __instance)
             {
-                WrapUpPostfix(__instance.exiled);
+                try
+                {
+                    WrapUpPostfix(__instance.exiled);
+                }
+                finally
+                {
+                    WrapUpFinalizer(__instance.exiled);
+                }
             }
         }
         static void WrapUpPostfix(GameData.PlayerInfo exiled)
@@ -112,6 +127,11 @@ namespace TownOfHost
                 AntiBlackout.SendGameData();
                 exiled?.Object?.RpcExileV2();
             }, 0.5f, "Restore IsDead Task");
+        }
+
+        static void WrapUpFinalizer(GameData.PlayerInfo exiled)
+        {
+            //WrapUpPostfixで例外が発生しても、この部分だけは確実に実行されます。
             Logger.Info("タスクフェイズ開始", "Phase");
         }
     }

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -122,16 +122,16 @@ namespace TownOfHost
             Utils.AfterMeetingTasks();
             Utils.CustomSyncAllSettings();
             Utils.NotifyRoles();
-            new LateTask(() =>
-            {
-                AntiBlackout.SendGameData();
-                exiled?.Object?.RpcExileV2();
-            }, 0.5f, "Restore IsDead Task");
         }
 
         static void WrapUpFinalizer(GameData.PlayerInfo exiled)
         {
             //WrapUpPostfixで例外が発生しても、この部分だけは確実に実行されます。
+            new LateTask(() =>
+            {
+                AntiBlackout.SendGameData();
+                exiled?.Object?.RpcExileV2();
+            }, 0.5f, "Restore IsDead Task");
             Logger.Info("タスクフェイズ開始", "Phase");
         }
     }

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -110,7 +110,7 @@ namespace TownOfHost
             new LateTask(() =>
             {
                 AntiBlackout.SendGameData();
-                exiled.Object?.RpcExileV2();
+                exiled?.Object?.RpcExileV2();
             }, 0.5f, "Restore IsDead Task");
             Logger.Info("タスクフェイズ開始", "Phase");
         }


### PR DESCRIPTION
- WrapUpPostfixで例外が出ても関係なく実行される`WrapUpFinalizer`を追加し、そこに`Restore IsDead Task`を移動。
- 今後使うかは不明だが、`isDeadCache`に値が入っているかを表す`IsCached`を追加。
- 誰も追放されなかった場合に`Restore IsDead Task`がnull参照を起こす問題を修正。(#940 と同じ)