### PR TITLE
死人のタスクを無効化するオプションを追加

### DIFF
--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -182,6 +182,7 @@ namespace TownOfHost
         public static CustomOption ColorNameMode;
         public static CustomOption GhostCanSeeOtherRoles;
         public static CustomOption GhostCanSeeOtherVotes;
+        public static CustomOption GhostIgnoreTasks;
         public static CustomOption HideGameSettings;
         public static readonly string[] suffixModes =
         {
@@ -457,6 +458,8 @@ namespace TownOfHost
             GhostCanSeeOtherRoles = CustomOption.Create(100603, Color.white, "GhostCanSeeOtherRoles", true)
                 .SetGameMode(CustomGameMode.All);
             GhostCanSeeOtherVotes = CustomOption.Create(100604, Color.white, "GhostCanSeeOtherVotes", true)
+                .SetGameMode(CustomGameMode.All);
+            GhostIgnoreTasks = CustomOption.Create(100607, Color.white, "GhostIgnoreTasks", false)
                 .SetGameMode(CustomGameMode.All);
             HideGameSettings = CustomOption.Create(100606, Color.white, "HideGameSettings", false)
                 .SetGameMode(CustomGameMode.All);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -178,6 +178,7 @@ namespace TownOfHost
             }
             else
             {
+                if (p.IsDead && Options.GhostIgnoreTasks.GetBool()) hasTasks = false;
                 var cRoleFound = Main.AllPlayerCustomRoles.TryGetValue(p.PlayerId, out var cRole);
                 if (cRoleFound)
                 {

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -233,6 +233,7 @@ SuffixMode.Recording,Recording,録画中,录制中,錄影中
 ColorNameMode,Color Name Mode,色名前モード,显示颜色名称,名字將被顏色名稱替換
 GhostCanSeeOtherRoles,Ghost Can See Other Roles,幽霊が他人の役職を見ることができる,幽灵可见他人职业,幽靈可以看見所有玩家職業
 GhostCanSeeOtherVotes,Ghost Can See Other Votes,幽霊が他人の投票先を見ることができる,幽灵可见投票情况,幽靈可以看見所有玩家的投票
+GhostIgnoreTasks,Ghost Ignore Tasks,死人のタスクを免除する,,
 HideGameSettings,Hide Game Settings,ゲーム設定を隠す,隐藏游戏设置,隱藏遊戲設定
 RoleOptions,Role Options,役職設定,职业设置,職業設定
 ModeOptions,Mode Options,モード設定,模组设置,模式設定


### PR DESCRIPTION
死人のタスクを無効化するオプションを追加。
StandardHASに実装するつもりだったが、限定するメリットもないので共用にした。