### PR TITLE
Fix/AntiBlackout-2

### DIFF
--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -72,11 +72,23 @@ namespace TownOfHost
         public static void SendGameData([CallerMemberName] string callerMethodName = "")
         {
             Logger.Info($"SendGameData is called from {callerMethodName}", "AntiBlackout");
-            MessageWriter writer = AmongUsClient.Instance.Streams[(int)SendOption.Reliable];
-            writer.StartMessage(1);
-            writer.WritePacked(GameData.Instance.NetId);
-            GameData.Instance.Serialize(writer, true);
+            MessageWriter writer = MessageWriter.Get(SendOption.Reliable);
+            // 書き込み {}は読みやすさのためです。
+            writer.StartMessage(5); //0x05 GameData
+            {
+                writer.Write(AmongUsClient.Instance.GameId);
+                writer.StartMessage(1); //0x01 Data
+                {
+                    writer.WritePacked(GameData.Instance.NetId);
+                    GameData.Instance.Serialize(writer, true);
+
+                }
+                writer.EndMessage();
+            }
             writer.EndMessage();
+
+            AmongUsClient.Instance.SendOrDisconnect(writer);
+            writer.Recycle();
         }
     }
 }

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -99,9 +99,11 @@ namespace TownOfHost
         public static void TempRestore(Action action)
         {
             Logger.Info("==Temp Restore==", "AntiBlackout");
+            //IsDeadが上書きされた状態でTempRestoreが実行されたかどうか
+            bool before_IsCached = IsCached;
             try
             {
-                RestoreIsDead(doSend: false);
+                if (before_IsCached) RestoreIsDead(doSend: false);
                 action();
             }
             catch (Exception ex)
@@ -110,7 +112,7 @@ namespace TownOfHost
             }
             finally
             {
-                SetIsDead(doSend: false);
+                if (before_IsCached) SetIsDead(doSend: false);
             }
             Logger.Info("==/Temp Restore==", "AntiBlackout");
         }

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using Hazel;
@@ -89,6 +90,29 @@ namespace TownOfHost
 
             AmongUsClient.Instance.SendOrDisconnect(writer);
             writer.Recycle();
+        }
+
+        ///<summary>
+        ///一時的にIsDeadを本来のものに戻した状態でコードを実行します
+        ///<param name="action">実行内容</param>
+        ///</summary>
+        public static void TempRestore(Action action)
+        {
+            Logger.Info("==Temp Restore==", "AntiBlackout");
+            try
+            {
+                RestoreIsDead(doSend: false);
+                action();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex.ToString(), "AntiBlackout.TempRestore");
+            }
+            finally
+            {
+                SetIsDead(doSend: false);
+            }
+            Logger.Info("==/Temp Restore==", "AntiBlackout");
         }
     }
 }

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -127,11 +127,12 @@ namespace TownOfHost
         static void WrapUpFinalizer(GameData.PlayerInfo exiled)
         {
             //WrapUpPostfixで例外が発生しても、この部分だけは確実に実行されます。
-            new LateTask(() =>
-            {
-                AntiBlackout.SendGameData();
-                exiled?.Object?.RpcExileV2();
-            }, 0.5f, "Restore IsDead Task");
+            if (AmongUsClient.Instance.AmHost)
+                new LateTask(() =>
+                {
+                    AntiBlackout.SendGameData();
+                    exiled?.Object?.RpcExileV2();
+                }, 0.5f, "Restore IsDead Task");
             Logger.Info("タスクフェイズ開始", "Phase");
         }
     }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -373,7 +373,7 @@ namespace TownOfHost
         public static void Postfix()
         {
             Logger.Info("------------会議終了------------", "Phase");
-            if (AmongUsClient.Instance.AmHost)
+            if (AmongUsClient.Instance.AmHost && !AntiBlackout.IsCached)
                 AntiBlackout.SetIsDead();
         }
     }


### PR DESCRIPTION
- `Restore IsDead Task`をホスト以外が実行することによるBANを修正
- `SendGameData`実行時に送信をAmongUsに任せず、即時送信するよう変更
- `SetIsDead`関数の実行時に`IsCached`を使ったチェックを行うよう変更
- 一時的にIsDeadを本来のものに戻した状態でコードを実行する`TempRestore`関数を追加