### PR TITLE
mod入りクライアントのアドミン無効化の条件が反転している問題を修正

### DIFF
--- a/Patches/Devices/Admin.cs
+++ b/Patches/Devices/Admin.cs
@@ -23,7 +23,7 @@ namespace TownOfHost
                 bool isGuard = false;
 
                 DisabledText.gameObject.SetActive(false);
-                if (!PlayerControl.LocalPlayer.IsAlive())
+                if (PlayerControl.LocalPlayer.IsAlive())
                 {
                     if (DisableAdmin)
                     {


### PR DESCRIPTION
生きているときに見れて死んでいるときに見れない(条件反転)