### PR TITLE
renameコマンドの修正

### DIFF
--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -67,7 +67,7 @@ namespace TownOfHost
                     case "/r":
                     case "/rename":
                         canceled = true;
-                        if (args.Length > 1) { Main.nickName = args[1]; }
+                        Main.nickName = args.Length > 1 ? Main.nickName = args[1] : "";
                         break;
 
                     case "/n":


### PR DESCRIPTION
## 問題
/renameコマンドで名前を戻す場合は引数を空にする必要があるが、「/rename」では引数がないことになり後ろにスペースを入れる必要があった。

## 修正
- renameコマンドの引数がない場合に空白を代入