### PR TITLE
Refact/CustomWinner

### DIFF
--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -13,13 +13,13 @@ namespace TownOfHost
         public static CustomWinner WinnerTeam;
         // 追加勝利するプレイヤーのチームが格納されます。
         // リザルトの表示に使用されます。
-        public static List<CustomWinner> AdditionalWinnerTeams;
+        public static HashSet<CustomWinner> AdditionalWinnerTeams;
         // 勝者の役職が格納され、この変数に格納されている役職のプレイヤーは全員勝利となります。
         // チームとなる第三陣営の処理に最適です。
-        public static List<CustomRoles> WinnerRoles;
+        public static HashSet<CustomRoles> WinnerRoles;
         // 勝者のPlayerIDが格納され、このIDを持つプレイヤーは全員勝利します。
         // 単独勝利する第三陣営の処理に最適です。
-        public static List<byte> WinnerIds;
+        public static HashSet<byte> WinnerIds;
 
         public static void Reset()
         {

--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -16,5 +16,12 @@ namespace TownOfHost
         // 勝者のPlayerIDが格納され、このIDを持つプレイヤーは全員勝利します。
         // 単独勝利する第三陣営の処理に最適です。
         public static List<byte> WinnerIds;
+
+        public static void Reset()
+        {
+            WinnerTeam = CustomWinner.Default;
+            WinnerRoles = new();
+            WinnerIds = new();
+        }
     }
 }

--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using InnerNet;
+
+namespace TownOfHost
+{
+    public static class CustomWinnerHolder
+    {
+        // 勝者のチームが格納されます。
+        // リザルトの背景色の決定などに使用されます。
+        public static CustomWinner WinnerTeam;
+        // 勝者の役職が格納され、この変数に格納されている役職のプレイヤーは全員勝利となります。
+        // チームとなる第三陣営の処理に最適です。
+        public static CustomRoles WinnerRoles;
+        // 勝者のPlayerIDが格納され、このIDを持つプレイヤーは全員勝利します。
+        // 単独勝利する第三陣営の処理に最適です。
+        public static List<byte> WinnerIds;
+    }
+}

--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -11,6 +11,9 @@ namespace TownOfHost
         // 勝者のチームが格納されます。
         // リザルトの背景色の決定などに使用されます。
         public static CustomWinner WinnerTeam;
+        // 追加勝利するプレイヤーのチームが格納されます。
+        // リザルトの表示に使用されます。
+        public static List<CustomWinner> AdditionalWinnerTeams;
         // 勝者の役職が格納され、この変数に格納されている役職のプレイヤーは全員勝利となります。
         // チームとなる第三陣営の処理に最適です。
         public static List<CustomRoles> WinnerRoles;
@@ -21,6 +24,7 @@ namespace TownOfHost
         public static void Reset()
         {
             WinnerTeam = CustomWinner.Default;
+            AdditionalWinnerTeams = new();
             WinnerRoles = new();
             WinnerIds = new();
         }
@@ -28,6 +32,10 @@ namespace TownOfHost
         public static MessageWriter WriteTo(MessageWriter writer)
         {
             writer.Write((int)WinnerTeam);
+
+            writer.Write(AdditionalWinnerTeams.Count);
+            foreach (var wt in AdditionalWinnerTeams)
+                writer.Write((int)wt);
 
             writer.Write(WinnerRoles.Count);
             foreach (var wr in WinnerRoles)
@@ -42,6 +50,11 @@ namespace TownOfHost
         public static void ReadFrom(MessageReader reader)
         {
             WinnerTeam = (CustomWinner)reader.ReadInt32();
+
+            AdditionalWinnerTeams = new();
+            int AdditionalWinnerTeamsCount = reader.ReadInt32();
+            for (int i = 0; i < AdditionalWinnerTeamsCount; i++)
+                AdditionalWinnerTeams.Add((CustomWinner)reader.ReadInt32());
 
             WinnerRoles = new();
             int WinnerRolesCount = reader.ReadInt32();

--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -13,7 +13,7 @@ namespace TownOfHost
         public static CustomWinner WinnerTeam;
         // 追加勝利するプレイヤーのチームが格納されます。
         // リザルトの表示に使用されます。
-        public static HashSet<CustomWinner> AdditionalWinnerTeams;
+        public static HashSet<AdditionalWinners> AdditionalWinnerTeams;
         // 勝者の役職が格納され、この変数に格納されている役職のプレイヤーは全員勝利となります。
         // チームとなる第三陣営の処理に最適です。
         public static HashSet<CustomRoles> WinnerRoles;
@@ -54,7 +54,7 @@ namespace TownOfHost
             AdditionalWinnerTeams = new();
             int AdditionalWinnerTeamsCount = reader.ReadInt32();
             for (int i = 0; i < AdditionalWinnerTeamsCount; i++)
-                AdditionalWinnerTeams.Add((CustomWinner)reader.ReadInt32());
+                AdditionalWinnerTeams.Add((AdditionalWinners)reader.ReadInt32());
 
             WinnerRoles = new();
             int WinnerRolesCount = reader.ReadInt32();

--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using InnerNet;
+using Hazel;
 
 namespace TownOfHost
 {
@@ -22,6 +23,35 @@ namespace TownOfHost
             WinnerTeam = CustomWinner.Default;
             WinnerRoles = new();
             WinnerIds = new();
+        }
+
+        public static MessageWriter WriteTo(MessageWriter writer)
+        {
+            writer.Write((int)WinnerTeam);
+
+            writer.Write(WinnerRoles.Count);
+            foreach (var wr in WinnerRoles)
+                writer.Write((int)wr);
+
+            writer.Write(WinnerIds.Count);
+            foreach (var id in WinnerIds)
+                writer.Write(id);
+
+            return writer;
+        }
+        public static void ReadFrom(MessageReader reader)
+        {
+            WinnerTeam = (CustomWinner)reader.ReadInt32();
+
+            WinnerRoles = new();
+            int WinnerRolesCount = reader.ReadInt32();
+            for (int i = 0; i < WinnerRolesCount; i++)
+                WinnerRoles.Add((CustomRoles)reader.ReadInt32());
+
+            WinnerIds = new();
+            int WinnerIdsCount = reader.ReadInt32();
+            for (int i = 0; i < WinnerIdsCount; i++)
+                WinnerIds.Add(reader.ReadByte());
         }
     }
 }

--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -12,7 +12,7 @@ namespace TownOfHost
         public static CustomWinner WinnerTeam;
         // 勝者の役職が格納され、この変数に格納されている役職のプレイヤーは全員勝利となります。
         // チームとなる第三陣営の処理に最適です。
-        public static CustomRoles WinnerRoles;
+        public static List<CustomRoles> WinnerRoles;
         // 勝者のPlayerIDが格納され、このIDを持つプレイヤーは全員勝利します。
         // 単独勝利する第三陣営の処理に最適です。
         public static List<byte> WinnerIds;

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -335,28 +335,6 @@ namespace TownOfHost
             writer.Write(targetId);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
