### PR TITLE
エゴイスト、ジャッカルのスニッチマーク修正 ※修正分

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -675,8 +675,7 @@ namespace TownOfHost
                     || seer.Is(CustomRoles.Executioner)
                     || seer.Is(CustomRoles.Doctor) //seerがドクター
                     || seer.Is(CustomRoles.Puppeteer)
-                    || seer.Is(CustomRoles.Egoist) //seerがエゴイスト
-                    || seer.Is(CustomRoles.Jackal) //seerがジャッカル
+                    || seer.IsNeutralKiller() //seerがキル出来る第三陣営
                     || IsActive(SystemTypes.Electrical)
                     || NoCache
                     || ForceLoop


### PR DESCRIPTION
・Utils.NotifyRoles
　第二ループを適用条件を
　　エゴイスト、ジャッカル⇒キルできる第三陣営
　に変更