### PR TITLE
Airshipで初手会議前にキルできない問題を修正

### DIFF
--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -255,8 +255,8 @@ namespace TownOfHost
             Main.introDestroyed = true;
             if (AmongUsClient.Instance.AmHost)
             {
-                foreach (var pc in PlayerControl.AllPlayerControls)
-                    pc.RpcResetAbilityCooldown();
+                if (PlayerControl.GameOptions.MapId != 4)
+                    PlayerControl.AllPlayerControls.ToArray().Do(pc => pc.RpcResetAbilityCooldown());
                 new LateTask(() => PlayerControl.AllPlayerControls.ToArray().Do(pc => pc.RpcSetRole(RoleTypes.Shapeshifter)), 2f, "SetImpostorForServer");
                 if (PlayerControl.LocalPlayer.Is(CustomRoles.GM))
                 {

--- a/Patches/RandomSpawnPatch.cs
+++ b/Patches/RandomSpawnPatch.cs
@@ -31,7 +31,9 @@ namespace TownOfHost
 
                     if (NumOfTP[player.PlayerId] == 2)
                     {
-                        if (!(Options.RandomSpawn.GetBool() && PlayerControl.GameOptions.MapId == 4)) return; //ランダムスポーンが無効か、マップがエアシップじゃなかったらreturn
+                        if (PlayerControl.GameOptions.MapId != 4) return; //マップがエアシップじゃなかったらreturn
+                        player.RpcResetAbilityCooldown();
+                        if (!Options.RandomSpawn.GetBool()) return; //ランダムスポーンが無効ならreturn
                         new AirshipSpawnMap().RandomTeleport(player);
                     }
                 }


### PR DESCRIPTION
## 概要
Airshipでイントロ破棄直後に`RpcResetAbilityCooldown`を呼ぶとシールドが剥がれなくなり、最初の会議が終わるまでキルが出来なくなる。

## 修正
- RpcResetAbilityCooldownのタイミングをAirShipのみスポーン位置選択後に変更