-        public static void CustomWinTrigger(byte winnerID)
-        {
-            List<PlayerControl> Impostors = new();
-            foreach (var p in PlayerControl.AllPlayerControls)
-            {
-                PlayerControl Winner = null;
-                if (p.PlayerId == winnerID) Winner = p;
-                if (p.Data.Role.IsImpostor)
-                {
-                    Impostors.Add(p);
-                }
-            }
-            if (AmongUsClient.Instance.AmHost)
-            {
-                foreach (var imp in Impostors)
-                {
-                    imp.RpcSetRole(RoleTypes.GuardianAngel);
-                }
-                new LateTask(() => Main.CustomWinTrigger = true,
-                0.2f, "Custom Win Trigger Task");
-            }
-        }
         public static void SendRpcLogger(uint targetNetId, byte callId, int targetClientId = -1)
         {
             if (!Main.AmDebugger.Value) return;

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -253,95 +253,11 @@ namespace TownOfHost
         {
             try
             {
-                List<byte> winner = new();
-                CustomWinnerHolder.WinnerTeam = (CustomWinner)reader.ReadInt32();
-                while (reader.BytesRemaining > 0) winner.Add(reader.ReadByte());
-                switch (CustomWinnerHolder.WinnerTeam)
-                {
-                    case CustomWinner.Draw:
-                        ForceEndGame();
-                        break;
-                    case CustomWinner.None:
-                        EveryoneDied();
-                        break;
-                    case CustomWinner.Jester:
-                        JesterExiled(winner[0]);
-                        break;
-                    case CustomWinner.Terrorist:
-                        TerroristWin(winner[0]);
-                        break;
-                    case CustomWinner.Executioner:
-                        ExecutionerWin(winner[0]);
-                        break;
-                    case CustomWinner.Arsonist:
-                        ArsonistWin(winner[0]);
-                        break;
-                    case CustomWinner.HASTroll:
-                        TrollWin(winner[0]);
-                        break;
-                    case CustomWinner.Jackal:
-                        JackalWin();
-                        break;
-
-                    default:
-                        if (CustomWinnerHolder.WinnerTeam != CustomWinner.Default)
-                            Logger.Warn($"{CustomWinnerHolder.WinnerTeam}は無効なCustomWinnerです", "EndGame");
-                        break;
-                }
+                CustomWinnerHolder.ReadFrom(reader);
             }
             catch (Exception ex)
             {
                 Logger.Error($"正常にEndGameを行えませんでした。{ex}", "EndGame");
-            }
-        }
-        public static void TrollWin(byte trollID)
-        {
-            Main.WonTrollID = trollID;
-            CustomWinnerHolder.WinnerTeam = CustomWinner.HASTroll;
-            CustomWinTrigger(trollID);
-        }
-        public static void JesterExiled(byte jesterID)
-        {
-            Main.ExiledJesterID = jesterID;
-            CustomWinnerHolder.WinnerTeam = CustomWinner.Jester;
-            CustomWinTrigger(jesterID);
-        }
-        public static void TerroristWin(byte terroristID)
-        {
-            Main.WonTerroristID = terroristID;
-            CustomWinnerHolder.WinnerTeam = CustomWinner.Terrorist;
-            CustomWinTrigger(terroristID);
-        }
-        public static void ExecutionerWin(byte executionerID)
-        {
-            Main.WonExecutionerID = executionerID;
-            CustomWinnerHolder.WinnerTeam = CustomWinner.Executioner;
-            CustomWinTrigger(executionerID);
-        }
-        public static void ArsonistWin(byte arsonistID)
-        {
-            Main.WonArsonistID = arsonistID;
-            CustomWinnerHolder.WinnerTeam = CustomWinner.Arsonist;
-            CustomWinTrigger(arsonistID);
-        }
-        public static void JackalWin()
-        {
-            CustomWinnerHolder.WinnerTeam = CustomWinner.Jackal;
-            CustomWinTrigger(0);
-        }
-        public static void EveryoneDied()
-        {
-            CustomWinnerHolder.WinnerTeam = CustomWinner.None;
-            CustomWinTrigger(0);
-        }
-        public static void ForceEndGame()
-        {
-            if (ShipStatus.Instance == null) return;
-            CustomWinnerHolder.WinnerTeam = CustomWinner.Draw;
-            if (AmongUsClient.Instance.AmHost)
-            {
-                ShipStatus.Instance.enabled = false;
-                ShipStatus.RpcEndGame(GameOverReason.ImpostorByKill, false);
             }
         }
         public static void PlaySound(byte playerID, Sounds sound)

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -253,10 +253,12 @@ namespace TownOfHost
         {
             try
             {
+                Logger.SendInGame("EndGame受信");
                 CustomWinnerHolder.ReadFrom(reader);
             }
             catch (Exception ex)
             {
+                Logger.SendInGame($"正常にEndGameを行えませんでした。{ex}");
                 Logger.Error($"正常にEndGameを行えませんでした。{ex}", "EndGame");
             }
         }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -254,9 +254,9 @@ namespace TownOfHost
             try
             {
                 List<byte> winner = new();
-                Main.currentWinner = (CustomWinner)reader.ReadInt32();
+                CustomWinnerHolder.WinnerTeam = (CustomWinner)reader.ReadInt32();
                 while (reader.BytesRemaining > 0) winner.Add(reader.ReadByte());
-                switch (Main.currentWinner)
+                switch (CustomWinnerHolder.WinnerTeam)
                 {
                     case CustomWinner.Draw:
                         ForceEndGame();
@@ -284,8 +284,8 @@ namespace TownOfHost
                         break;
 
                     default:
-                        if (Main.currentWinner != CustomWinner.Default)
-                            Logger.Warn($"{Main.currentWinner}は無効なCustomWinnerです", "EndGame");
+                        if (CustomWinnerHolder.WinnerTeam != CustomWinner.Default)
+                            Logger.Warn($"{CustomWinnerHolder.WinnerTeam}は無効なCustomWinnerです", "EndGame");
                         break;
                 }
             }
@@ -297,47 +297,47 @@ namespace TownOfHost
         public static void TrollWin(byte trollID)
         {
             Main.WonTrollID = trollID;
-            Main.currentWinner = CustomWinner.HASTroll;
+            CustomWinnerHolder.WinnerTeam = CustomWinner.HASTroll;
             CustomWinTrigger(trollID);
         }
         public static void JesterExiled(byte jesterID)
         {
             Main.ExiledJesterID = jesterID;
-            Main.currentWinner = CustomWinner.Jester;
+            CustomWinnerHolder.WinnerTeam = CustomWinner.Jester;
             CustomWinTrigger(jesterID);
         }
         public static void TerroristWin(byte terroristID)
         {
             Main.WonTerroristID = terroristID;
-            Main.currentWinner = CustomWinner.Terrorist;
+            CustomWinnerHolder.WinnerTeam = CustomWinner.Terrorist;
             CustomWinTrigger(terroristID);
         }
         public static void ExecutionerWin(byte executionerID)
         {
             Main.WonExecutionerID = executionerID;
-            Main.currentWinner = CustomWinner.Executioner;
+            CustomWinnerHolder.WinnerTeam = CustomWinner.Executioner;
             CustomWinTrigger(executionerID);
         }
         public static void ArsonistWin(byte arsonistID)
         {
             Main.WonArsonistID = arsonistID;
-            Main.currentWinner = CustomWinner.Arsonist;
+            CustomWinnerHolder.WinnerTeam = CustomWinner.Arsonist;
             CustomWinTrigger(arsonistID);
         }
         public static void JackalWin()
         {
-            Main.currentWinner = CustomWinner.Jackal;
+            CustomWinnerHolder.WinnerTeam = CustomWinner.Jackal;
             CustomWinTrigger(0);
         }
         public static void EveryoneDied()
         {
-            Main.currentWinner = CustomWinner.None;
+            CustomWinnerHolder.WinnerTeam = CustomWinner.None;
             CustomWinTrigger(0);
         }
         public static void ForceEndGame()
         {
             if (ShipStatus.Instance == null) return;
-            Main.currentWinner = CustomWinner.Draw;
+            CustomWinnerHolder.WinnerTeam = CustomWinner.Draw;
             if (AmongUsClient.Instance.AmHost)
             {
                 ShipStatus.Instance.enabled = false;

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -253,12 +253,10 @@ namespace TownOfHost
         {
             try
             {
-                Logger.SendInGame("EndGame受信");
                 CustomWinnerHolder.ReadFrom(reader);
             }
             catch (Exception ex)
             {
-                Logger.SendInGame($"正常にEndGameを行えませんでした。{ex}");
                 Logger.Error($"正常にEndGameを行えませんでした。{ex}", "EndGame");
             }
         }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -464,11 +464,8 @@ namespace TownOfHost
                         PlayerState.SetDead(pc.PlayerId);
                     }
                 }
-                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
-                writer.Write((byte)CustomWinner.Terrorist);
-                writer.Write(Terrorist.PlayerId);
-                AmongUsClient.Instance.FinishRpcImmediately(writer);
-                RPC.TerroristWin(Terrorist.PlayerId);
+                CustomWinnerHolder.WinnerTeam = CustomWinner.Terrorist;
+                CustomWinnerHolder.WinnerIds.Add(Terrorist.PlayerId);
             }
         }
         public static void SendMessage(string text, byte sendTo = byte.MaxValue)

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -84,10 +84,7 @@ namespace TownOfHost
             if (statistics.TotalAlive <= 0)
             {
                 __instance.enabled = false;
-                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
-                writer.Write((int)CustomWinner.None);
-                AmongUsClient.Instance.FinishRpcImmediately(writer);
-                RPC.EveryoneDied();
+                CustomWinnerHolder.WinnerTeam = CustomWinner.None;
                 ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
                 return true;
             }
