### PR TITLE
Feature/task text color

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -258,7 +258,7 @@ namespace TownOfHost
                     {
                         var pc = GetPlayerById(playerId);
                         var afterFinishingcolor = HasTasks(pc.Data) ? Color.green : Color.red; //タスク完了後の色
-                        var beforeFinishingcolor = HasTasks(pc.Data) ? Color.green : Color.red; //カウントされない人外は白色
+                        var beforeFinishingcolor = HasTasks(pc.Data) ? Color.yellow : Color.white; //カウントされない人外は白色
                         Color color = taskState.IsTaskFinished && !comms ? afterFinishingcolor : beforeFinishingcolor;
                         string Completed = comms ? "?" : $"{taskState.CompletedTasksCount}";
                         ProgressText = Helpers.ColorString(color, $"({Completed}/{taskState.AllTasksCount})");

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -259,7 +259,8 @@ namespace TownOfHost
                         var pc = GetPlayerById(playerId);
                         var afterFinishingcolor = HasTasks(pc.Data) ? Color.green : Color.red; //タスク完了後の色
                         var beforeFinishingcolor = HasTasks(pc.Data) ? Color.yellow : Color.white; //カウントされない人外は白色
-                        Color color = taskState.IsTaskFinished && !comms ? afterFinishingcolor : beforeFinishingcolor;
+                        var nonCommsColor = taskState.IsTaskFinished ? afterFinishingcolor : beforeFinishingcolor;
+                        Color color = comms ? Color.gray : nonCommsColor;
                         string Completed = comms ? "?" : $"{taskState.CompletedTasksCount}";
                         ProgressText = Helpers.ColorString(color, $"({Completed}/{taskState.AllTasksCount})");
                     }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -256,8 +256,11 @@ namespace TownOfHost
                     var taskState = PlayerState.taskState?[playerId];
                     if (taskState.hasTasks)
                     {
+                        var pc = GetPlayerById(playerId);
+                        Color color = taskState.IsTaskFinished && !comms ? (role.IsCrewmate() ? Color.green : Color.red) //タスク完了後の色
+                                                                        : (HasTasks(pc.Data) ? Color.yellow : Color.white); //カウントされない人外は白色
                         string Completed = comms ? "?" : $"{taskState.CompletedTasksCount}";
-                        ProgressText = Helpers.ColorString(Color.yellow, $"({Completed}/{taskState.AllTasksCount})");
+                        ProgressText = Helpers.ColorString(color, $"({Completed}/{taskState.AllTasksCount})");
                     }
                     break;
             }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -257,8 +257,9 @@ namespace TownOfHost
                     if (taskState.hasTasks)
                     {
                         var pc = GetPlayerById(playerId);
-                        Color color = taskState.IsTaskFinished && !comms ? (HasTasks(pc.Data) ? Color.green : Color.red) //タスク完了後の色
-                                                                        : (HasTasks(pc.Data) ? Color.yellow : Color.white); //カウントされない人外は白色
+                        var afterFinishingcolor = HasTasks(pc.Data) ? Color.green : Color.red; //タスク完了後の色
+                        var beforeFinishingcolor = HasTasks(pc.Data) ? Color.green : Color.red; //カウントされない人外は白色
+                        Color color = taskState.IsTaskFinished && !comms ? afterFinishingcolor : beforeFinishingcolor;
                         string Completed = comms ? "?" : $"{taskState.CompletedTasksCount}";
                         ProgressText = Helpers.ColorString(color, $"({Completed}/{taskState.AllTasksCount})");
                     }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -257,7 +257,7 @@ namespace TownOfHost
                     if (taskState.hasTasks)
                     {
                         var pc = GetPlayerById(playerId);
-                        Color color = taskState.IsTaskFinished && !comms ? (role.IsCrewmate() ? Color.green : Color.red) //タスク完了後の色
+                        Color color = taskState.IsTaskFinished && !comms ? (HasTasks(pc.Data) ? Color.green : Color.red) //タスク完了後の色
                                                                         : (HasTasks(pc.Data) ? Color.yellow : Color.white); //カウントされない人外は白色
                         string Completed = comms ? "?" : $"{taskState.CompletedTasksCount}";
                         ProgressText = Helpers.ColorString(color, $"({Completed}/{taskState.AllTasksCount})");


### PR DESCRIPTION
役職名横のタスク進捗の色を変更
タスクカウントされるプレイヤー：黄色→緑（完了後）
それ以外（マッド、テロリストなど）：白→赤（完了後）
コミュサボ中：灰色