### PR TITLE
全員生存時の会議時間オプションを追加

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -357,6 +357,12 @@ namespace TownOfHost
             opt.DiscussionTime = Mathf.Clamp(Main.DiscussionTime, 0, 300);
             opt.VotingTime = Mathf.Clamp(Main.VotingTime, TimeThief.LowerLimitVotingTime.GetInt(), 300);
 
+            if (Options.AllAliveMeeting.GetBool() && PlayerControl.AllPlayerControls.ToArray().All(x => !x.Data.IsDead))
+            {
+                opt.DiscussionTime = 0;
+                opt.VotingTime = Options.AllAliveMeetingTime.GetInt();
+            }
+
             opt.RoleOptions.ShapeshifterCooldown = Mathf.Max(1f, opt.RoleOptions.ShapeshifterCooldown);
 
             if (player.AmOwner) PlayerControl.GameOptions = opt;

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -145,6 +145,10 @@ namespace TownOfHost
         public static VoteMode GetWhenSkipVote() => (VoteMode)WhenSkipVote.GetSelection();
         public static VoteMode GetWhenNonVote() => (VoteMode)WhenNonVote.GetSelection();
 
+        // 全員生存時の会議時間
+        public static CustomOption AllAliveMeeting;
+        public static CustomOption AllAliveMeetingTime;
+
         //転落死
         public static CustomOption LadderDeath;
         public static CustomOption LadderDeathChance;
@@ -419,6 +423,10 @@ namespace TownOfHost
                 .SetGameMode(CustomGameMode.Standard);
             WhenNonVote = CustomOption.Create(100502, Color.white, "WhenNonVote", voteModes, voteModes[0], VoteMode)
                 .SetGameMode(CustomGameMode.Standard);
+
+            // 全員生存時の会議時間
+            AllAliveMeeting = CustomOption.Create(100900, Color.white, "AllAliveMeeting", false, null, true);
+            AllAliveMeetingTime = CustomOption.Create(100901, Color.white, "AllAliveMeetingTime", 10, 1, 300, 1, AllAliveMeeting);
 
             // 転落死
             LadderDeath = CustomOption.Create(101100, Color.white, "LadderDeath", false, null, true);

--- a/Modules/OptionShower.cs
+++ b/Modules/OptionShower.cs
@@ -112,6 +112,7 @@ namespace TownOfHost
                     nameAndValue(Options.IgnoreVent);
                 }
                 text += "\n";
+                listUp(Options.AllAliveMeeting);
                 listUp(Options.LadderDeath);
                 listUp(Options.DisableTasks);
                 listUp(Options.RandomMapsMode);

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -212,6 +212,8 @@ AddedTheSkeld,Include TheSkeld,TheSkeldを追加,添加骷髅舰地图,將The Sk
 AddedMIRAHQ,Include MIRAHQ,MIRAHQを追加,添加米拉总部地图,將MIRA HQ地圖列入選項
 AddedPolus,Include Polus,Polusを追加,添加波鲁斯地图,將Polus地圖列入選項
 AddedTheAirShip,Include TheAirShip,TheAirShipを追加,添加飞艇地图,將The AirShip列入選項
+AllAliveMeeting,All Alive Meeting,全員生存時の会議,,
+AllAliveMeetingTime,All Alive Meeting Time,全員生存時の会議時間,,
 LadderDeath,Fall From Ladders,ハシゴから転落,从梯子上下滑时有可能摔死,從梯子上下滑時可能會摔死
 LadderDeathChance,Fall To Death Chance,転落する確率,从梯子上摔死的概率,從梯子上下滑摔死機率
 DisableTasks,Disable Tasks,タスクを無効化する,禁用某些任务,禁用某些特定的任務


### PR DESCRIPTION
全員生存時の会議時間オプションを追加
- 全員が生存しているときの会議時間を設定
- 範囲は1~300秒

死体がない状態で長々と雑談されたくない人用