### PR TITLE
ゲーム設定の秘匿オプションを追加

### DIFF
--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -171,6 +171,7 @@ namespace TownOfHost
         public static CustomOption ColorNameMode;
         public static CustomOption GhostCanSeeOtherRoles;
         public static CustomOption GhostCanSeeOtherVotes;
+        public static CustomOption HideGameSettings;
         public static readonly string[] suffixModes =
         {
             "SuffixMode.None",
@@ -438,6 +439,8 @@ namespace TownOfHost
             GhostCanSeeOtherRoles = CustomOption.Create(100603, Color.white, "GhostCanSeeOtherRoles", true)
                 .SetGameMode(CustomGameMode.All);
             GhostCanSeeOtherVotes = CustomOption.Create(100604, Color.white, "GhostCanSeeOtherVotes", true)
+                .SetGameMode(CustomGameMode.All);
+            HideGameSettings = CustomOption.Create(100606, Color.white, "HideGameSettings", false)
                 .SetGameMode(CustomGameMode.All);
 
             IsLoaded = true;

--- a/Modules/OptionShower.cs
+++ b/Modules/OptionShower.cs
@@ -23,87 +23,95 @@ namespace TownOfHost
             };
             //ゲームモードの表示
             text += $"{Options.GameMode.GetName()}: {Options.GameMode.GetString()}\n\n";