@@ -125,10 +122,8 @@ namespace TownOfHost
                     _ => GameOverReason.ImpostorByVote,
                 };
 
-                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
-                writer.Write((byte)CustomWinner.Jackal);
-                AmongUsClient.Instance.FinishRpcImmediately(writer);
-                RPC.JackalWin();
+                CustomWinnerHolder.WinnerTeam = CustomWinner.Jackal;
+                CustomWinnerHolder.WinnerRoles.Add(CustomRoles.Jackal);
 
                 ResetRoleAndEndGame(endReason, false);
                 return true;

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -14,10 +14,7 @@ namespace TownOfHost
             var statistics = new PlayerStatistics(__instance);
             if (Options.NoGameEnd.GetBool()) return false;
 
-            if (CheckAndEndGameForJester(__instance)) return false;
-            if (CheckAndEndGameForTerrorist(__instance)) return false;
-            if (CheckAndEndGameForExecutioner(__instance)) return false;
-            if (CheckAndEndGameForArsonist(__instance)) return false;
+            if (CheckAndEndGameForSoloWin(__instance)) return false;
             if (CustomWinnerHolder.WinnerTeam == CustomWinner.Default)
             {
                 if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
@@ -179,39 +176,9 @@ namespace TownOfHost
             return false;
         }
 
-        private static bool CheckAndEndGameForJester(ShipStatus __instance)
+        private static bool CheckAndEndGameForSoloWin(ShipStatus __instance)
         {
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Jester && Main.CustomWinTrigger)
-            {
-                __instance.enabled = false;
-                ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
-                return true;
-            }
-            return false;
-        }
-        private static bool CheckAndEndGameForTerrorist(ShipStatus __instance)
-        {
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Terrorist && Main.CustomWinTrigger)
-            {
-                __instance.enabled = false;
-                ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
-                return true;
-            }
-            return false;
-        }
-        private static bool CheckAndEndGameForExecutioner(ShipStatus __instance)
-        {
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Executioner && Main.CustomWinTrigger)
-            {
-                __instance.enabled = false;
-                ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
-                return true;
-            }
-            return false;
-        }
-        private static bool CheckAndEndGameForArsonist(ShipStatus __instance)
-        {
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Arsonist && Main.CustomWinTrigger)
+            if (CustomWinnerHolder.WinnerTeam != CustomWinner.Default)
             {
                 __instance.enabled = false;
                 ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -229,6 +229,8 @@ namespace TownOfHost
                     writer.Write(showAd);
                 }
                 writer.EndMessage();
+
+                AmongUsClient.Instance.SendOrDisconnect(writer);
             }, 0.5f, "EndGameTask");
         }
         private static void SetImpostorsToGA()

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -85,6 +85,7 @@ namespace TownOfHost
             {
                 __instance.enabled = false;
                 CustomWinnerHolder.WinnerTeam = CustomWinner.None;
+                SetImpostorsToGA();
                 ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
                 return true;
             }
@@ -124,7 +125,7 @@ namespace TownOfHost
 
                 CustomWinnerHolder.WinnerTeam = CustomWinner.Jackal;
                 CustomWinnerHolder.WinnerRoles.Add(CustomRoles.Jackal);
-
+                SetImpostorsToGA();
                 ResetRoleAndEndGame(endReason, false);
                 return true;
             }
@@ -163,6 +164,7 @@ namespace TownOfHost
                 {
                     CustomWinnerHolder.WinnerTeam = CustomWinner.HASTroll;
                     CustomWinnerHolder.WinnerIds.Add(pc.PlayerId);
+                    SetImpostorsToGA();
                     __instance.enabled = false;
                     ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
                     return true;
@@ -177,6 +179,7 @@ namespace TownOfHost
             {
                 __instance.enabled = false;
                 ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
+                SetImpostorsToGA();
                 return true;
             }
             return false;
@@ -227,6 +230,13 @@ namespace TownOfHost
                 }
                 writer.EndMessage();
             }, 0.5f, "EndGameTask");
