### PR TITLE
fix/JackalAutoMute

### DIFF
--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -284,12 +284,12 @@ namespace TownOfHost
                                 if (role is not CustomRoles.HASFox and not CustomRoles.HASTroll) numTotalAlive++;
                             }
 
-                            if (playerInfo.Role.TeamType == RoleTeamTypes.Impostor &&
+                            if (playerInfo.GetCustomRole() == CustomRoles.Jackal) numJackalsAlive++;
+                            else if (playerInfo.Role.TeamType == RoleTeamTypes.Impostor &&
                             (playerInfo.GetCustomRole() != CustomRoles.Sheriff || playerInfo.GetCustomRole() != CustomRoles.Arsonist))
                             {
                                 numImpostorsAlive++;
                             }
-                            else if (playerInfo.GetCustomRole() == CustomRoles.Jackal) numJackalsAlive++;
                         }
                     }
                 }

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -246,6 +246,7 @@ namespace TownOfHost
                 {
                     pc.RpcSetRole(RoleTypes.Shapeshifter);
                     pc.RpcResetAbilityCooldown();
+                    if (pc.Is(CustomRoles.Jackal)) pc.Data.Role.TeamType = RoleTeamTypes.Impostor;
                 }
                 if (PlayerControl.LocalPlayer.Is(CustomRoles.GM))
                 {

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -310,6 +310,9 @@ namespace TownOfHost
                         if (Main.ExecutionerTarget.TryGetValue(seer.PlayerId, out var targetId) && target.PlayerId == targetId) //targetがValue
                             pva.NameText.text += Helpers.ColorString(Utils.GetRoleColor(CustomRoles.Executioner), "♦");
                         break;
+                    case CustomRoles.Jackal:
+                        pva.NameText.color = Utils.GetRoleColor(CustomRoles.Crewmate); //インポスターも含めて名前を白くする
+                        break;
                 }
 
                 switch (target.GetCustomRole())
@@ -331,7 +334,14 @@ namespace TownOfHost
 
                 if (LocalPlayerKnowsImpostor)
                 {
-                    if (target != null && target.GetCustomRole().IsImpostor()) //変更先がインポスター
+                    if (Options.SnitchCanFindNeutralKiller.GetBool())
+                    {
+                        if (target.Is(CustomRoles.Jackal))
+                            pva.NameText.color = Utils.GetRoleColor(CustomRoles.Jackal);
+                        if (target.Is(CustomRoles.Egoist))
+                            pva.NameText.color = Utils.GetRoleColor(CustomRoles.Egoist);
+                    }
+                    if (target.GetCustomRole().IsImpostor()) //変更先がインポスター
                         pva.NameText.color = Palette.ImpostorRed; //変更対象の名前を赤くする
                 }
                 //呪われている場合

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -16,6 +16,14 @@ namespace TownOfHost
 
             Logger.Info("-----------ゲーム終了-----------", "Phase");
             PlayerControl.GameOptions.killCooldown = Options.DefaultKillCooldown;
+            foreach (var p in PlayerControl.AllPlayerControls)
+            {
+                if (p.Is(CustomRoles.Jackal))
+                {
+                    p.Data.Role.TeamType = RoleTeamTypes.Crewmate;
+                }
+            }
+
             //winnerListリセット
             TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
             Main.additionalwinners = new HashSet<AdditionalWinners>();

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -421,7 +421,11 @@ namespace TownOfHost
                     foreach (var pc in PlayerControl.AllPlayerControls)
                     {
                         if (pc == player) continue;
-                        if (pc.PlayerId == 0) player.SetRole(RoleTypes.Scientist); //ホスト視点用
+                        if (pc.PlayerId == 0)
+                        {
+                            player.SetRole(RoleTypes.Scientist); //ホスト視点用
+                            if (role is CustomRoles.Jackal) player.Data.Role.TeamType = RoleTeamTypes.Impostor;
+                        }
                         else sender.RpcSetRole(player, RoleTypes.Scientist, pc.GetClientId());
                     }
                 }
@@ -429,6 +433,7 @@ namespace TownOfHost
                 {
                     //ホストは別の役職にする
                     player.SetRole(hostBaseRole); //ホスト視点用
+                    if (role is CustomRoles.Jackal) player.Data.Role.TeamType = RoleTeamTypes.Impostor;
                     sender.RpcSetRole(player, hostBaseRole);
                 }
                 player.Data.IsDead = true;

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -421,11 +421,7 @@ namespace TownOfHost
                     foreach (var pc in PlayerControl.AllPlayerControls)
                     {
                         if (pc == player) continue;
-                        if (pc.PlayerId == 0)
-                        {
-                            player.SetRole(RoleTypes.Scientist); //ホスト視点用
-                            if (role is CustomRoles.Jackal) player.Data.Role.TeamType = RoleTeamTypes.Impostor;
-                        }
+                        if (pc.PlayerId == 0) player.SetRole(RoleTypes.Scientist); //ホスト視点用
                         else sender.RpcSetRole(player, RoleTypes.Scientist, pc.GetClientId());
                     }
                 }
@@ -433,7 +429,6 @@ namespace TownOfHost
                 {
                     //ホストは別の役職にする
                     player.SetRole(hostBaseRole); //ホスト視点用
-                    if (role is CustomRoles.Jackal) player.Data.Role.TeamType = RoleTeamTypes.Impostor;
                     sender.RpcSetRole(player, hostBaseRole);
                 }
                 player.Data.IsDead = true;


### PR DESCRIPTION
AutoMuteBotでインポスター・ジャッカル残りになった場合にAutoMuteが試合終了判定してしまう。

原因
　AutoMuteはRoleTeamTypes.Impostorが0人の場合試合終了判定している

対策
　JackalにRoleTeamTypes.Impostorを割り当てることでインポスター・ジャッカル残りでも終了判定にならない