-            //Standardの時のみ実行
-            if (Options.CurrentGameMode == CustomGameMode.Standard)
+            if (Options.HideGameSettings.GetBool() && !AmongUsClient.Instance.AmHost)
             {
-                //役職一覧
-                text += $"<color={Utils.GetRoleColorCode(CustomRoles.LastImpostor)}>{Utils.GetRoleName(CustomRoles.LastImpostor)}:</color> {Options.EnableLastImpostor.GetString()}\n\n";
+                text += $"<color=#ff0000>{GetString("Message.HideGameSettings")}</color>";
+            }
+            else
+            {
+                //Standardの時のみ実行
+                if (Options.CurrentGameMode == CustomGameMode.Standard)
+                {
+                    //役職一覧
+                    text += $"<color={Utils.GetRoleColorCode(CustomRoles.LastImpostor)}>{Utils.GetRoleName(CustomRoles.LastImpostor)}:</color> {Options.EnableLastImpostor.GetString()}\n\n";
+                    foreach (var kvp in Options.CustomRoleSpawnChances)
+                        if (kvp.Value.GameMode is CustomGameMode.Standard or CustomGameMode.All) //スタンダードか全てのゲームモードで表示する役職
+                            text += $"{Helpers.ColorString(Utils.GetRoleColor(kvp.Key), Utils.GetRoleName(kvp.Key))}: {kvp.Value.GetString()}×{kvp.Key.GetCount()}\n";
+                    pages.Add(text + "\n\n");
+                    text = "";
+                }
+                //有効な役職と詳細設定一覧
+                pages.Add("");
+                if (Options.CurrentGameMode == CustomGameMode.Standard)
+                {
+                    if (Options.EnableLastImpostor.GetBool())
+                    {
+                        text += $"<color={Utils.GetRoleColorCode(CustomRoles.LastImpostor)}>{Utils.GetRoleName(CustomRoles.LastImpostor)}:</color> {Options.EnableLastImpostor.GetString()}\n";
+                        text += $"\t{GetString("LastImpostorKillCooldown")}: {Options.LastImpostorKillCooldown.GetString()}\n\n";
+                    }
+                }
                 foreach (var kvp in Options.CustomRoleSpawnChances)
-                    if (kvp.Value.GameMode is CustomGameMode.Standard or CustomGameMode.All) //スタンダードか全てのゲームモードで表示する役職
-                        text += $"{Helpers.ColorString(Utils.GetRoleColor(kvp.Key), Utils.GetRoleName(kvp.Key))}: {kvp.Value.GetString()}×{kvp.Key.GetCount()}\n";
-                pages.Add(text + "\n\n");
-                text = "";
-            }
-            //有効な役職と詳細設定一覧
-            pages.Add("");
-            if (Options.CurrentGameMode == CustomGameMode.Standard)
-            {
-                if (Options.EnableLastImpostor.GetBool())
                 {
-                    text += $"<color={Utils.GetRoleColorCode(CustomRoles.LastImpostor)}>{Utils.GetRoleName(CustomRoles.LastImpostor)}:</color> {Options.EnableLastImpostor.GetString()}\n";
-                    text += $"\t{GetString("LastImpostorKillCooldown")}: {Options.LastImpostorKillCooldown.GetString()}\n\n";
-                }
-            }
-            foreach (var kvp in Options.CustomRoleSpawnChances)
-            {
-                if (!kvp.Key.IsEnable()) continue;
-                if (!(kvp.Value.GameMode == Options.CurrentGameMode || kvp.Value.GameMode == CustomGameMode.All)) continue; //現在のゲームモードでも全てのゲームモードでも表示しない役職なら飛ばす
-                text += $"{Helpers.ColorString(Utils.GetRoleColor(kvp.Key), Utils.GetRoleName(kvp.Key))}: {kvp.Value.GetString()}×{kvp.Key.GetCount()}\n";
-                foreach (var c in kvp.Value.Children) //詳細設定をループする
-                {
-                    if (c.Name == "Maximum") continue; //Maximumの項目は飛ばす
-                    text += $"\t{c.GetName()}: {c.GetString()}\n";
-                }
-                if (kvp.Key.IsMadmate()) //マッドメイトの時に追加する詳細設定
-                {
-                    text += $"\t{Options.MadmateCanFixLightsOut.GetName()}: {Options.MadmateCanFixLightsOut.GetString()}\n";
-                    text += $"\t{Options.MadmateCanFixComms.GetName()}: {Options.MadmateCanFixComms.GetString()}\n";
-                    text += $"\t{Options.MadmateHasImpostorVision.GetName()}: {Options.MadmateHasImpostorVision.GetString()}\n";
-                    text += $"\t{Options.MadmateVentCooldown.GetName()}: {Options.MadmateVentCooldown.GetString()}\n";
-                    text += $"\t{Options.MadmateVentMaxTime.GetName()}: {Options.MadmateVentMaxTime.GetString()}\n";
-                }
-                if (kvp.Key is CustomRoles.Shapeshifter/* or CustomRoles.ShapeMaster*/ or CustomRoles.BountyHunter or CustomRoles.SerialKiller) //シェイプシフター役職の時に追加する詳細設定
-                {
-                    text += $"\t{Options.CanMakeMadmateCount.GetName()}: {Options.CanMakeMadmateCount.GetString()}\n";
-                }
-                if (kvp.Key == CustomRoles.Mayor && Options.MayorHasPortableButton.GetBool())
-                {
-                    text += $"\t{Options.MayorNumOfUseButton.GetName()}: {Options.MayorNumOfUseButton.GetString()}\n";
-                }
-                text += "\n";
-            }
-            //Onの時に子要素まで表示するメソッド
-            void listUp(CustomOption o)
-            {
-                if (o.GetBool())
-                {
-                    text += $"{o.GetName()}: {o.GetString()}\n";
-                    foreach (var c in o.Children)
-                        text += $"\t{c.GetName_v()}: {c.GetString()}\n";
+                    if (!kvp.Key.IsEnable()) continue;
+                    if (!(kvp.Value.GameMode == Options.CurrentGameMode || kvp.Value.GameMode == CustomGameMode.All)) continue; //現在のゲームモードでも全てのゲームモードでも表示しない役職なら飛ばす
+                    text += $"{Helpers.ColorString(Utils.GetRoleColor(kvp.Key), Utils.GetRoleName(kvp.Key))}: {kvp.Value.GetString()}×{kvp.Key.GetCount()}\n";
+                    foreach (var c in kvp.Value.Children) //詳細設定をループする
+                    {
+                        if (c.Name == "Maximum") continue; //Maximumの項目は飛ばす
+                        text += $"\t{c.GetName()}: {c.GetString()}\n";
+                    }
+                    if (kvp.Key.IsMadmate()) //マッドメイトの時に追加する詳細設定
+                    {
+                        text += $"\t{Options.MadmateCanFixLightsOut.GetName()}: {Options.MadmateCanFixLightsOut.GetString()}\n";
+                        text += $"\t{Options.MadmateCanFixComms.GetName()}: {Options.MadmateCanFixComms.GetString()}\n";
+                        text += $"\t{Options.MadmateHasImpostorVision.GetName()}: {Options.MadmateHasImpostorVision.GetString()}\n";
+                        text += $"\t{Options.MadmateVentCooldown.GetName()}: {Options.MadmateVentCooldown.GetString()}\n";
+                        text += $"\t{Options.MadmateVentMaxTime.GetName()}: {Options.MadmateVentMaxTime.GetString()}\n";
+                    }
+                    if (kvp.Key is CustomRoles.Shapeshifter/* or CustomRoles.ShapeMaster*/ or CustomRoles.BountyHunter or CustomRoles.SerialKiller) //シェイプシフター役職の時に追加する詳細設定
+                    {
+                        text += $"\t{Options.CanMakeMadmateCount.GetName()}: {Options.CanMakeMadmateCount.GetString()}\n";
+                    }
+                    if (kvp.Key == CustomRoles.Mayor && Options.MayorHasPortableButton.GetBool())
+                    {
+                        text += $"\t{Options.MayorNumOfUseButton.GetName()}: {Options.MayorNumOfUseButton.GetString()}\n";
+                    }
                     text += "\n";
                 }
+                //Onの時に子要素まで表示するメソッド
+                void listUp(CustomOption o)
+                {
+                    if (o.GetBool())
+                    {
+                        text += $"{o.GetName()}: {o.GetString()}\n";
+                        foreach (var c in o.Children)
+                            text += $"\t{c.GetName_v()}: {c.GetString()}\n";
+                        text += "\n";
+                    }
+                }
+                void nameAndValue(CustomOption o) => text += $"{o.GetName()}: {o.GetString()}\n";
+                if (Options.CurrentGameMode == CustomGameMode.Standard)
+                {
+                    listUp(Options.SyncButtonMode);
+                    listUp(Options.VoteMode);
+                    listUp(Options.SabotageTimeControl);
+                    nameAndValue(Options.StandardHAS);
+                }
+                else if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
+                {
+                    nameAndValue(Options.AllowCloseDoors);
+                    nameAndValue(Options.KillDelay);
+                    //nameAndValue(Options.IgnoreCosmetics);
+                    nameAndValue(Options.IgnoreVent);
+                }
+                text += "\n";
+                listUp(Options.LadderDeath);
+                listUp(Options.DisableTasks);
+                listUp(Options.RandomMapsMode);
+                nameAndValue(Options.NoGameEnd);
+                nameAndValue(Options.GhostCanSeeOtherRoles);
+                nameAndValue(Options.HideGameSettings);
             }