+        }
+        private static void SetImpostorsToGA()
+        {
+            foreach (var pc in PlayerControl.AllPlayerControls)
+            {
+                if (pc.Data.Role.IsImpostor) pc.RpcSetRole(RoleTypes.GuardianAngel);
+            }
         }
         //プレイヤー統計
         internal class PlayerStatistics

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -18,7 +18,7 @@ namespace TownOfHost
             if (CheckAndEndGameForTerrorist(__instance)) return false;
             if (CheckAndEndGameForExecutioner(__instance)) return false;
             if (CheckAndEndGameForArsonist(__instance)) return false;
-            if (Main.currentWinner == CustomWinner.Default)
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Default)
             {
                 if (Options.CurrentGameMode == CustomGameMode.HideAndSeek)
                 {
@@ -184,7 +184,7 @@ namespace TownOfHost
 
         private static bool CheckAndEndGameForJester(ShipStatus __instance)
         {
-            if (Main.currentWinner == CustomWinner.Jester && Main.CustomWinTrigger)
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Jester && Main.CustomWinTrigger)
             {
                 __instance.enabled = false;
                 ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
@@ -194,7 +194,7 @@ namespace TownOfHost
         }
         private static bool CheckAndEndGameForTerrorist(ShipStatus __instance)
         {
-            if (Main.currentWinner == CustomWinner.Terrorist && Main.CustomWinTrigger)
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Terrorist && Main.CustomWinTrigger)
             {
                 __instance.enabled = false;
                 ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
@@ -204,7 +204,7 @@ namespace TownOfHost
         }
         private static bool CheckAndEndGameForExecutioner(ShipStatus __instance)
         {
-            if (Main.currentWinner == CustomWinner.Executioner && Main.CustomWinTrigger)
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Executioner && Main.CustomWinTrigger)
             {
                 __instance.enabled = false;
                 ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
@@ -214,7 +214,7 @@ namespace TownOfHost
         }
         private static bool CheckAndEndGameForArsonist(ShipStatus __instance)
         {
-            if (Main.currentWinner == CustomWinner.Arsonist && Main.CustomWinTrigger)
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Arsonist && Main.CustomWinTrigger)
             {
                 __instance.enabled = false;
                 ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
@@ -236,8 +236,8 @@ namespace TownOfHost
             {
                 var LoseImpostorRole = Main.AliveImpostorCount == 0 ? pc.Is(RoleType.Impostor) : pc.Is(CustomRoles.Egoist);
                 if (pc.Is(CustomRoles.Sheriff) ||
-                    (!(Main.currentWinner == CustomWinner.Arsonist) && pc.Is(CustomRoles.Arsonist)) ||
-                    (Main.currentWinner != CustomWinner.Jackal && pc.Is(CustomRoles.Jackal)) ||
+                    (!(CustomWinnerHolder.WinnerTeam == CustomWinner.Arsonist) && pc.Is(CustomRoles.Arsonist)) ||
+                    (CustomWinnerHolder.WinnerTeam != CustomWinner.Jackal && pc.Is(CustomRoles.Jackal)) ||
                     LoseImpostorRole)
                 {
                     pc.RpcSetRole(RoleTypes.GuardianAngel);

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -211,6 +211,7 @@ namespace TownOfHost
                 // CustomWinnerHolderの情報送信
                 writer.StartMessage(5); //GameData
                 {
+                    writer.Write(AmongUsClient.Instance.GameId);
                     writer.StartMessage(2); //RPC
                     {
                         writer.WritePacked(PlayerControl.LocalPlayer.NetId);

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -209,7 +209,28 @@ namespace TownOfHost
             }
             new LateTask(() =>
             {
-                ShipStatus.RpcEndGame(reason, showAd);
+                MessageWriter writer = MessageWriter.Get(SendOption.Reliable);
+                // CustomWinnerHolderの情報送信
+                writer.StartMessage(5); //GameData
+                {
+                    writer.StartMessage(2); //RPC
+                    {
+                        writer.WritePacked(PlayerControl.LocalPlayer.NetId);
+                        writer.Write((byte)CustomRPC.EndGame);
+                        CustomWinnerHolder.WriteTo(writer);
+                    }
+                    writer.EndMessage();
+                }
+                writer.EndMessage();
+
+                // AmongUs側のゲーム終了RPC
+                writer.StartMessage(8);
+                {
+                    writer.Write(AmongUsClient.Instance.GameId); //ここまでStartEndGameの内容
+                    writer.Write((byte)reason);
+                    writer.Write(showAd);
+                }
+                writer.EndMessage();
             }, 0.5f, "EndGameTask");
         }
         //プレイヤー統計

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -169,11 +169,8 @@ namespace TownOfHost
                 if (!hasRole) return false;
                 if (role == CustomRoles.HASTroll && pc.Data.IsDead)
                 {
-                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
-                    writer.Write((byte)CustomWinner.HASTroll);
-                    writer.Write(pc.PlayerId);
-                    AmongUsClient.Instance.FinishRpcImmediately(writer);
-                    RPC.TrollWin(pc.PlayerId);
+                    CustomWinnerHolder.WinnerTeam = CustomWinner.HASTroll;
+                    CustomWinnerHolder.WinnerIds.Add(pc.PlayerId);
                     __instance.enabled = false;
                     ResetRoleAndEndGame(GameOverReason.ImpostorByKill, false);
                     return true;

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -39,10 +39,7 @@ namespace TownOfHost
             //廃村
             if (Input.GetKeyDown(KeyCode.Return) && Input.GetKey(KeyCode.L) && Input.GetKey(KeyCode.LeftShift) && GameStates.IsInGame)
             {
-                MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
-                writer.Write((int)CustomWinner.Draw);
-                AmongUsClient.Instance.FinishRpcImmediately(writer);
-                RPC.ForceEndGame();
+                CustomWinnerHolder.WinnerTeam = CustomWinner.Draw;
             }
             //ミーティングを強制終了
             if (Input.GetKeyDown(KeyCode.Return) && Input.GetKey(KeyCode.M) && Input.GetKey(KeyCode.LeftShift) && GameStates.IsMeeting)

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -83,7 +83,7 @@ namespace TownOfHost
                     exiled.Object.ExiledSchrodingerCatTeamChange();
 
 
-                if (Main.currentWinner != CustomWinner.Terrorist) PlayerState.SetDead(exiled.PlayerId);
+                if (CustomWinnerHolder.WinnerTeam != CustomWinner.Terrorist) PlayerState.SetDead(exiled.PlayerId);
             }
             if (AmongUsClient.Instance.AmHost && Main.IsFixedCooldown)
                 Main.RefixCooldownDelay = Options.DefaultKillCooldown - 3f;

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -65,6 +65,7 @@ namespace TownOfHost
                         if (GetValue && exiled.PlayerId == targetId)
                         {
                             CustomWinnerHolder.WinnerIds.Add(executioner);
+                            CustomWinnerHolder.AdditionalWinnerTeams.Add(AdditionalWinners.Executioner);
                         }
                     }
                     DecidedWinner = true;

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -56,11 +56,8 @@ namespace TownOfHost
                 var role = exiled.GetCustomRole();
                 if (role == CustomRoles.Jester && AmongUsClient.Instance.AmHost)
                 {
-                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
-                    writer.Write((byte)CustomWinner.Jester);
-                    writer.Write(exiled.PlayerId);
-                    AmongUsClient.Instance.FinishRpcImmediately(writer);
-                    RPC.JesterExiled(exiled.PlayerId);
+                    CustomWinnerHolder.WinnerTeam = CustomWinner.Jester;
+                    CustomWinnerHolder.WinnerIds.Add(exiled.PlayerId);
                     DecidedWinner = true;
                 }
                 if (role == CustomRoles.Terrorist && AmongUsClient.Instance.AmHost)
@@ -76,12 +73,8 @@ namespace TownOfHost
                     if (kvp.Value == exiled.PlayerId && AmongUsClient.Instance.AmHost && !DecidedWinner)
                     {
                         //RPC送信開始
-                        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
-                        writer.Write((byte)CustomWinner.Executioner);
-                        writer.Write(kvp.Key);
-                        AmongUsClient.Instance.FinishRpcImmediately(writer); //終了
-
-                        RPC.ExecutionerWin(kvp.Key);
+                        CustomWinnerHolder.WinnerTeam = CustomWinner.Executioner;
+                        CustomWinnerHolder.WinnerIds.Add(kvp.Key);
                     }
                 }
                 if (exiled.Object.Is(CustomRoles.TimeThief))

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -21,42 +21,42 @@ namespace TownOfHost
             Main.additionalwinners = new HashSet<AdditionalWinners>();
             var winner = new List<PlayerControl>();
             //勝者リスト作成
-            if (TempData.DidHumansWin(endGameResult.GameOverReason) || endGameResult.GameOverReason.Equals(GameOverReason.HumansByTask) || endGameResult.GameOverReason.Equals(GameOverReason.HumansByVote))
+            if (CustomWinnerHolder.WinnerTeam != CustomWinner.Default)
             {
-                if (CustomWinnerHolder.WinnerTeam == CustomWinner.Default)
+                foreach (var pc in PlayerControl.AllPlayerControls)
                 {
-                    CustomWinnerHolder.WinnerTeam = CustomWinner.Crewmate;
-                }
-                foreach (var p in PlayerControl.AllPlayerControls)
-                {
-                    if (p.GetCustomSubRole() == CustomRoles.Lovers) continue;
-                    bool canWin = p.Is(RoleType.Crewmate);
-                    if (canWin) winner.Add(p);
+                    if (CustomWinnerHolder.WinnerRoles.Contains(pc.GetCustomRole()) ||
+                       CustomWinnerHolder.WinnerIds.Contains(pc.PlayerId))
+                        winner.Add(pc);
                 }
             }
-            if (TempData.DidImpostorsWin(endGameResult.GameOverReason))
+            else
             {
-                if (CustomWinnerHolder.WinnerTeam == CustomWinner.Default)
-                    CustomWinnerHolder.WinnerTeam = CustomWinner.Impostor;
-                foreach (var p in PlayerControl.AllPlayerControls)
+                if (TempData.DidHumansWin(endGameResult.GameOverReason) || endGameResult.GameOverReason.Equals(GameOverReason.HumansByTask) || endGameResult.GameOverReason.Equals(GameOverReason.HumansByVote))
                 {
-                    if (p.GetCustomSubRole() == CustomRoles.Lovers) continue;
-                    bool canWin = p.Is(RoleType.Impostor) || p.Is(RoleType.Madmate);
-                    if (canWin) winner.Add(p);
+                    if (CustomWinnerHolder.WinnerTeam == CustomWinner.Default)
+                    {
+                        CustomWinnerHolder.WinnerTeam = CustomWinner.Crewmate;
+                    }
+                    foreach (var p in PlayerControl.AllPlayerControls)
+                    {
+                        if (p.GetCustomSubRole() == CustomRoles.Lovers) continue;
+                        bool canWin = p.Is(RoleType.Crewmate);
+                        if (canWin) winner.Add(p);
+                    }
                 }
-                Egoist.OverrideCustomWinner();
-            }
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Jackal)
-            {
-                winner.Clear();
-                foreach (var p in PlayerControl.AllPlayerControls)
+                if (TempData.DidImpostorsWin(endGameResult.GameOverReason))
                 {
-                    if (p.Is(CustomRoles.Jackal) || p.Is(CustomRoles.JSchrodingerCat)) winner.Add(p);
+                    if (CustomWinnerHolder.WinnerTeam == CustomWinner.Default)
+                        CustomWinnerHolder.WinnerTeam = CustomWinner.Impostor;
+                    foreach (var p in PlayerControl.AllPlayerControls)
+                    {
+                        if (p.GetCustomSubRole() == CustomRoles.Lovers) continue;
+                        bool canWin = p.Is(RoleType.Impostor) || p.Is(RoleType.Madmate);
+                        if (canWin) winner.Add(p);
+                    }
+                    Egoist.OverrideCustomWinner();
                 }
-            }
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.None)
-            {
-                winner.Clear();
             }
 
             //廃村時の処理など
@@ -72,28 +72,6 @@ namespace TownOfHost
             }
 
             //単独勝利
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Jester && CustomRoles.Jester.IsEnable())
-            { //Jester単独勝利
-                winner = new();
-                foreach (var p in PlayerControl.AllPlayerControls)
-                {
-                    if (p.PlayerId == Main.ExiledJesterID)
-                    {
-                        winner.Add(p);
-                    }
-                }
-            }
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Terrorist && CustomRoles.Terrorist.IsEnable())
-            { //Terrorist単独勝利
-                winner = new();
-                foreach (var p in PlayerControl.AllPlayerControls)
-                {
-                    if (p.PlayerId == Main.WonTerroristID)
-                    {
-                        winner.Add(p);
-                    }
-                }
-            }
             if (CustomRoles.Lovers.IsEnable() && Options.CurrentGameMode == CustomGameMode.Standard && Main.LoversPlayers.Count > 0 && Main.LoversPlayers.ToArray().All(p => !p.Data.IsDead) //ラバーズが生きていて
             && (CustomWinnerHolder.WinnerTeam == CustomWinner.Impostor || CustomWinnerHolder.WinnerTeam == CustomWinner.Jackal
             || (CustomWinnerHolder.WinnerTeam == CustomWinner.Crewmate && !endGameResult.GameOverReason.Equals(GameOverReason.HumansByTask))))   //クルー勝利でタスク勝ちじゃなければ
