### PR TITLE
初期スポーン時のクールダウンを修正するオプション

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -171,6 +171,8 @@ namespace TownOfHost
         }
         public static void SetKillCooldown(this PlayerControl player, float time)
         {
+            CustomRoles role = player.GetCustomRole();
+            if (!(role.IsImpostor() || player.IsNeutralKiller() || role is CustomRoles.Arsonist or CustomRoles.Sheriff)) return;
             if (player.AmOwner)
             {
                 player.SetKillTimer(time);

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -169,6 +169,19 @@ namespace TownOfHost
                 sender.SendMessage();
             }
         }
+        public static void SetKillCooldown(this PlayerControl player, float time)
+        {
+            if (player.AmOwner)
+            {
+                player.SetKillTimer(time);
+            }
+            else
+            {
+                Main.AllPlayerKillCooldown[player.PlayerId] = time * 2;
+                player.CustomSyncSettings();
+                player.RpcGuardAndKill();
+            }
+        }
         public static void RpcSpecificMurderPlayer(this PlayerControl killer, PlayerControl target = null)
         {
             if (target == null) target = killer;

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -145,6 +145,7 @@ namespace TownOfHost
     public static class GameStates
     {
         public static bool InGame = false;
+        public static bool MeetingCalled = false;
         public static bool IsLobby => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Joined;
         public static bool IsInGame => InGame;
         public static bool IsEnded => AmongUsClient.Instance.GameState == AmongUsClient.GameStates.Ended;

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -182,6 +182,7 @@ namespace TownOfHost
         public static CustomOption AutoDisplayLastResult;
         public static CustomOption SuffixMode;
         public static CustomOption ColorNameMode;
+        public static CustomOption FixFirstKillCooldown;
         public static CustomOption GhostCanSeeOtherRoles;
         public static CustomOption GhostCanSeeOtherVotes;
         public static CustomOption GhostIgnoreTasks;
@@ -476,6 +477,8 @@ namespace TownOfHost
             SuffixMode = CustomOption.Create(100602, TabGroup.MainSettings, Color.white, "SuffixMode", suffixModes, suffixModes[0])
                 .SetGameMode(CustomGameMode.All);
             ColorNameMode = CustomOption.Create(100605, TabGroup.MainSettings, Color.white, "ColorNameMode", false)
+                .SetGameMode(CustomGameMode.All);
+            FixFirstKillCooldown = CustomOption.Create(100608, TabGroup.MainSettings, Color.white, "FixFirstKillCooldown", false)
                 .SetGameMode(CustomGameMode.All);
             GhostCanSeeOtherRoles = CustomOption.Create(100603, TabGroup.MainSettings, Color.white, "GhostCanSeeOtherRoles", true)
                 .SetGameMode(CustomGameMode.All);

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -256,7 +256,14 @@ namespace TownOfHost
             if (AmongUsClient.Instance.AmHost)
             {
                 if (PlayerControl.GameOptions.MapId != 4)
+                {
                     PlayerControl.AllPlayerControls.ToArray().Do(pc => pc.RpcResetAbilityCooldown());
+                    if (Options.FixFirstKillCooldown.GetBool())
+                        new LateTask(() =>
+                        {
+                            PlayerControl.AllPlayerControls.ToArray().Do(pc => pc.SetKillCooldown(Main.AllPlayerKillCooldown[pc.PlayerId] - 2f));
+                        }, 2f, "FixKillCooldownTask");
+                }
                 new LateTask(() => PlayerControl.AllPlayerControls.ToArray().Do(pc => pc.RpcSetRole(RoleTypes.Shapeshifter)), 2f, "SetImpostorForServer");
                 if (PlayerControl.LocalPlayer.Is(CustomRoles.GM))
                 {

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -226,6 +226,7 @@ namespace TownOfHost
             Main.witchMeeting = true;
             Utils.NotifyRoles(isMeeting: true, NoCache: true);
             Main.witchMeeting = false;
+            GameStates.MeetingCalled = true;
         }
         public static void Postfix(MeetingHud __instance)
         {

--- a/Patches/RandomSpawnPatch.cs
+++ b/Patches/RandomSpawnPatch.cs
@@ -33,6 +33,7 @@ namespace TownOfHost
                     {
                         if (PlayerControl.GameOptions.MapId != 4) return; //マップがエアシップじゃなかったらreturn
                         player.RpcResetAbilityCooldown();
+                        if (Options.FixFirstKillCooldown.GetBool() && !GameStates.MeetingCalled) player.SetKillCooldown(Main.AllPlayerKillCooldown[player.PlayerId]);
                         if (!Options.RandomSpawn.GetBool()) return; //ランダムスポーンが無効ならreturn
                         new AirshipSpawnMap().RandomTeleport(player);
                     }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -107,6 +107,8 @@ namespace TownOfHost
             EvilTracker.Init();
             CustomWinnerHolder.Reset();
             AntiBlackout.Reset();
+
+            GameStates.MeetingCalled = false;
         }
     }
     [HarmonyPatch(typeof(RoleManager), nameof(RoleManager.SelectRoles))]

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -241,6 +241,7 @@ SuffixMode.Version,Version,バージョン,版本,版本
 SuffixMode.Streaming,Streaming,配信中,直播中,直播中
 SuffixMode.Recording,Recording,録画中,录制中,錄影中
 ColorNameMode,Color Name Mode,色名前モード,显示颜色名称,名字將被顏色名稱替換
+FixFirstKillCooldown,Fix Kill Cooldown For First Spawn,初期スポーン時のクールダウン修正,,
 GhostCanSeeOtherRoles,Ghost Can See Other Roles,幽霊が他人の役職を見ることができる,幽灵可见他人职业,幽靈可以看見所有玩家職業
 GhostCanSeeOtherVotes,Ghost Can See Other Votes,幽霊が他人の投票先を見ることができる,幽灵可见投票情况,幽靈可以看見所有玩家的投票
 GhostIgnoreTasks,Ghost Ignore Tasks,死人のタスクを免除する,,


### PR DESCRIPTION
## 概要
通常、初期スポーン時のキルクールが10秒に設定されるところを、本来のキルクールに修正するオプション。

## 備考
- イントロの同期ずれが稀に起こるため、AirShip以外は2秒の遅延を入れている。