-            void nameAndValue(CustomOption o) => text += $"{o.GetName()}: {o.GetString()}\n";
-            if (Options.CurrentGameMode == CustomGameMode.Standard)
-            {
-                listUp(Options.SyncButtonMode);
-                listUp(Options.VoteMode);
-                listUp(Options.SabotageTimeControl);
-                nameAndValue(Options.StandardHAS);
-            }
-            else if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
-            {
-                nameAndValue(Options.AllowCloseDoors);
-                nameAndValue(Options.KillDelay);
-                //nameAndValue(Options.IgnoreCosmetics);
-                nameAndValue(Options.IgnoreVent);
-            }
-            text += "\n";
-            listUp(Options.LadderDeath);
-            listUp(Options.DisableTasks);
-            listUp(Options.RandomMapsMode);
-            nameAndValue(Options.NoGameEnd);
-            nameAndValue(Options.GhostCanSeeOtherRoles);
             //1ページにつき35行までにする処理
             List<string> tmp = new(text.Split("\n\n"));
             for (var i = 0; i < tmp.Count; i++)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -255,6 +255,11 @@ namespace TownOfHost
         }
         public static void ShowActiveSettings(byte PlayerId = byte.MaxValue)
         {
+            if (Options.HideGameSettings.GetBool() && PlayerId != byte.MaxValue)
+            {
+                SendMessage(GetString("Message.HideGameSettings"), PlayerId);
+                return;
+            }
             var text = "";
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
             {
@@ -328,6 +333,11 @@ namespace TownOfHost
         }
         public static void ShowActiveRoles(byte PlayerId = byte.MaxValue)
         {
+            if (Options.HideGameSettings.GetBool() && PlayerId != byte.MaxValue)
+            {
+                SendMessage(GetString("Message.HideGameSettings"), PlayerId);
+                return;
+            }
             var text = GetString("Roles") + ":";
             foreach (CustomRoles role in Enum.GetValues(typeof(CustomRoles)))
             {

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -221,6 +221,7 @@ SuffixMode.Recording,Recording,録画中,录像中,錄影中
 ColorNameMode,Color Name Mode,色名前モード,显示颜色,七彩名字模式
 GhostCanSeeOtherRoles,Ghost Can See Other Roles,幽霊が他人の役職を見ることができる,幽灵可见他人职业,幽靈可以看見所有玩家職業
 GhostCanSeeOtherVotes,Ghost Can See Other Votes,幽霊が他人の投票先を見ることができる,幽灵可见投票情况,幽靈可以看見所有玩家的投票
+HideGameSettings,Hide Game Settings,ゲーム設定を隠す,,
 RoleOptions,Role Options,役職設定,职业设置,職業設定
 ModeOptions,Mode Options,モード設定,模组设置,模式設定
 ForceJapanese,Force Japanese,日本語に強制,强制使用日语,強制使用日語
@@ -371,6 +372,7 @@ Message.TemplateNotFoundHost,"No messages matching "{0}" were found.\nPlease add
 Message.TemplateNotFoundClient,"No messages matching "{0}" were found.",「{0}」に該当するメッセージが見つかりませんでした。,,
 Message.SyncButtonLeft,The emergency meeting button can be used {0} more times,緊急会議ボタンはあと{0}回使用できます,,
 Message.Executed,{0} was executed,{0}を処刑しました,,
+Message.HideGameSettings,Game settings are hidden by the host.,ゲーム設定はホストによって秘匿されています。,,
 
 ## 警告
 Warning.EgoistCannotWin,Egoist cannot win!,エゴイストが勝利できません,野心家无法获胜,利己主義者無法獲勝


### PR DESCRIPTION
ゲーム設定の秘匿オプションを追加
- ホスト以外はゲーム設定を確認できない
- ホスト以外の/nowコマンドは代わりにメッセージを表示