@@ -103,28 +81,6 @@ namespace TownOfHost
                 foreach (var lp in Main.LoversPlayers)
                 {
                     winner.Add(lp);
-                }
-            }
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Executioner && CustomRoles.Executioner.IsEnable())
-            { //Executioner単独勝利
-                winner = new();
-                foreach (var p in PlayerControl.AllPlayerControls)
-                {
-                    if (p.PlayerId == Main.WonExecutionerID)
-                    {
-                        winner.Add(p);
-                    }
-                }
-            }
-            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Arsonist && CustomRoles.Arsonist.IsEnable())
-            { //Arsonist単独勝利
-                winner = new();
-                foreach (var p in PlayerControl.AllPlayerControls)
-                {
-                    if (p.PlayerId == Main.WonArsonistID)
-                    {
-                        winner.Add(p);
-                    }
                 }
             }
             TeamEgoist.SoloWin(winner);

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -22,7 +22,6 @@ namespace TownOfHost
             PlayerControl.GameOptions.killCooldown = Options.DefaultKillCooldown;
             //winnerListリセット
             TempData.winners = new Il2CppSystem.Collections.Generic.List<WinningPlayerData>();
-            Main.additionalwinners = new HashSet<AdditionalWinners>();
             var winner = new List<PlayerControl>();
             //勝者リスト作成
             if (CustomWinnerHolder.WinnerTeam != CustomWinner.Default)
