### PR TITLE
Feature/Fork Config

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -73,8 +73,8 @@ namespace TownOfHost
         public readonly Version version;
         public readonly string tag;
         public readonly string forkId;
-        public PlayerVersion(string ver, string tag_str) => new PlayerVersion(Version.Parse(ver), tag_str, "");
-        public PlayerVersion(Version ver, string tag_str) => new PlayerVersion(ver, tag_str, "");
+        [Obsolete] public PlayerVersion(string ver, string tag_str) => new PlayerVersion(Version.Parse(ver), tag_str, "");
+        [Obsolete] public PlayerVersion(Version ver, string tag_str) => new PlayerVersion(ver, tag_str, "");
         public PlayerVersion(string ver, string tag_str, string forkId) => new PlayerVersion(Version.Parse(ver), tag_str, forkId);
         public PlayerVersion(Version ver, string tag_str, string forkId)
         {

--- a/Helpers.cs
+++ b/Helpers.cs
@@ -72,10 +72,15 @@ namespace TownOfHost
     {
         public readonly Version version;
         public readonly string tag;
-        public PlayerVersion(string ver, string tag_str)
+        public readonly string forkId;
+        public PlayerVersion(string ver, string tag_str) => new PlayerVersion(Version.Parse(ver), tag_str, "");
+        public PlayerVersion(Version ver, string tag_str) => new PlayerVersion(ver, tag_str, "");
+        public PlayerVersion(string ver, string tag_str, string forkId) => new PlayerVersion(Version.Parse(ver), tag_str, forkId);
+        public PlayerVersion(Version ver, string tag_str, string forkId)
         {
-            version = Version.Parse(ver);
+            version = ver;
             tag = tag_str;
+            this.forkId = forkId;
         }
         public bool IsEqual(PlayerVersion pv)
         {

--- a/Helpers.cs
+++ b/Helpers.cs
@@ -73,9 +73,9 @@ namespace TownOfHost
         public readonly Version version;
         public readonly string tag;
         public readonly string forkId;
-        [Obsolete] public PlayerVersion(string ver, string tag_str) => new PlayerVersion(Version.Parse(ver), tag_str, "");
-        [Obsolete] public PlayerVersion(Version ver, string tag_str) => new PlayerVersion(ver, tag_str, "");
-        public PlayerVersion(string ver, string tag_str, string forkId) => new PlayerVersion(Version.Parse(ver), tag_str, forkId);
+        [Obsolete] public PlayerVersion(string ver, string tag_str) : this(Version.Parse(ver), tag_str, "") { }
+        [Obsolete] public PlayerVersion(Version ver, string tag_str) : this(ver, tag_str, "") { }
+        public PlayerVersion(string ver, string tag_str, string forkId) : this(Version.Parse(ver), tag_str, forkId) { }
         public PlayerVersion(Version ver, string tag_str, string forkId)
         {
             version = ver;

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -83,8 +83,9 @@ namespace TownOfHost
                 case CustomRPC.VersionCheck:
                     try
                     {
-                        string version = reader.ReadString();
+                        Version version = Version.Parse(reader.ReadString());
                         string tag = reader.ReadString();
+                        string forkId = 3 <= version.Major ? reader.ReadString() : Main.OriginalForkId;
                         Main.playerVersion[__instance.PlayerId] = new PlayerVersion(version, tag);
                     }
                     catch
@@ -229,6 +230,7 @@ namespace TownOfHost
             MessageWriter writer = AmongUsClient.Instance.StartRpc(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.VersionCheck, SendOption.Reliable);
             writer.Write(Main.PluginVersion);
             writer.Write($"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})");
+            writer.Write(Main.ForkId);
             writer.EndMessage();
             Main.playerVersion[PlayerControl.LocalPlayer.PlayerId] = new PlayerVersion(Main.PluginVersion, $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})");
         }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -232,7 +232,7 @@ namespace TownOfHost
             writer.Write($"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})");
             writer.Write(Main.ForkId);
             writer.EndMessage();
-            Main.playerVersion[PlayerControl.LocalPlayer.PlayerId] = new PlayerVersion(Main.PluginVersion, $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})");
+            Main.playerVersion[PlayerControl.LocalPlayer.PlayerId] = new PlayerVersion(Main.PluginVersion, $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})", Main.ForkId);
         }
         public static void SendDeathReason(byte playerId, PlayerState.DeathReason deathReason)
         {

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -86,7 +86,7 @@ namespace TownOfHost
                         Version version = Version.Parse(reader.ReadString());
                         string tag = reader.ReadString();
                         string forkId = 3 <= version.Major ? reader.ReadString() : Main.OriginalForkId;
-                        Main.playerVersion[__instance.PlayerId] = new PlayerVersion(version, tag, Main.ForkId);
+                        Main.playerVersion[__instance.PlayerId] = new PlayerVersion(version, tag, forkId);
                     }
                     catch
                     {

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -86,7 +86,7 @@ namespace TownOfHost
                         Version version = Version.Parse(reader.ReadString());
                         string tag = reader.ReadString();
                         string forkId = 3 <= version.Major ? reader.ReadString() : Main.OriginalForkId;
-                        Main.playerVersion[__instance.PlayerId] = new PlayerVersion(version, tag);
+                        Main.playerVersion[__instance.PlayerId] = new PlayerVersion(version, tag, Main.ForkId);
                     }
                     catch
                     {

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -497,7 +497,7 @@ namespace TownOfHost
                     case SuffixModes.None:
                         break;
                     case SuffixModes.TOH:
-                        name += "\r\n<color=" + Main.modColor + ">TOH v" + Main.PluginVersion + "</color>";
+                        name += "\r\n<color=" + Main.ModColor + ">TOH v" + Main.PluginVersion + "</color>";
                         break;
                     case SuffixModes.Streaming:
                         name += $"\r\n{GetString("SuffixMode.Streaming")}";

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -39,7 +39,7 @@ namespace TownOfHost
                     string version_text = "";
                     foreach (var kvp in Main.playerVersion.OrderBy(pair => pair.Key))
                     {
-                        version_text += $"{kvp.Key}:{Utils.GetPlayerById(kvp.Key)?.Data?.PlayerName}:{kvp.Value.version}({kvp.Value.tag})\n";
+                        version_text += $"{kvp.Key}:{Utils.GetPlayerById(kvp.Key)?.Data?.PlayerName}:{kvp.Value.forkId}/{kvp.Value.version}({kvp.Value.tag})\n";
                     }
                     if (version_text != "") HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, version_text);
                     break;

