### PR TITLE
アドミン制限で意図しないコミュサボ解除が行われる問題を修正

### DIFF
--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -78,7 +78,7 @@ namespace TownOfHost
                             }
                             else
                             {
-                                if (!RepairSystemPatch.IsComms && OldDesyncCommsPlayers.Contains(pc.PlayerId))
+                                if (!GameStates.IsComms && OldDesyncCommsPlayers.Contains(pc.PlayerId))
                                 {
                                     OldDesyncCommsPlayers.Remove(pc.PlayerId);
 

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -152,5 +152,6 @@ namespace TownOfHost
         public static bool IsInTask => InGame && !MeetingHud.Instance;
         public static bool IsMeeting => InGame && MeetingHud.Instance;
         public static bool IsCountDown => GameStartManager.InstanceExists && GameStartManager.Instance.startState == GameStartManager.StartingStates.Countdown;
+        public static bool IsComms => ShipStatus.Instance.Systems[SystemTypes.Comms].Cast<HudOverrideSystemType>().IsActive;
     }
 }


### PR DESCRIPTION
## 概要
コミュサボ中にアドミン制限の範囲外に出ると、対象のみインポスターによるコミュサボが解除されてしまう問題を修正。

## 修正
GameStatesにコミュサボの正しい参照先を持つIsCommsを追加。

判定に上記を使用。