@@ -97,14 +96,14 @@ namespace TownOfHost
                 if (pc.Is(CustomRoles.Opportunist) && !pc.Data.IsDead && CustomWinnerHolder.WinnerTeam != CustomWinner.Draw && CustomWinnerHolder.WinnerTeam != CustomWinner.Terrorist)
                 {
                     winner.Add(pc);
-                    Main.additionalwinners.Add(AdditionalWinners.Opportunist);
+                    CustomWinnerHolder.AdditionalWinnerTeams.Add(AdditionalWinners.Opportunist);
                 }
                 //SchrodingerCat
                 if (Options.CanBeforeSchrodingerCatWinTheCrewmate.GetBool())
                     if (pc.Is(CustomRoles.SchrodingerCat) && CustomWinnerHolder.WinnerTeam == CustomWinner.Crewmate)
                     {
                         winner.Add(pc);
-                        Main.additionalwinners.Add(AdditionalWinners.SchrodingerCat);
+                        CustomWinnerHolder.AdditionalWinnerTeams.Add(AdditionalWinners.SchrodingerCat);
                     }
             }
 
@@ -139,7 +138,7 @@ namespace TownOfHost
                     else if (role == CustomRoles.HASFox && CustomWinnerHolder.WinnerTeam != CustomWinner.HASTroll && !pc.Data.IsDead)
                     {
                         winner.Add(pc);
-                        Main.additionalwinners.Add(AdditionalWinners.HASFox);
+                        CustomWinnerHolder.AdditionalWinnerTeams.Add(AdditionalWinners.HASFox);
                     }
                 }
             }
@@ -231,7 +230,7 @@ namespace TownOfHost
                     break;
             }
 
-            foreach (var additionalwinners in Main.additionalwinners)
+            foreach (var additionalwinners in CustomWinnerHolder.AdditionalWinnerTeams)
             {
                 var addWinnerRole = (CustomRoles)additionalwinners;
                 AdditionalWinnerText += "＆" + Helpers.ColorString(Utils.GetRoleColor(addWinnerRole), Utils.GetRoleName(addWinnerRole));

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -23,9 +23,9 @@ namespace TownOfHost
             //勝者リスト作成
             if (TempData.DidHumansWin(endGameResult.GameOverReason) || endGameResult.GameOverReason.Equals(GameOverReason.HumansByTask) || endGameResult.GameOverReason.Equals(GameOverReason.HumansByVote))
             {
-                if (Main.currentWinner == CustomWinner.Default)
+                if (CustomWinnerHolder.WinnerTeam == CustomWinner.Default)
                 {
-                    Main.currentWinner = CustomWinner.Crewmate;
+                    CustomWinnerHolder.WinnerTeam = CustomWinner.Crewmate;
                 }
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
@@ -36,8 +36,8 @@ namespace TownOfHost
             }
             if (TempData.DidImpostorsWin(endGameResult.GameOverReason))
             {
-                if (Main.currentWinner == CustomWinner.Default)
-                    Main.currentWinner = CustomWinner.Impostor;
+                if (CustomWinnerHolder.WinnerTeam == CustomWinner.Default)
+                    CustomWinnerHolder.WinnerTeam = CustomWinner.Impostor;
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
                     if (p.GetCustomSubRole() == CustomRoles.Lovers) continue;
@@ -46,7 +46,7 @@ namespace TownOfHost
                 }
                 Egoist.OverrideCustomWinner();
             }
-            if (Main.currentWinner == CustomWinner.Jackal)
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Jackal)
             {
                 winner.Clear();
                 foreach (var p in PlayerControl.AllPlayerControls)
@@ -54,7 +54,7 @@ namespace TownOfHost
                     if (p.Is(CustomRoles.Jackal) || p.Is(CustomRoles.JSchrodingerCat)) winner.Add(p);
                 }
             }
-            if (Main.currentWinner == CustomWinner.None)
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.None)
             {
                 winner.Clear();
             }
@@ -62,7 +62,7 @@ namespace TownOfHost
             //廃村時の処理など
             if (endGameResult.GameOverReason == GameOverReason.HumansDisconnect ||
             endGameResult.GameOverReason == GameOverReason.ImpostorDisconnect ||
-            Main.currentWinner == CustomWinner.Draw)
+            CustomWinnerHolder.WinnerTeam == CustomWinner.Draw)
             {
                 winner = new List<PlayerControl>();
                 foreach (var p in PlayerControl.AllPlayerControls)
@@ -72,7 +72,7 @@ namespace TownOfHost
             }
 
             //単独勝利
-            if (Main.currentWinner == CustomWinner.Jester && CustomRoles.Jester.IsEnable())
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Jester && CustomRoles.Jester.IsEnable())
             { //Jester単独勝利
                 winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
@@ -83,7 +83,7 @@ namespace TownOfHost
                     }
                 }
             }
-            if (Main.currentWinner == CustomWinner.Terrorist && CustomRoles.Terrorist.IsEnable())
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Terrorist && CustomRoles.Terrorist.IsEnable())
             { //Terrorist単独勝利
                 winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
@@ -95,17 +95,17 @@ namespace TownOfHost
                 }
             }
             if (CustomRoles.Lovers.IsEnable() && Options.CurrentGameMode == CustomGameMode.Standard && Main.LoversPlayers.Count > 0 && Main.LoversPlayers.ToArray().All(p => !p.Data.IsDead) //ラバーズが生きていて
-            && (Main.currentWinner == CustomWinner.Impostor || Main.currentWinner == CustomWinner.Jackal
-            || (Main.currentWinner == CustomWinner.Crewmate && !endGameResult.GameOverReason.Equals(GameOverReason.HumansByTask))))   //クルー勝利でタスク勝ちじゃなければ
+            && (CustomWinnerHolder.WinnerTeam == CustomWinner.Impostor || CustomWinnerHolder.WinnerTeam == CustomWinner.Jackal
+            || (CustomWinnerHolder.WinnerTeam == CustomWinner.Crewmate && !endGameResult.GameOverReason.Equals(GameOverReason.HumansByTask))))   //クルー勝利でタスク勝ちじゃなければ
             { //Loversの単独勝利
                 winner = new();
-                Main.currentWinner = CustomWinner.Lovers;
+                CustomWinnerHolder.WinnerTeam = CustomWinner.Lovers;
                 foreach (var lp in Main.LoversPlayers)
                 {
                     winner.Add(lp);
                 }
             }
