### PR TITLE
GMが生きている判定になってることで起きる問題を修正

### DIFF
--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -237,7 +237,11 @@ namespace TownOfHost
                     pc.RpcSetRole(RoleTypes.Shapeshifter);
                     pc.RpcResetAbilityCooldown();
                 }
-                if (PlayerControl.LocalPlayer.Is(CustomRoles.GM)) PlayerControl.LocalPlayer.RpcExile();
+                if (PlayerControl.LocalPlayer.Is(CustomRoles.GM))
+                {
+                    PlayerControl.LocalPlayer.RpcExile();
+                    PlayerState.SetDead(PlayerControl.LocalPlayer.PlayerId);
+                }
             }
             Logger.Info("OnDestroy", "IntroCutscene");
         }


### PR DESCRIPTION
バウンティのターゲットなどにGMが選ばれる問題がありました。