### PR TITLE
IntroDestroyが実行される前に廃村したときに出るエラーを修正

### DIFF
--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -251,6 +251,7 @@ namespace TownOfHost
     {
         public static void Postfix(IntroCutscene __instance)
         {
+            if (!GameStates.IsInGame) return;
             Main.introDestroyed = true;
             if (AmongUsClient.Instance.AmHost)
             {


### PR DESCRIPTION
最速廃村で部屋に戻ったときにシェイプシフターになっている問題も思わぬところで修正できました。