### PR TITLE
エゴイスト、ジャッカルのスニッチマーク修正

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -675,6 +675,8 @@ namespace TownOfHost
                     || seer.Is(CustomRoles.Executioner)
                     || seer.Is(CustomRoles.Doctor) //seerがドクター
                     || seer.Is(CustomRoles.Puppeteer)
+                    || seer.Is(CustomRoles.Egoist) //seerがエゴイスト
+                    || seer.Is(CustomRoles.Jackal) //seerがジャッカル
                     || IsActive(SystemTypes.Electrical)
                     || NoCache
                     || ForceLoop

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -309,6 +309,13 @@ namespace TownOfHost
                         if (Main.ExecutionerTarget.TryGetValue(seer.PlayerId, out var targetId) && target.PlayerId == targetId) //targetがValue
                             pva.NameText.text += Helpers.ColorString(Utils.GetRoleColor(CustomRoles.Executioner), "♦");
                         break;
+                    case CustomRoles.Egoist:
+                    case CustomRoles.Jackal:
+                        if (Options.SnitchCanFindNeutralKiller.GetBool() &&
+                        target.Is(CustomRoles.Snitch) && //変更対象がSnitch
+                        target.GetPlayerTaskState().DoExpose) //変更対象のタスクが終わりそう)
+                            pva.NameText.text += Helpers.ColorString(Utils.GetRoleColor(CustomRoles.Snitch), "★"); //変更対象にSnitchマークをつける
+                        break;
                 }
 
                 switch (target.GetCustomRole())

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -876,8 +876,8 @@ namespace TownOfHost
 
                     }
                     //タスクが終わりそうなSnitchがいるとき、インポスター/キル可能な第三陣営に警告が表示される
-                    if ((!GameStates.IsMeeting && target.GetCustomRole().IsImpostor())
-                        || (Options.SnitchCanFindNeutralKiller.GetBool() && target.IsNeutralKiller()))
+                    if (!GameStates.IsMeeting && (target.GetCustomRole().IsImpostor()
+                        || (Options.SnitchCanFindNeutralKiller.GetBool() && target.IsNeutralKiller())))
                     { //targetがインポスターかつ自分自身
                         var found = false;
                         var update = false;


### PR DESCRIPTION
・Utils.NotifyRoles
　エゴイスト、ジャッカルに第二ループを適用
　（ゲーム中スニッチ★マーク）
・FixedUpdatePatch.Postfix
　Snitch表記処理でのIsMeeting判定誤り修正
　（会議中スニッチ矢印非表示）
・MeetingHudStartPatch.Postfix
　会議後スニッチ表記処理をインポスターに合わせる