--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -10,6 +10,12 @@ namespace TownOfHost
     {
         public static bool Prefix(GameStartManager __instance)
         {
+            // 定数設定による公開ルームブロック
+            if (!Main.AllowPublicRoom)
+            {
+                return false;
+            }
+            // 名前確認による公開ルームブロック
             bool NameIncludeTOH = SaveManager.PlayerName.ToUpper().Contains("TOH");
             if (ModUpdater.isBroken || ModUpdater.hasUpdate || !NameIncludeTOH)
             {

--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -13,6 +13,9 @@ namespace TownOfHost
             // 定数設定による公開ルームブロック
             if (!Main.AllowPublicRoom)
             {
+                var message = GetString("DisabledBySettings");
+                Logger.Info(message, "MakePublicPatch");
+                Logger.SendInGame(message);
                 return false;
             }
             // 名前確認による公開ルームブロック

--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -13,7 +13,7 @@ namespace TownOfHost
             // 定数設定による公開ルームブロック
             if (!Main.AllowPublicRoom)
             {
-                var message = GetString("DisabledBySettings");
+                var message = GetString("DisabledByProgram");
                 Logger.Info(message, "MakePublicPatch");
                 Logger.SendInGame(message);
                 return false;

--- a/Patches/CredentialsPatch.cs
+++ b/Patches/CredentialsPatch.cs
@@ -46,7 +46,7 @@ namespace TownOfHost
             private static TMPro.TextMeshPro ErrorText;
             static void Postfix(VersionShower __instance)
             {
-                Main.credentialsText = $"\r\n<color={Main.modColor}>Town Of Host</color> v{Main.PluginVersion}";
+                Main.credentialsText = $"\r\n<color={Main.modColor}>{Main.modName}</color> v{Main.PluginVersion}";
                 if (ThisAssembly.Git.Branch != "main")
                     Main.credentialsText += $"\r\n<color={Main.modColor}>{ThisAssembly.Git.Branch}({ThisAssembly.Git.Commit})</color>";
                 var credentials = UnityEngine.Object.Instantiate<TMPro.TextMeshPro>(__instance.text);

--- a/Patches/CredentialsPatch.cs
+++ b/Patches/CredentialsPatch.cs
@@ -46,9 +46,9 @@ namespace TownOfHost
             private static TMPro.TextMeshPro ErrorText;
             static void Postfix(VersionShower __instance)
             {
-                Main.credentialsText = $"\r\n<color={Main.modColor}>{Main.modName}</color> v{Main.PluginVersion}";
+                Main.credentialsText = $"\r\n<color={Main.ModColor}>{Main.ModName}</color> v{Main.PluginVersion}";
                 if (ThisAssembly.Git.Branch != "main")
-                    Main.credentialsText += $"\r\n<color={Main.modColor}>{ThisAssembly.Git.Branch}({ThisAssembly.Git.Commit})</color>";
+                    Main.credentialsText += $"\r\n<color={Main.ModColor}>{ThisAssembly.Git.Branch}({ThisAssembly.Git.Commit})</color>";
                 var credentials = UnityEngine.Object.Instantiate<TMPro.TextMeshPro>(__instance.text);
                 credentials.text = Main.credentialsText;
                 credentials.alignment = TMPro.TextAlignmentOptions.TopRight;

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -37,7 +37,7 @@ namespace TownOfHost
                 HideName = Object.Instantiate(__instance.GameRoomNameCode, __instance.GameRoomNameCode.transform);
                 HideName.text = ColorUtility.TryParseHtmlString(Main.HideColor.Value, out _)
                         ? $"<color={Main.HideColor.Value}>{Main.HideName.Value}</color>"
-                        : $"<color={Main.modColor}>{Main.HideName.Value}</color>";
+                        : $"<color={Main.ModColor}>{Main.HideName.Value}</color>";
 
                 // Make Public Button
                 bool NameIncludeMod = SaveManager.PlayerName.ToLower().Contains("mod");

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -42,7 +42,8 @@ namespace TownOfHost
                 // Make Public Button
                 bool NameIncludeMod = SaveManager.PlayerName.ToLower().Contains("mod");
                 bool NameIncludeTOH = SaveManager.PlayerName.ToUpper().Contains("TOH");
-                if (ModUpdater.isBroken || ModUpdater.hasUpdate || (NameIncludeMod && !NameIncludeTOH))
+                if (ModUpdater.isBroken || ModUpdater.hasUpdate || (NameIncludeMod && !NameIncludeTOH) ||
+                    !Main.AllowPublicRoom)
                 {
                     __instance.MakePublicButton.color = Palette.DisabledClear;
                     __instance.privatePublicText.color = Palette.DisabledClear;

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -65,7 +65,7 @@ namespace TownOfHost
                 var text = pc.AmOwner ? "[*]" : "   ";
                 text += $"{pc.PlayerId,-2}:{pc.Data?.PlayerName?.PadRightV2(20)}:{pc.GetClient().PlatformData.Platform.ToString().Replace("Standalone", ""),-11}";
                 if (Main.playerVersion.TryGetValue(pc.PlayerId, out PlayerVersion pv))
-                    text += $":Mod({pv.version}:{pv.tag})";
+                    text += $":Mod({pv.forkId}/{pv.version}:{pv.tag})";
                 else text += ":Vanilla";
                 Logger.Info(text, "Info");
             }

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -169,7 +169,7 @@ namespace TownOfHost
 
             if (Input.GetKey(KeyCode.RightShift))
             {
-                __instance.TeamTitle.text = "Town Of Host";
+                __instance.TeamTitle.text = Main.modName;
                 __instance.ImpostorText.gameObject.SetActive(true);
                 __instance.ImpostorText.text = "https://github.com/tukasa0001/TownOfHost" +
                     "\r\nOut Now on Github";

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -169,7 +169,7 @@ namespace TownOfHost
 
             if (Input.GetKey(KeyCode.RightShift))
             {
-                __instance.TeamTitle.text = Main.modName;
+                __instance.TeamTitle.text = Main.ModName;
                 __instance.ImpostorText.gameObject.SetActive(true);
                 __instance.ImpostorText.text = "https://github.com/tukasa0001/TownOfHost" +
                     "\r\nOut Now on Github";

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -749,9 +749,13 @@ namespace TownOfHost
                 if (GameStates.IsLobby)
                 {
                     if (Main.playerVersion.TryGetValue(__instance.PlayerId, out var ver))
-                        if (Main.version.CompareTo(ver.version) == 0)
+                    {
+                        if (Main.ForkId != ver.forkId) // フォークIDが違う場合
+                            __instance.cosmetics.nameText.text = $"<color=#ff0000><size=1.2>v{ver.forkId}</size>\n{__instance?.name}</color>";
+                        else if (Main.version.CompareTo(ver.version) == 0)
                             __instance.cosmetics.nameText.text = ver.tag == $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})" ? $"<color=#87cefa>{__instance.name}</color>" : $"<color=#ffff00><size=1.2>{ver.tag}</size>\n{__instance?.name}</color>";
                         else __instance.cosmetics.nameText.text = $"<color=#ff0000><size=1.2>v{ver.version}</size>\n{__instance?.name}</color>";
+                    }
                     else __instance.cosmetics.nameText.text = __instance?.Data?.PlayerName;
                 }
                 if (GameStates.IsInGame)

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -751,7 +751,7 @@ namespace TownOfHost
                     if (Main.playerVersion.TryGetValue(__instance.PlayerId, out var ver))
                     {
                         if (Main.ForkId != ver.forkId) // フォークIDが違う場合
-                            __instance.cosmetics.nameText.text = $"<color=#ff0000><size=1.2>v{ver.forkId}</size>\n{__instance?.name}</color>";
+                            __instance.cosmetics.nameText.text = $"<color=#ff0000><size=1.2>{ver.forkId}</size>\n{__instance?.name}</color>";
                         else if (Main.version.CompareTo(ver.version) == 0)
                             __instance.cosmetics.nameText.text = ver.tag == $"{ThisAssembly.Git.Commit}({ThisAssembly.Git.Branch})" ? $"<color=#87cefa>{__instance.name}</color>" : $"<color=#ffff00><size=1.2>{ver.tag}</size>\n{__instance?.name}</color>";
                         else __instance.cosmetics.nameText.text = $"<color=#ff0000><size=1.2>v{ver.version}</size>\n{__instance?.name}</color>";

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -505,7 +505,7 @@ namespace TownOfHost
                 var vampireID = bp.Value.Item1;
                 var bitten = Utils.GetPlayerById(bp.Key);
 
-                if (bitten!=null && !bitten.Data.IsDead)
+                if (bitten != null && !bitten.Data.IsDead)
                 {
                     PlayerState.SetDeathReason(bitten.PlayerId, PlayerState.DeathReason.Bite);
                     //Protectは強制的にはがす
@@ -548,7 +548,7 @@ namespace TownOfHost
 
             if (AmongUsClient.Instance.AmHost)
             {//実行クライアントがホストの場合のみ実行
-                if (GameStates.IsLobby && (ModUpdater.hasUpdate || ModUpdater.isBroken) && AmongUsClient.Instance.IsGamePublic)
+                if (GameStates.IsLobby && (ModUpdater.hasUpdate || ModUpdater.isBroken || !Main.AllowPublicRoom) && AmongUsClient.Instance.IsGamePublic)
                     AmongUsClient.Instance.ChangeGamePublic(false);
 
                 if (GameStates.IsInTask && CustomRoles.Vampire.IsEnable())

--- a/Patches/TaskAdderPatch.cs
+++ b/Patches/TaskAdderPatch.cs
@@ -19,7 +19,7 @@ namespace TownOfHost
                     __instance.transform
                 );
                 rolesFolder.gameObject.SetActive(false);
-                rolesFolder.FolderName = "Town Of Host";
+                rolesFolder.FolderName = Main.modName;
                 CustomRolesFolder = rolesFolder;
                 __instance.Root.SubFolders.Add(rolesFolder);
             }

--- a/Patches/TaskAdderPatch.cs
+++ b/Patches/TaskAdderPatch.cs
@@ -19,7 +19,7 @@ namespace TownOfHost
                     __instance.transform
                 );
                 rolesFolder.gameObject.SetActive(false);
-                rolesFolder.FolderName = Main.modName;
+                rolesFolder.FolderName = Main.ModName;
                 CustomRolesFolder = rolesFolder;
                 __instance.Root.SubFolders.Add(rolesFolder);
             }

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -417,6 +417,7 @@ onSetPublicNoLatest,Public rooms is prohibited except for the latest version.\nP
 CanNotJoinPublicRoomNoLatest,You can't join public rooms except for the latest version.\nPlease update.,最新版以外で公開ルームには参加できません。\nアップデートをしてください。,不可以在未安装最新模组的前提下进入公开房间。\n请更新本模组。,"無法在未安裝最新版本的前提下進入公開房間\n請更新本模組"
 ModBrokenMessage,The MOD file is broken.\nPlease re-install it again.,MODを構成するファイルが破損しています。\nもう一度導入しなおしてください。,模组文件损坏。\n请重新安装本模组。,模組檔案損壞\n請重新安裝模組
 NameIncludeTOH,"You cannot make public rooms unless "TOH" is included in your name.",""TOH"が名前に含まれていない状態では公開部屋にすることはできません。","不可以在昵称中未带有"TOH"字样的前提下把房间状态设置为公开。","無法公開此房間,因為你名字中沒有含有'TOH'"
+DisabledByProgram,"Making room public is disabled by program.","公開ルームはプログラムによって無効化されています"
 EnterVentToWin,Enter Vent to Win!!,ベントに入って勝利しろ!!,跳管道来获得胜利！,跳管道來獲得勝利!!
 FireworksPutPhase,Put {0} Fireworks,あと{0}個置け,还要安放{0}枚烟花,還需要安裝{0}枚煙火
 FireworksWaitPhase,Wait for time...,時を待て...,耐心等待....,等待時機...

--- a/main.cs
+++ b/main.cs
@@ -19,9 +19,9 @@ namespace TownOfHost
     {
         // == 定数設定 / Constant Config == <=名前募集中
         // modの名前 / Mod Name (Default: Town Of Host)
-        public static readonly string modName = "Town Of Host";
+        public static readonly string ModName = "Town Of Host";
         // modの色 / Mod Color (Default: #00bfff)
-        public static readonly string modColor = "#00bfff";
+        public static readonly string ModColor = "#00bfff";
         // 公開ルームを許可する / Allow Public Room (Default: true)
         public static readonly bool AllowPublicRoom = true;
         // ==========
@@ -122,7 +122,7 @@ namespace TownOfHost
 
             //Client Options
             HideName = Config.Bind("Client Options", "Hide Game Code Name", "Town Of Host");
-            HideColor = Config.Bind("Client Options", "Hide Game Code Color", $"{modColor}");
+            HideColor = Config.Bind("Client Options", "Hide Game Code Color", $"{ModColor}");
             ForceJapanese = Config.Bind("Client Options", "Force Japanese", false);
             JapaneseRoleName = Config.Bind("Client Options", "Japanese Role Name", true);
             Logger = BepInEx.Logging.Logger.CreateLogSource("TownOfHost");

--- a/main.cs
+++ b/main.cs
@@ -17,6 +17,11 @@ namespace TownOfHost
     [BepInProcess("Among Us.exe")]
     public class Main : BasePlugin
     {
+        // == 定数設定 / Constant Config ==
+        // 公開ルームを許可する / Allow Public Room (Default: true)
+        public const bool AllowPublicRoom = true;
+        // ==========
+
         //Sorry for many Japanese comments.
         public const string PluginGuid = "com.emptybottle.townofhost";
         public const string PluginVersion = "3.0.0";

--- a/main.cs
+++ b/main.cs
@@ -17,7 +17,7 @@ namespace TownOfHost
     [BepInProcess("Among Us.exe")]
     public class Main : BasePlugin
     {
-        // == 定数設定 / Constant Config == <=名前募集中
+        // == プログラム設定 / Program Config ==
         // modの名前 / Mod Name (Default: Town Of Host)
         public static readonly string ModName = "Town Of Host";
         // modの色 / Mod Color (Default: #00bfff)

--- a/main.cs
+++ b/main.cs
@@ -18,6 +18,8 @@ namespace TownOfHost
     public class Main : BasePlugin
     {
         // == 定数設定 / Constant Config == <=名前募集中
+        // modの名前 / Mod Name (Default: Town Of Host)
+        public static readonly string modName = "Town Of Host";
         // modの色 / Mod Color (Default: #00bfff)
         public static readonly string modColor = "#00bfff";
         // 公開ルームを許可する / Allow Public Room (Default: true)

--- a/main.cs
+++ b/main.cs
@@ -19,7 +19,7 @@ namespace TownOfHost
     {
         // == 定数設定 / Constant Config ==
         // 公開ルームを許可する / Allow Public Room (Default: true)
-        public const bool AllowPublicRoom = true;
+        public static readonly bool AllowPublicRoom = true;
         // ==========
 
         //Sorry for many Japanese comments.

--- a/main.cs
+++ b/main.cs
@@ -17,7 +17,7 @@ namespace TownOfHost
     [BepInProcess("Among Us.exe")]
     public class Main : BasePlugin
     {
-        // == 定数設定 / Constant Config ==
+        // == 定数設定 / Constant Config == <=名前募集中
         // 公開ルームを許可する / Allow Public Room (Default: true)
         public static readonly bool AllowPublicRoom = true;
         // ==========

--- a/main.cs
+++ b/main.cs
@@ -24,8 +24,10 @@ namespace TownOfHost
         public static readonly string ModColor = "#00bfff";
         // 公開ルームを許可する / Allow Public Room (Default: true)
         public static readonly bool AllowPublicRoom = true;
+        // フォークID / ForkId (Default: OriginalTOH)
+        public static readonly string ForkId = "OriginalTOH";
         // ==========
-
+        public const string OriginalForkId = "OriginalTOH";
         //Sorry for many Japanese comments.
         public const string PluginGuid = "com.emptybottle.townofhost";
         public const string PluginVersion = "3.0.0";

--- a/main.cs
+++ b/main.cs
@@ -27,7 +27,7 @@ namespace TownOfHost
         // フォークID / ForkId (Default: OriginalTOH)
         public static readonly string ForkId = "OriginalTOH";
         // ==========
-        public const string OriginalForkId = "OriginalTOH";
+        public const string OriginalForkId = "OriginalTOH"; // Don't Change The Value. / この値を変更しないでください。
         //Sorry for many Japanese comments.
         public const string PluginGuid = "com.emptybottle.townofhost";
         public const string PluginVersion = "3.0.0";

--- a/main.cs
+++ b/main.cs
@@ -18,6 +18,8 @@ namespace TownOfHost
     public class Main : BasePlugin
     {
         // == 定数設定 / Constant Config == <=名前募集中
+        // modの色 / Mod Color (Default: #00bfff)
+        public static readonly string modColor = "#00bfff";
         // 公開ルームを許可する / Allow Public Room (Default: true)
         public static readonly bool AllowPublicRoom = true;
         // ==========
@@ -57,8 +59,6 @@ namespace TownOfHost
         public static Dictionary<byte, Color32> PlayerColors = new();
         public static Dictionary<byte, PlayerState.DeathReason> AfterMeetingDeathPlayers = new();
         public static Dictionary<CustomRoles, String> roleColors;
-        //これ変えたらmod名とかの色が変わる
-        public static string modColor = "#00bfff";
         public static bool IsFixedCooldown => CustomRoles.Vampire.IsEnable();
         public static float RefixCooldownDelay = 0f;
         public static int BeforeFixMeetingCooldown = 10;


### PR DESCRIPTION
TOHをフォークする際に内部設定を簡単に変更できるようにしました。
# 設定
| 名前 | 役割 | 備考 |
| ---- | ---- | ---- |
| ModName | modの名前 | タイトルとPingTracerのmod名表示を変更できます |
| ModColor | modの色 | 旧変数`modColor`を移動・リネームしたものです |
| AllowPublicRoom | 公開ルームの許可 | 名前にTOHが含まれていない場合と同様の処理です |
| ForkId | フォーク固有のID | VersionCheckRPCで送受信され、バージョンが違った場合と似た表示になります |

# VersionCheckRpcの変更点
- 送信時にForkIdを添付するようになりました
- 送信元のメジャーバージョンが3以上の時のみ、ForkIdを読み取るようになりました

# 未実装の要素
- [x] AllowPublicRoomがオフの時のメッセージ
- [x] 肝心の設定の名前が決まっていない。名前募集中です。

# 画像
<details>
<summary>ForkIDが一致しないときの表示</summary>

![TOH-GM](https://user-images.githubusercontent.com/51523918/186449159-8d3df654-45ba-4736-afd4-a1501bd66474.png)
</details>