### PR TITLE
エスクキューショナーが抜けた際にTOHクライアントがキックされる問題を修正

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -455,6 +455,7 @@ namespace TownOfHost
         }
         public static void RemoveExecutionerKey(byte Key)
         {
+            if (!AmongUsClient.Instance.AmHost) return;
             MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.RemoveExecutionerTarget, Hazel.SendOption.Reliable, -1);
             writer.Write(Key);
             AmongUsClient.Instance.FinishRpcImmediately(writer);


### PR DESCRIPTION
## 現象
エクスキューショナーが抜けた際に不正なRPCとしてTOHクライアントがキックされる。

## 原因
ホスト以外が「RemoveExecutionerTarget」を送信しているため不正なRPCとみなされている。

## 修正
- ホスト以外送信しないように変更。