### PR TITLE
Fix/Vampireに噛まれたプレイヤーが切断すると会議が始まらない

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -504,7 +504,7 @@ namespace TownOfHost
                 var vampireID = bp.Value.Item1;
                 var bitten = Utils.GetPlayerById(bp.Key);
 
-                if (!bitten.Data.IsDead)
+                if (bitten!=null && !bitten.Data.IsDead)
                 {
                     PlayerState.SetDeathReason(bitten.PlayerId, PlayerState.DeathReason.Bite);
                     //Protectは強制的にはがす


### PR DESCRIPTION
噛まれたプレイヤーの処理でNullチェックが漏れていたため例外発生
=>bittenのNullチェック追加