### PR TITLE
MiraHQでIsActiveが例外を吐く問題を修正

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -50,8 +50,16 @@ namespace TownOfHost
                     }
                 case SystemTypes.Comms:
                     {
-                        var HudOverrideSystemType = ShipStatus.Instance.Systems[type].Cast<HudOverrideSystemType>();
-                        return HudOverrideSystemType != null && HudOverrideSystemType.IsActive;
+                        if (mapId == 1)
+                        {
+                            var HqHudSystemType = ShipStatus.Instance.Systems[type].Cast<HqHudSystemType>();
+                            return HqHudSystemType != null && HqHudSystemType.IsActive;
+                        }
+                        else
+                        {
+                            var HudOverrideSystemType = ShipStatus.Instance.Systems[type].Cast<HudOverrideSystemType>();
+                            return HudOverrideSystemType != null && HudOverrideSystemType.IsActive;
+                        }
                     }
                 default:
                     return false;


### PR DESCRIPTION
## 概要
MiraHQで`IsActive(SystemType.Comms)`を呼ぶと、MiraHQのみ`HudOverrideSystemType`ではないためキャスト時に例外を吐く。

## 修正
- MiraHQのみキャスト先をHqHudSystemTypeに変更