### PR TITLE
カスタム翻訳ファイル機能を追加

### DIFF
--- a/Modules/Translator.cs
+++ b/Modules/Translator.cs
@@ -1,11 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
+using HarmonyLib;
+
 namespace TownOfHost
 {
     public static class Translator
     {
         public static Dictionary<string, Dictionary<int, string>> tr;
+        public const string LANGUAGE_FOLDER_NAME = "Language";
         public static void Init()
         {
             Logger.Info("Language Dictionary Initialize...", "Translator");
@@ -83,6 +88,16 @@ namespace TownOfHost
                 res = $"*{dic[0]}";
             }
             return res;
+        }
+
+        private static void CreateTemplateFile()
+        {
+            var text = "";
+            foreach (var title in tr) text += $"{title.Key}:\n";
+            File.WriteAllText(@$"./{LANGUAGE_FOLDER_NAME}/template.dat", text);
+            text = "";
+            foreach (var title in tr) text += $"{title.Key}:{title.Value[0].Replace("\n", "\\n").Replace("\r", "\\r")}\n";
+            File.WriteAllText(@$"./{LANGUAGE_FOLDER_NAME}/template_English.dat", text);
         }
     }
 }

--- a/Modules/Translator.cs
+++ b/Modules/Translator.cs
@@ -67,6 +67,9 @@ namespace TownOfHost
             }
             // カスタム翻訳ファイルの読み込み
             if (!Directory.Exists(LANGUAGE_FOLDER_NAME)) Directory.CreateDirectory(LANGUAGE_FOLDER_NAME);
+
+            // 翻訳テンプレートの作成
+            CreateTemplateFile();
         }
 
         public static string GetString(string s, Dictionary<string, string> replacementDic = null)

--- a/Modules/Translator.cs
+++ b/Modules/Translator.cs
@@ -95,6 +95,30 @@ namespace TownOfHost
             return res;
         }
 
+        public static void LoadCustomTranslation(string filename, SupportedLangs lang)
+        {
+            string path = @$"./{LANGUAGE_FOLDER_NAME}/{filename}";
+            if (File.Exists(path))
+            {
+                Logger.Info($"カスタム翻訳ファイル「{filename}」を読み込み", "LoadCustomTranslation");
+                using StreamReader sr = new(path, Encoding.GetEncoding("UTF-8"));
+                string text;
+                string[] tmp = { };
+                while ((text = sr.ReadLine()) != null)
+                {
+                    tmp = text.Split(":");
+                    if (tmp.Length > 1 && tmp[1] != "")
+                    {
+                        tr[tmp[0]][(int)lang] = tmp.Skip(1).Join(delimiter: ":").Replace("\\n", "\n").Replace("\\r", "\r");
+                    }
+                }
+            }
+            else
+            {
+                Logger.Error($"カスタム翻訳ファイル「{filename}」が見つかりませんでした", "LoadCustomTranslation");
+            }
+        }
+
         private static void CreateTemplateFile()
         {
             var text = "";

--- a/Modules/Translator.cs
+++ b/Modules/Translator.cs
@@ -70,6 +70,11 @@ namespace TownOfHost
 
             // 翻訳テンプレートの作成
             CreateTemplateFile();
+            foreach (var lang in Enum.GetValues(typeof(SupportedLangs)))
+            {
+                if (File.Exists(@$"./{LANGUAGE_FOLDER_NAME}/{lang}.dat"))
+                    LoadCustomTranslation($"{lang}.dat", (SupportedLangs)lang);
+            }
         }
 
         public static string GetString(string s, Dictionary<string, string> replacementDic = null)

--- a/Modules/Translator.cs
+++ b/Modules/Translator.cs
@@ -65,6 +65,8 @@ namespace TownOfHost
                     continue;
                 }
             }
+            // カスタム翻訳ファイルの読み込み
+            if (!Directory.Exists(LANGUAGE_FOLDER_NAME)) Directory.CreateDirectory(LANGUAGE_FOLDER_NAME);
         }
 
         public static string GetString(string s, Dictionary<string, string> replacementDic = null)

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -26,6 +26,13 @@ namespace TownOfHost
                 if (resolutionIndex >= resolutions.Length) resolutionIndex = 0;
                 ResolutionManager.SetResolution(resolutions[resolutionIndex].Item1, resolutions[resolutionIndex].Item2, false);
             }
+            //カスタム翻訳のリロード
+            if (Input.GetKeyDown(KeyCode.F5) && Input.GetKey(KeyCode.T))
+            {
+                Logger.Info("Reload Custom Translation File", "KeyCommand");
+                Translator.LoadLangs();
+                Logger.SendInGame("Reloaded Custom Translation File");
+            }
             //ログファイルのダンプ
             if (Input.GetKeyDown(KeyCode.F1) && Input.GetKey(KeyCode.LeftControl))
             {


### PR DESCRIPTION
## 概要
ユーザーが独自の翻訳を作って読み込める機能を追加。

## 使用方法
- Languageフォルダの中の`template.dat`、もしくは、`template_English.dat`をコピーする。
- `{言語名}.dat`に名前変更する。
  - 例: English.dat
- ファイルを開いて`翻訳対象:翻訳内容`のように記載する
  - 例: Skip:スキップ

## 機能
- `T`+`F5`でカスタム翻訳ファイルをリロード