### PR TITLE
コミュサボ解除の条件を修正

### DIFF
--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -78,7 +78,7 @@ namespace TownOfHost
                             }
                             else
                             {
-                                if (!RepairSystemPatch.IsComms && OldDesyncCommsPlayers.Contains(pc.PlayerId))
+                                if (!Utils.IsActive(SystemTypes.Comms) && OldDesyncCommsPlayers.Contains(pc.PlayerId))
                                 {
                                     OldDesyncCommsPlayers.Remove(pc.PlayerId);
 

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -49,6 +49,11 @@ namespace TownOfHost
                         var LifeSuppSystemType = ShipStatus.Instance.Systems[type].Cast<LifeSuppSystemType>();
                         return LifeSuppSystemType != null && LifeSuppSystemType.IsActive;
                     }
+                case SystemTypes.Comms:
+                    {
+                        var HudOverrideSystemType = ShipStatus.Instance.Systems[type].Cast<HudOverrideSystemType>();
+                        return HudOverrideSystemType != null && HudOverrideSystemType.IsActive;
+                    }
                 default:
                     return false;
             }


### PR DESCRIPTION
## 概要
コミュサボ中にアドミン制限の範囲外に出ると、対象のみインポスターによるコミュサボが解除されてしまう問題を修正。

## 修正
IsActiveにCommsを追加。

判定に上記を使用。