### PR TITLE
チャットの試合結果が見づらい問題を修正

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -984,7 +984,7 @@ namespace TownOfHost
         {
             var RolePos = TranslationController.Instance.currentLanguage.languageID == SupportedLangs.English ? 47 : 37;
             string summary = $"{Helpers.ColorString(Main.PlayerColors[id], Main.AllPlayerNames[id])}<pos=22%> {GetProgressText(id)}</pos><pos=29%> {GetVitalText(id)}</pos><pos={RolePos}%> {Helpers.ColorString(GetRoleColor(Main.AllPlayerCustomRoles[id]), GetRoleName(Main.AllPlayerCustomRoles[id]))}{GetShowLastSubRolesText(id)}</pos>";
-            return disableColor ? summary.RemoveHtmlTags() : Regex.Replace(summary, " ", "");
+            return disableColor ? summary.RemoveHtmlTags() : summary;
         }
         public static string RemoveHtmlTags(this string str) => Regex.Replace(str, "<[^>]*?>", "");
         public static bool CanMafiaKill()


### PR DESCRIPTION
## 概要
チャットで表示される試合結果の空白が削除されて見づらい問題を修正。

## 修正
- SummaryTextsで`disableColor`がfalseの時に空白を削除しない