### PR TITLE
unity-libsの参照の削除 (fix/unity-libs)

### DIFF
--- a/TownOfHost.csproj
+++ b/TownOfHost.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
       <Reference Include="$(AmongUs)\BepInEx\core\*.dll" />
       <Reference Include="$(AmongUs)\BepInEx\unhollowed\*.dll" />
-      <Reference Include="$(AmongUs)\BepInEx\unity-libs\*.dll" />
+      <!--<Reference Include="$(AmongUs)\BepInEx\unity-libs\*.dll" />-->
       <EmbeddedResource Include=".\Resources\*.png" />
       <EmbeddedResource Include=".\Resources\string.csv" />
   </ItemGroup>


### PR DESCRIPTION
AmongUsを再インストールしたら、VSCode上で大量のエラーが出るようになり、ビルドも通らなくなりました。
そして、.csprojファイル内の`unity-libs`への参照を削除してみると、VSCode上でエラーが出なくなり、ビルドも通るようになりました。
また、`unhollowed`フォルダー内に`unity-libs`内のdllと同名のdllが含まれています。
ほかの人の環境でも問題なくエラーが通れば、こちらのほうがいいと思います。