-            if (Main.currentWinner == CustomWinner.Executioner && CustomRoles.Executioner.IsEnable())
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Executioner && CustomRoles.Executioner.IsEnable())
             { //Executioner単独勝利
                 winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
@@ -116,7 +116,7 @@ namespace TownOfHost
                     }
                 }
             }
-            if (Main.currentWinner == CustomWinner.Arsonist && CustomRoles.Arsonist.IsEnable())
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Arsonist && CustomRoles.Arsonist.IsEnable())
             { //Arsonist単独勝利
                 winner = new();
                 foreach (var p in PlayerControl.AllPlayerControls)
@@ -132,20 +132,20 @@ namespace TownOfHost
             //Opportunist
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
-                if (Main.currentWinner == CustomWinner.None) break;
-                if (pc.Is(CustomRoles.Opportunist) && !pc.Data.IsDead && Main.currentWinner != CustomWinner.Draw && Main.currentWinner != CustomWinner.Terrorist)
+                if (CustomWinnerHolder.WinnerTeam == CustomWinner.None) break;
+                if (pc.Is(CustomRoles.Opportunist) && !pc.Data.IsDead && CustomWinnerHolder.WinnerTeam != CustomWinner.Draw && CustomWinnerHolder.WinnerTeam != CustomWinner.Terrorist)
                 {
                     winner.Add(pc);
                     Main.additionalwinners.Add(AdditionalWinners.Opportunist);
                 }
                 //SchrodingerCat
                 if (Options.CanBeforeSchrodingerCatWinTheCrewmate.GetBool())
-                    if (pc.Is(CustomRoles.SchrodingerCat) && Main.currentWinner == CustomWinner.Crewmate)
+                    if (pc.Is(CustomRoles.SchrodingerCat) && CustomWinnerHolder.WinnerTeam == CustomWinner.Crewmate)
                     {
                         winner.Add(pc);
                         Main.additionalwinners.Add(AdditionalWinners.SchrodingerCat);
                     }
-                if (Main.currentWinner == CustomWinner.Jester)
+                if (CustomWinnerHolder.WinnerTeam == CustomWinner.Jester)
                     foreach (var ExecutionerTarget in Main.ExecutionerTarget)
                     {
                         if (Main.ExiledJesterID == ExecutionerTarget.Value && pc.PlayerId == ExecutionerTarget.Key)
@@ -158,7 +158,7 @@ namespace TownOfHost
 
             //HideAndSeek専用
             if (Options.CurrentGameMode == CustomGameMode.HideAndSeek &&
-                Main.currentWinner != CustomWinner.Draw && Main.currentWinner != CustomWinner.None)
+                CustomWinnerHolder.WinnerTeam != CustomWinner.Draw && CustomWinnerHolder.WinnerTeam != CustomWinner.None)
             {
                 winner = new();
                 foreach (var pc in PlayerControl.AllPlayerControls)
@@ -184,7 +184,7 @@ namespace TownOfHost
                         };
                         break;
                     }
-                    else if (role == CustomRoles.HASFox && Main.currentWinner != CustomWinner.HASTroll && !pc.Data.IsDead)
+                    else if (role == CustomRoles.HASFox && CustomWinnerHolder.WinnerTeam != CustomWinner.HASTroll && !pc.Data.IsDead)
                     {
                         winner.Add(pc);
                         Main.additionalwinners.Add(AdditionalWinners.HASFox);
@@ -194,7 +194,7 @@ namespace TownOfHost
             Main.winnerList = new();
             foreach (var pc in winner)
             {
-                if (Main.currentWinner is not CustomWinner.Draw && pc.Is(CustomRoles.GM)) continue;
+                if (CustomWinnerHolder.WinnerTeam is not CustomWinner.Draw && pc.Is(CustomRoles.GM)) continue;
 
                 TempData.winners.Add(new WinningPlayerData(pc.Data));
                 Main.winnerList.Add(pc.PlayerId);
@@ -235,7 +235,7 @@ namespace TownOfHost
             string AdditionalWinnerText = "";
             string CustomWinnerColor = Utils.GetRoleColorCode(CustomRoles.Crewmate);
 
-            var winnerRole = (CustomRoles)Main.currentWinner;
+            var winnerRole = (CustomRoles)CustomWinnerHolder.WinnerTeam;
             if (winnerRole >= 0)
             {
                 CustomWinnerText = Utils.GetRoleName(winnerRole);
@@ -251,7 +251,7 @@ namespace TownOfHost
                 __instance.WinText.color = Utils.GetRoleColor(CustomRoles.GM);
                 __instance.BackgroundBar.material.color = Utils.GetRoleColor(CustomRoles.GM);
             }
-            switch (Main.currentWinner)
+            switch (CustomWinnerHolder.WinnerTeam)
             {
                 //通常勝利
                 case CustomWinner.Crewmate:
@@ -284,7 +284,7 @@ namespace TownOfHost
                 var addWinnerRole = (CustomRoles)additionalwinners;
                 AdditionalWinnerText += "＆" + Helpers.ColorString(Utils.GetRoleColor(addWinnerRole), Utils.GetRoleName(addWinnerRole));
             }
-            if (Main.currentWinner != CustomWinner.Draw && Main.currentWinner != CustomWinner.None)
+            if (CustomWinnerHolder.WinnerTeam != CustomWinner.Draw && CustomWinnerHolder.WinnerTeam != CustomWinner.None)
             {
                 textRenderer.text = $"<color={CustomWinnerColor}>{CustomWinnerText}{AdditionalWinnerText}{GetString("Win")}</color>";
             }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -1118,11 +1118,8 @@ namespace TownOfHost
                                 RPC.PlaySoundRPC(pc.PlayerId, Sounds.KillSound);
                         }
                     }
-                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.EndGame, Hazel.SendOption.Reliable, -1);
-                    writer.Write((byte)CustomWinner.Arsonist);
-                    writer.Write(__instance.myPlayer.PlayerId);
-                    AmongUsClient.Instance.FinishRpcImmediately(writer);
-                    RPC.ArsonistWin(__instance.myPlayer.PlayerId);
+                    CustomWinnerHolder.WinnerTeam = CustomWinner.Arsonist;
+                    CustomWinnerHolder.WinnerIds.Add(__instance.myPlayer.PlayerId);
                     return true;
                 }
                 if (__instance.myPlayer.Is(CustomRoles.Sheriff) ||

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -99,6 +99,7 @@ namespace TownOfHost
             Mare.Init();
             Egoist.Init();
             Sheriff.Init();
+            CustomWinnerHolder.Reset();
             AntiBlackout.Reset();
         }
     }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -15,7 +15,6 @@ namespace TownOfHost
             //注:この時点では役職は設定されていません。
             PlayerState.Init();
 
