### PR TITLE
fix/SetTargetRpc

### DIFF
--- a/Roles/Executioner.cs
+++ b/Roles/Executioner.cs
@@ -52,20 +52,20 @@ namespace TownOfHost
         {
             playerIdList.Add(playerId);
 
-            List<PlayerControl> targetList = new();
-            var rand = new System.Random();
-            foreach (var target in PlayerControl.AllPlayerControls)
-            {
-                if (playerId == target.PlayerId) continue;
-                else if (!CanTargetImpostor.GetBool() && target.Is(RoleType.Impostor)) continue;
-                else if (!CanTargetNeutralKiller.GetBool() && target.IsNeutralKiller()) continue;
-                if (target.Is(CustomRoles.GM)) continue;
-
-                targetList.Add(target);
-            }
             //ターゲット割り当て
             if (AmongUsClient.Instance.AmHost)
             {
+                List<PlayerControl> targetList = new();
+                var rand = new System.Random();
+                foreach (var target in PlayerControl.AllPlayerControls)
+                {
+                    if (playerId == target.PlayerId) continue;
+                    else if (!CanTargetImpostor.GetBool() && target.Is(RoleType.Impostor)) continue;
+                    else if (!CanTargetNeutralKiller.GetBool() && target.IsNeutralKiller()) continue;
+                    if (target.Is(CustomRoles.GM)) continue;
+
+                    targetList.Add(target);
+                }
                 var SelectedTarget = targetList[rand.Next(targetList.Count)];
                 Target.Add(playerId, SelectedTarget.PlayerId);
                 SendRPC(playerId, SelectedTarget.PlayerId, "SetTarget");

--- a/Roles/Executioner.cs
+++ b/Roles/Executioner.cs
@@ -63,10 +63,14 @@ namespace TownOfHost
 
                 targetList.Add(target);
             }
-            var SelectedTarget = targetList[rand.Next(targetList.Count)];
-            Target.Add(playerId, SelectedTarget.PlayerId);
-            SendRPC(playerId, SelectedTarget.PlayerId, "SetTarget");
-            Logger.Info($"{Utils.GetPlayerById(playerId)?.GetNameWithRole()}:{SelectedTarget.GetNameWithRole()}", "Executioner");
+            //ターゲット割り当て
+            if (AmongUsClient.Instance.AmHost)
+            {
+                var SelectedTarget = targetList[rand.Next(targetList.Count)];
+                Target.Add(playerId, SelectedTarget.PlayerId);
+                SendRPC(playerId, SelectedTarget.PlayerId, "SetTarget");
+                Logger.Info($"{Utils.GetPlayerById(playerId)?.GetNameWithRole()}:{SelectedTarget.GetNameWithRole()}", "Executioner");
+            }
         }
         public static bool IsEnable() => playerIdList.Count > 0;
         public static void SendRPC(byte executionerId, byte targetId = 0x73, string Progress = "")


### PR DESCRIPTION
- Executionerのターゲット割り当て処理をホストのみ実行するよう変更
割り当て処理が各クライアント側で行われ、その影響で不正なRPCとしてキックされている問題の修正

@soukunsandesu 