### PR TITLE
OptionShowerとチャットコマンドでChildrenを自動で追加

### DIFF
--- a/Modules/OptionShower.cs
+++ b/Modules/OptionShower.cs
@@ -61,6 +61,16 @@ namespace TownOfHost
                     {
                         if (c.Name == "Maximum") continue; //Maximumの項目は飛ばす
                         text += $"\t{c.GetName()}: {c.GetString()}\n";
+                        if (c.GetBool() && c.Children != null)
+                            foreach (var d in c.Children)
+                            {
+                                text += $"\t\t{d.GetName()}: {d.GetString()}\n"; //子
+                                if (d.GetBool() && d.Children != null)
+                                    foreach (var e in d.Children)
+                                    {
+                                        text += $"\t\t\t{e.GetName()}: {e.GetString()}\n"; //孫？
+                                    }
+                            }
                     }
                     if (kvp.Key.IsMadmate()) //マッドメイトの時に追加する詳細設定
                     {
@@ -73,10 +83,6 @@ namespace TownOfHost
                     if (kvp.Key is CustomRoles.Shapeshifter/* or CustomRoles.ShapeMaster*/ or CustomRoles.BountyHunter or CustomRoles.SerialKiller) //シェイプシフター役職の時に追加する詳細設定
                     {
                         text += $"\t{Options.CanMakeMadmateCount.GetName()}: {Options.CanMakeMadmateCount.GetString()}\n";
-                    }
-                    if (kvp.Key == CustomRoles.Mayor && Options.MayorHasPortableButton.GetBool())
-                    {
-                        text += $"\t{Options.MayorNumOfUseButton.GetName()}: {Options.MayorNumOfUseButton.GetString()}\n";
                     }
                     text += "\n";
                 }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -329,25 +329,19 @@ namespace TownOfHost
                     {
                         if (isFirst) { isFirst = false; continue; }
                         text += $"\n{c.GetName(disableColor: true)}:{c.GetString()}";
-
-                        //タスク上書き設定用の処理
-                        if (c.Name == "doOverride" && c.GetBool() == true)
-                        {
+                        if (c.Children != null && c.GetBool())
                             foreach (var d in c.Children)
                             {
-                                text += $"\n{d.GetName(disableColor: true)}:{d.GetString()}";
+                                text += $"\n└{d.GetName(disableColor: true)}:{d.GetString()}";
+                                if (d.Children != null && d.GetBool())
+                                    foreach (var e in d.Children)
+                                    {
+                                        text += $"\n　└{e.GetName(disableColor: true)}:{e.GetString()}";
+                                    }
                             }
-                        }
-                        //メイヤーのポータブルボタン使用可能回数
-                        if (c.Name == "MayorHasPortableButton" && c.GetBool() == true)
-                        {
-                            foreach (var d in c.Children)
-                            {
-                                text += $"\n{d.GetName(disableColor: true)}:{d.GetString()}";
-                            }
-                        }
                         text = text.RemoveHtmlTags();
                     }
+                    text += "\n";
                 }
                 if (Options.EnableLastImpostor.GetBool()) text += String.Format("\n{0}:{1}", GetString("LastImpostorKillCooldown"), Options.LastImpostorKillCooldown.GetString());
                 if (Options.DisableDevices.GetBool())


### PR DESCRIPTION
・オプションに子があるかで判断し、あればすぐ下に子のオプションをインデントまたは└を入れて表示
・↑によりタスク上書きとメイヤーボタン数の個別表示追加を削除
・チャットコマンドは役職ごとに間に改行追加
・子の更に子(孫?)まで対応