### PR TITLE
推奨設定を調整

### DIFF
--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -291,10 +291,10 @@ namespace TownOfHost
             __instance.PlayerSpeedMod = __instance.MapId == 4 ? 1.25f : 1f; //AirShipなら1.25、それ以外は1
             __instance.CrewLightMod = 0.5f;
             __instance.ImpostorLightMod = 1.75f;
-            __instance.KillCooldown = GameOptionsData.RecommendedKillCooldown[numPlayers];
+            __instance.KillCooldown = 25f;
             __instance.NumCommonTasks = 2;
-            __instance.NumLongTasks = 3;
-            __instance.NumShortTasks = 5;
+            __instance.NumLongTasks = 4;
+            __instance.NumShortTasks = 6;
             __instance.NumEmergencyMeetings = 1;
             if (modes != GameModes.OnlineGame)
                 __instance.NumImpostors = GameOptionsData.RecommendedImpostors[numPlayers];
@@ -304,7 +304,6 @@ namespace TownOfHost
             __instance.isDefaults = true;
             __instance.ConfirmImpostor = false;
             __instance.VisualTasks = false;
-            __instance.EmergencyCooldown = (int)__instance.killCooldown - 5; //キルクールより5秒短く
             __instance.RoleOptions.ShapeshifterCooldown = 10f;
             __instance.RoleOptions.ShapeshifterDuration = 30f;
             __instance.RoleOptions.ShapeshifterLeaveSkin = false;
@@ -329,8 +328,8 @@ namespace TownOfHost
             if (Options.IsStandardHAS) //StandardHAS
             {
                 __instance.PlayerSpeedMod = 1.75f;
-                __instance.CrewLightMod = 1f;
-                __instance.ImpostorLightMod = 1f;
+                __instance.CrewLightMod = 5f;
+                __instance.ImpostorLightMod = 0.25f;
                 __instance.NumImpostors = 1;
                 __instance.NumCommonTasks = 0;
                 __instance.NumLongTasks = 0;


### PR DESCRIPTION
推奨設定を調整
- ボタンクールダウンを対象外に
- キルクールダウンを25秒で固定
- タスクを2:4:6に変更
- StandardHASの視界をHideAndSeekと同一に修正