-            Main.currentWinner = CustomWinner.Default;
             Main.CustomWinTrigger = false;
             Main.AllPlayerCustomRoles = new Dictionary<byte, CustomRoles>();
             Main.AllPlayerCustomSubRoles = new Dictionary<byte, CustomRoles>();

--- a/Roles/Egoist.cs
+++ b/Roles/Egoist.cs
@@ -30,7 +30,7 @@ namespace TownOfHost
         {
             foreach (var id in playerIdList)
                 if (TeamEgoist.CompleteWinCondition(id))
-                    Main.currentWinner = CustomWinner.Egoist;
+                    CustomWinnerHolder.WinnerTeam = CustomWinner.Egoist;
         }
     }
 }

--- a/Roles/TeamEgoist.cs
+++ b/Roles/TeamEgoist.cs
@@ -16,6 +16,7 @@ namespace TownOfHost
         {
             if (CustomWinnerHolder.WinnerTeam == CustomWinner.Egoist && CustomRoles.Egoist.IsEnable()) //横取り勝利
             {
+                Logger.SendInGame("Egoist横取り勝利");
                 winner = new();
                 foreach (var id in playerIdList)
                 {

--- a/Roles/TeamEgoist.cs
+++ b/Roles/TeamEgoist.cs
@@ -11,10 +11,10 @@ namespace TownOfHost
         {
             playerIdList.Add(teamEgo);
         }
-        public static bool CompleteWinCondition(byte id) => Main.currentWinner == CustomWinner.Impostor && !PlayerState.isDead[id] && !PlayerControl.AllPlayerControls.ToArray().Any(p => p.Is(RoleType.Impostor) && !PlayerState.isDead[p.PlayerId]);
+        public static bool CompleteWinCondition(byte id) => CustomWinnerHolder.WinnerTeam == CustomWinner.Impostor && !PlayerState.isDead[id] && !PlayerControl.AllPlayerControls.ToArray().Any(p => p.Is(RoleType.Impostor) && !PlayerState.isDead[p.PlayerId]);
         public static void SoloWin(List<PlayerControl> winner)
         {
-            if (Main.currentWinner == CustomWinner.Egoist && CustomRoles.Egoist.IsEnable()) //横取り勝利
+            if (CustomWinnerHolder.WinnerTeam == CustomWinner.Egoist && CustomRoles.Egoist.IsEnable()) //横取り勝利
             {
                 winner = new();
                 foreach (var id in playerIdList)

--- a/Roles/TeamEgoist.cs
+++ b/Roles/TeamEgoist.cs
@@ -16,7 +16,6 @@ namespace TownOfHost
         {
             if (CustomWinnerHolder.WinnerTeam == CustomWinner.Egoist && CustomRoles.Egoist.IsEnable()) //横取り勝利
             {
-                Logger.SendInGame("Egoist横取り勝利");
                 winner = new();
                 foreach (var id in playerIdList)
                 {

--- a/main.cs
+++ b/main.cs
@@ -63,7 +63,6 @@ namespace TownOfHost
         public static ConfigEntry<bool> IgnoreWinnerCommand { get; private set; }
         public static ConfigEntry<string> WebhookURL { get; private set; }
         public static ConfigEntry<float> LastKillCooldown { get; private set; }
-        public static CustomWinner currentWinner;
         public static HashSet<AdditionalWinners> additionalwinners = new();
         public static GameOptionsData RealOptionsData;
         public static Dictionary<byte, string> AllPlayerNames;
@@ -150,7 +149,6 @@ namespace TownOfHost
             TownOfHost.Logger.Disable("SwitchSystem");
             //TownOfHost.Logger.isDetail = true;
 
-            currentWinner = CustomWinner.Default;
             additionalwinners = new HashSet<AdditionalWinners>();
 
             AllPlayerCustomRoles = new Dictionary<byte, CustomRoles>();

--- a/main.cs
+++ b/main.cs
@@ -63,7 +63,6 @@ namespace TownOfHost
         public static ConfigEntry<bool> IgnoreWinnerCommand { get; private set; }
         public static ConfigEntry<string> WebhookURL { get; private set; }
         public static ConfigEntry<float> LastKillCooldown { get; private set; }
-        public static HashSet<AdditionalWinners> additionalwinners = new();
         public static GameOptionsData RealOptionsData;
         public static Dictionary<byte, string> AllPlayerNames;
         public static Dictionary<(byte, byte), string> LastNotifyNames;
@@ -146,8 +145,6 @@ namespace TownOfHost
             TownOfHost.Logger.Disable("ReceiveRPC");
             TownOfHost.Logger.Disable("SwitchSystem");
             //TownOfHost.Logger.isDetail = true;
-
-            additionalwinners = new HashSet<AdditionalWinners>();
 
             AllPlayerCustomRoles = new Dictionary<byte, CustomRoles>();
             AllPlayerCustomSubRoles = new Dictionary<byte, CustomRoles>();

--- a/main.cs
+++ b/main.cs
@@ -182,7 +182,7 @@ namespace TownOfHost
             LastKillCooldown = Config.Bind("Other", "LastKillCooldown", (float)30);
 
             NameColorManager.Begin();
-
+            CustomWinnerHolder.Reset();
             Translator.Init();
 
             hasArgumentException = false;

--- a/main.cs
+++ b/main.cs
@@ -112,10 +112,6 @@ namespace TownOfHost
         public static bool isShipStart;
         public static Dictionary<byte, bool> CheckShapeshift = new();
         public static Dictionary<(byte, byte), string> targetArrows = new();
-        public static byte WonTrollID;
-        public static byte ExiledJesterID;
-        public static byte WonTerroristID;
-        public static byte WonArsonistID;
         public static bool CustomWinTrigger;
         public static bool VisibleTasksCount;
         public static string nickName = "";


### PR DESCRIPTION
特殊勝利の処理を簡略化しました。
似た処理の役職ごとの勝利関連の関数の一部を統一しました。
簡単な特殊勝利の追加にRPC.csとCheckGameEnd.csへの関数追加が不要になります。

# 処理の流れ
1. 特殊勝利確定時、CustomWinnerHolderに勝利陣営と勝利する役職 or プレイヤーIDが格納される。
2. 『CustomWinnerHolderに格納されている勝利陣営が`CustomWinner.Default`ではない』時にゲーム終了処理が入る。この時、一部の役職を除き同一の関数で行われる。(CheckGameEndForJester関数などが統一されている)
3. ゲーム終了RPCと同一のメッセージでCustomWinnerHolderの内容が同期される。
4. OutroPatch内でCustomWinnerHolderに格納されている勝利する役職とプレイヤーIDの情報を元に勝者リストを作る。

# 補足
- Egoistの勝利判定は元からバグってます。修正PRが既に存在するのでこのPRでは修正してません。 (#1072)
- modクライアントx5の環境でEgoist以外の変更を行った役職+Loversが正常に勝利することを確認しています。