### PR TITLE
NewFeature/Client クライアント

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -45,6 +45,7 @@ namespace TownOfHost
                 CustomRoles.Egoist or
                 CustomRoles.EgoSchrodingerCat or
                 CustomRoles.Jackal or
+                CustomRoles.JClient or
                 CustomRoles.JSchrodingerCat or
                 CustomRoles.HASTroll or
                 CustomRoles.HASFox;

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -332,7 +332,12 @@ namespace TownOfHost
                 case CustomRoles.JSchrodingerCat:
                     opt.SetVision(player, Options.JackalHasImpostorVision.GetBool());
                     break;
-
+                case CustomRoles.JClient:
+                    opt.RoleOptions.EngineerCooldown = Options.JClientVentCooldown.GetFloat();
+                    opt.RoleOptions.EngineerInVentMaxTime = Options.JClientVentMaxTime.GetFloat();
+                    if (Options.JClientHasImpostorVision.GetBool())
+                        opt.SetVision(player, true);
+                    break;
 
                 InfinityVent:
                     opt.RoleOptions.EngineerCooldown = 0;

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -68,6 +68,7 @@ namespace TownOfHost
             Execution,
             Disconnected,
             Fall,
+            JClientSuicide,
             etc = -1
         }
     }

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -55,6 +55,10 @@ namespace TownOfHost
             "Rate0", /*"Rate10", "Rate20", "Rate30", "Rate40", "Rate50",
             "Rate60", "Rate70", "Rate80", "Rate90", */"Rate100",
         };
+        public static readonly string[] JClientBereavementModes =
+        {
+            "JClientBereavementMode.None", "JClientBereavementMode.Following", 
+        };
 
         // 各役職の詳細設定
         public static CustomOption EnableGM;
@@ -96,6 +100,12 @@ namespace TownOfHost
         public static CustomOption JackalCanVent;
         public static CustomOption JackalCanUseSabotage;
         public static CustomOption JackalHasImpostorVision;
+        public static CustomOption JClientHasImpostorVision;
+        public static CustomOption JClientCanVent;
+        public static CustomOption JClientVentCooldown;
+        public static CustomOption JClientVentMaxTime;
+        public static CustomOption CanSeeTaskFinishedJClientFromJackal;
+        public static CustomOption JClientBereavementMode;
         public static CustomOption KillFlashDuration;
 
         // HideAndSeek
@@ -176,6 +186,7 @@ namespace TownOfHost
         public static OverrideTasksData TerroristTasks;
         public static OverrideTasksData SnitchTasks;
         public static OverrideTasksData MadSnitchTasks;
+        public static OverrideTasksData JClientTasks;
 
         // その他
         public static CustomOption NoGameEnd;
@@ -359,6 +370,16 @@ namespace TownOfHost
             JackalCanVent = CustomOption.Create(50911, TabGroup.NeutralRoles, Color.white, "CanVent", true, CustomRoleSpawnChances[CustomRoles.Jackal]);
             JackalCanUseSabotage = CustomOption.Create(50912, TabGroup.NeutralRoles, Color.white, "CanUseSabotage", false, CustomRoleSpawnChances[CustomRoles.Jackal]);
             JackalHasImpostorVision = CustomOption.Create(50913, TabGroup.NeutralRoles, Color.white, "ImpostorVision", true, CustomRoleSpawnChances[CustomRoles.Jackal]);
+            //JClient
+            SetupRoleOptions(51000, TabGroup.NeutralRoles, CustomRoles.JClient);
+            JClientHasImpostorVision = CustomOption.Create(51010, TabGroup.NeutralRoles, Color.white, "JClientHasImpostorVision", false, CustomRoleSpawnChances[CustomRoles.JClient]);
+            JClientCanVent = CustomOption.Create(51011, TabGroup.NeutralRoles, Color.white, "JClientCanVent", false, CustomRoleSpawnChances[CustomRoles.JClient]);
+            JClientVentCooldown = CustomOption.Create(51012, TabGroup.NeutralRoles, Color.white, "JClientVentCooldown", 0f, 0f, 180f, 5f, JClientCanVent);
+            JClientVentMaxTime = CustomOption.Create(51013, TabGroup.NeutralRoles, Color.white, "JClientVentMaxTime", 0f, 0f, 180f, 5f, JClientCanVent);
+            CanSeeTaskFinishedJClientFromJackal = CustomOption.Create(51014, TabGroup.NeutralRoles, Color.white, "CanSeeTaskFinishedJClientFromJackal", false, CustomRoleSpawnChances[CustomRoles.JClient]);
+            JClientBereavementMode = CustomOption.Create(51015, TabGroup.NeutralRoles, Color.white, "JClientBereavementMode", JClientBereavementModes, JClientBereavementModes[0], CustomRoleSpawnChances[CustomRoles.JClient]);
+            //ID51020~51023を使用
+            JClientTasks = OverrideTasksData.Create(51020, TabGroup.NeutralRoles, CustomRoles.JClient);
 
             // Attribute
             EnableLastImpostor = CustomOption.Create(80000, TabGroup.MainSettings, Utils.GetRoleColor(CustomRoles.Impostor), "LastImpostor", false, null, true)

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -288,6 +288,7 @@ namespace TownOfHost
                 { CustomRoles.SchrodingerCat, "sc" },
                 { CustomRoles.Terrorist, "te" },
                 { CustomRoles.Jackal, "jac" },
+                { CustomRoles.JClient, "cl" },
                 //Sub役職
                 { (CustomRoles)(-6), $"== {GetString("SubRole")} ==" }, //区切り用
                 {CustomRoles.Lovers, "lo" },

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -797,6 +797,13 @@ namespace TownOfHost
                     {
                         RealName = Helpers.ColorString(Utils.GetRoleColor(CustomRoles.Impostor), RealName); //targetの名前を赤色で表示
                     }
+                    //タスクを終わらせたJクライアントがジャッカルを確認できる
+                    else if (seer.Is(CustomRoles.JClient) && //seerがJクライアント
+                        target.Is(CustomRoles.Jackal) && //targetがジャッカル
+                        seer.GetPlayerTaskState().IsTaskFinished) //seerのタスクが終わっている
+                    {
+                        RealName = Helpers.ColorString(Utils.GetRoleColor(CustomRoles.Jackal), RealName); //targetの名前を赤色で表示
+                    }
                     //タスクを終わらせたSnitchがインポスターを確認できる
                     else if (PlayerControl.LocalPlayer.Is(CustomRoles.Snitch) && //LocalPlayerがSnitch
                         PlayerControl.LocalPlayer.GetPlayerTaskState().IsTaskFinished) //LocalPlayerのタスクが終わっている
@@ -814,6 +821,12 @@ namespace TownOfHost
                         else if (target.Is(CustomRoles.MadSnitch) && target.GetPlayerTaskState().IsTaskFinished) //targetがタスクを終わらせたマッドスニッチ
                             Mark += Helpers.ColorString(Utils.GetRoleColor(CustomRoles.MadSnitch), "★"); //targetにマーク付与
                     }
+                    //seerがジャッカル
+                    else if (seer.Is(CustomRoles.Jackal) && //seerがジャッカル
+                        target.Is(CustomRoles.JClient) && //targetがJクライアント
+                        Options.CanSeeTaskFinishedJClientFromJackal.GetBool() &&
+                        target.GetPlayerTaskState().IsTaskFinished) //targetのタスクが終わっている
+                        RealName = Helpers.ColorString(Utils.GetRoleColor(CustomRoles.Jackal), RealName); //targetの名前をジャッカル色で表示
 
                     else if ((seer.Is(CustomRoles.EgoSchrodingerCat) && target.Is(CustomRoles.Egoist)) || //エゴ猫 --> エゴイスト
                              (seer.Is(CustomRoles.JSchrodingerCat) && target.Is(CustomRoles.Jackal)) //J猫 --> ジャッカル

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -141,6 +141,9 @@ namespace TownOfHost
                 if (Options.MadSnitchCanVent.GetBool())
                     AdditionalEngineerNum += CustomRoles.MadSnitch.GetCount();
 
+                if (Options.JClientCanVent.GetBool())
+                    AdditionalEngineerNum += CustomRoles.JClient.GetCount();
+
                 roleOpt.SetRoleRate(RoleTypes.Engineer, EngineerNum + AdditionalEngineerNum, AdditionalEngineerNum > 0 ? 100 : roleOpt.GetChancePerGame(RoleTypes.Engineer));
 
                 int ShapeshifterNum = roleOpt.GetNumPerGame(RoleTypes.Shapeshifter);
@@ -286,6 +289,7 @@ namespace TownOfHost
                 AssignCustomRolesFromList(CustomRoles.TimeThief, Impostors);
                 AssignCustomRolesFromList(CustomRoles.EvilTracker, Shapeshifters);
                 AssignCustomRolesFromList(CustomRoles.Seer, Crewmates);
+                AssignCustomRolesFromList(CustomRoles.JClient, Options.JClientCanVent.GetBool() ? Engineers : Crewmates);
 
                 //RPCによる同期
                 foreach (var pc in PlayerControl.AllPlayerControls)
@@ -390,6 +394,9 @@ namespace TownOfHost
 
                 if (Options.MadSnitchCanVent.GetBool())
                     EngineerNum -= CustomRoles.MadSnitch.GetCount();
+
+                if (Options.JClientCanVent.GetBool())
+                    EngineerNum -= CustomRoles.JClient.GetCount();
 
                 roleOpt.SetRoleRate(RoleTypes.Engineer, EngineerNum, roleOpt.GetChancePerGame(RoleTypes.Engineer));
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -115,7 +115,7 @@ For example: `welcome:This room is using TownOfHost.`
 | [SerialKiller](#SerialKiller)       | [Nice Watcher](#Watcher)          | [Opportunist](#Opportunist)       |
 | [Sniper](#Sniper)                   | [SabotageMaster](#SabotageMaster) | [Terrorist](#Terrorist)           |
 | [TimeThief](#TimeThief)             | [Sheriff](#Sheriff)               | [SchrodingerCat](#SchrodingerCat) |
-| [Vampire](#Vampire)                 | [Snitch](#Snitch)                 |                                   |
+| [Vampire](#Vampire)                 | [Snitch](#Snitch)                 | [Client](#Client)                 |
 | [Warlock](#Warlock)                 | [SpeedBooster](#SpeedBooster)     |                                   |
 | [Witch](#Witch)                     | [Trapper](#Trapper)               |                                   |
 | [Mafia](#Mafia)                     |                                   |                                   |
@@ -723,6 +723,29 @@ The Terrorists are the Neutral Role where they win the game alone if they die wi
 Any cause of death is acceptable.<br>
 If they die before completing their tasks, or if they survive at the game end, they lose.<br>
 
+### Client
+
+Create and idea by くろにゃんこ<br>
+
+Team : Neutral<br>
+Basis : Crewmate or Engineer<br>
+
+The Client belong to team Jackal, like Inposter's Madmates.<br>
+They can see who is the Jackal after finishing all their tasks.<br>
+Depending on option, they can use vents.<br>
+
+#### Game Options
+
+| Name                                     |
+| ---------------------------------------- |
+| Client Have Impostor Vision              |
+| Client Can Use Vent                      |
+| Client Vent Cooldown                     |
+| Client Max Time In Vents (s)             |
+| Can see task finished Client from Jackal |
+| Jackal Bereavement Mode                  |
+| Client Tasks                             |
+
 ## Attribute
 
 ### LastImpostor
@@ -764,6 +787,7 @@ Example of overlapping Roles: <br>
 - [Opportunist](#opportunist) Lover: Win if you survive. <br>
 - [Jester](#jester) Lover: If you are voted out, you will win as Jester. If the other Lover is voted out, you are defeated. <br>
 - [Bait](#bait) Lover: When the other Lover is killed and you die afterwards, the other Lover immediately reports you. <br>
+- [Client](#Client) Lover: You have tasks, and you can see the Jackal after completing the task. <br>
 
 ## DisableDevice
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ AmongUsバージョン : **2022.7.12**
 | [SerialKiller/シリアルキラー](#SerialKillerシリアルキラー)                           | [Nice Watcher/ナイスウォッチャー](#Watcherウォッチャー)                    | [Opportunist/オポチュニスト](#Opportunistオポチュニスト)                   |
 | [Sniper/スナイパー](#Sniperスナイパー)                                               | [SabotageMaster/サボタージュマスター](#SabotageMasterサボタージュマスター) | [Terrorist/テロリスト](#Terroristテロリスト)                               |
 | [TimeThief/タイムシーフ](#TimeThiefタイムシーフ)                                     | [Sheriff/シェリフ](#Sheriffシェリフ)                                       | [SchrodingerCat/シュレディンガーの猫](#SchrodingerCatシュレディンガーの猫) |
-| [Vampire/ヴァンパイア](#Vampireヴァンパイア)                                         | [Snitch/スニッチ](#Snitchスニッチ)                                         |                                                                            |
+| [Vampire/ヴァンパイア](#Vampireヴァンパイア)                                         | [Snitch/スニッチ](#Snitchスニッチ)                                         | [Client/クライアント](#Clientクライアント)                                 |
 | [Warlock/ウォーロック](#Warlockウォーロック)                                         | [SpeedBooster/スピードブースター](#SpeedBoosterスピードブースター)         |                                                                            |
 | [Witch/魔女](#Witch魔女)                                                             | [Trapper/トラッパー](#Trapperトラッパー)                                   |                                                                            |
 | [Mafia/マフィア](#Mafiaマフィア)                                                     |                                                                            |                                                                            |
@@ -665,6 +665,28 @@ Polus や The Airship のドアを開けるとその部屋の全てのドアが�
 6.自殺系キル(ヴァンパイア除く)でキルされると、そのまま勝利条件が変わらず死亡する<br>
 
 また、全シュレディンガーの猫共通でタスクがありません。
+
+### Client/クライアント
+
+制作・考案者 : くろにゃんこ<br>
+
+陣営 : 第三<br>
+判定 : クルーメイトorエンジニア<br>
+
+ジャッカル陣営に属しますが、クライアントとジャッカルはお互い誰かはわかりません。<br>
+タスクを全て完了させるとジャッカルを認識できるようになります。<br>
+
+#### 設定
+
+| 設定名                                     |
+| ------------------------------------------ |
+| インポスターと同じ視界を持つ               |
+| ベントを使用できる                         |
+| ベントクールダウン                         |
+| ベント内での最大時間                       |
+| タスクが終わるとジャッカルからも視認できる |
+| ジャッカル死亡後のモード                   |
+| クライアントのタスク数                     |
 
 #### 設定
 

--- a/README_SChinese.md
+++ b/README_SChinese.md
@@ -116,7 +116,7 @@ AmongUs 版本: **2022.7.12**
 | [SerialKiller/嗜血杀手](#SerialKiller连环杀手)        | [Nice Watcher/正义的窥视者](#Watcher窥视者)  | [Opportunist/投机者](#Opportunist投机者)              |
 | [Sniper/狙击手](#Sniper狙击手)               | [SabotageMaster/修理大师](#SabotageMaster/修理大师)                | [Terrorist/恐怖分子](#Terrorist恐怖分子)               |
 | [TimeThief/蚀时者](#TimeThief蚀时者)                   | [Sheriff/警长](#Sheriff警长)                      | [SchrodingerCat/薛定谔的猫](#SchrodingerCat薛定谔的猫) |
-| [Vampire/吸血鬼](#Vampire吸血鬼)            | [Snitch/告密者](#Snitch告密者)                     |                                                      |
+| [Vampire/吸血鬼](#Vampire吸血鬼)            | [Snitch/告密者](#Snitch告密者)                     | [Client/请求者](#Client请求者)                       |
 | [Warlock/术士](#Warlock术士)                     | [SpeedBooster/增速者](#SpeedBooster增速者)        |                                                      |
 | [Witch/女巫](#Witch女巫)                        | [Trapper/陷阱师](#Trapper陷阱师)                   |                                                      |
 | [Mafia/黑手党](#Mafia黑手党)                         |                                                  |                                                      |
@@ -700,6 +700,29 @@ Kihi的想法
 恐怖分子属于中立阵营如果恐怖分子完成所有任务后死亡将独自获得胜利.<br>
 任何方式的死亡都可以.<br>
 如果恐怖分子在完成所有任务之前死亡，或者如果恐怖分子一直活到游戏结束，恐怖分子就会输.<br>
+
+### MadSnitch/背叛的告密者
+
+由くろにゃんこ创作和构思<br>
+
+阵营 : 中立阵营<br>
+基础 : 船员 or 工程师<br>
+
+请求者属于豺狼阵营，是叛徒的一种<br>
+完成所有任务后，他们可以看到谁是豺狼。<br>
+根据选项，他们可以使用通风口。.<br>
+
+#### 游戏选项
+
+| 名称                          |
+| ----------------------------- |
+| 请求者 有内鬼视野             |
+| 请求者 可以使用管道           |
+| 请求者 跳管道冷却时间         |
+| 请求者 在管道中停留的最大时间 |
+| 任务完成后 豺狼也能看到       |
+| 豺狼丧亲模式                  |
+| 请求者的任务数                |
 
 ## 属性
 

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -68,6 +68,7 @@ Opportunist,Opportunist,オポチュニスト,投机者,投機主義者
 Egoist,Egoist,エゴイスト,野心家,利己主義者
 Lovers,Lovers,恋人,恋人,戀人
 Jackal,Jackal,ジャッカル,豺狼,豺狼
+JClient,Client,クライアント,请求者,請求者
 
 # HideAndSeek
 HASFox,Fox,狐,狐狸,狐妖
@@ -143,6 +144,7 @@ ExecutionerInfo,Get your target voted out,ターゲットを追放させよう,�
 EgoistInfo,Replace the Impostor win,インポスター勝利を独占しよう,我们要把属于内鬼的胜利给夺走！,讓我們來奪取狼人的勝利
 LoversInfo,Survive with your lover,恋人と生きて幸せを掴もう,你坠入了爱河，成为了一对恋人，一起活到最后吧！,你墜入了愛河(心理)
 JackalInfo,Kill Everyone,すべてを殺せ,快去杀光所有人，一只苍蝇都不要剩下！,殺光所有人不留活口
+JClientInfo,Finish your tasks to help the Jackal,タスクを済ませ、ジャッカルの援助をしよう,完成任务后来帮助豺狼,完成你的任務並幫助豺狼
 
 # HideAndSeek
 HASFoxInfo,Stay alive,とにかく生き残りましょう,活下去吧！活到最后你就成为了赢家！,活到最後就是屬於你和贏家的一片天
@@ -200,6 +202,7 @@ SchrodingerCatInfoLong,"(Neutrals):\nWhen killed, they prevents the kill and bel
 OpportunistInfoLong,(Neutrals):\nThey win the game with any other Roles only if they are just alive at the game end.,(第三陣営):\n試合終了時に生存していれば追加勝利となる。,(独立阵营):\n若投机者在游戏结束时存活，则投机者跟随获胜玩家一同获得胜利。,"(中立):\n如果投機主義者活到最後,他將跟著遊戲結束獲勝的陣營一起獲勝。"
 EgoistInfoLong,"(Neutrals):\nAfter all the Impostors has gone, the Egoists Replace Impostor win.\nThe Impostors and Egoists can see each other.",(第三陣営):\n味方がすべて死んだ状態でインポスターが勝つと単独勝利する。\nインポスターは誰がエゴイストか分かる。エゴイストも、誰がインポスターか分かる。,(独立阵营):\n规则上野心家属于内鬼阵营。野心家与内鬼阵营玩家互认且不可以击杀对方。\n内鬼阵营玩家全部死亡后，若野心家存活且内鬼阵营达成胜利条件，则野心家单独获得胜利。,"(中立):\n如果所有的狼人都死光了且利己主義者活著,利己主義者將獨自獲勝。\n(狼人和利己主義者互相知道對方但是不可以互刀對方)"
 JackalInfoLong,"(Neutrals):\nJackal can kill all Crewmates, Impostors and Neutrals.\nTeam Jackal wins when living Jackal outnumbers living Crewmates and when there are no Impostors alive.",(第三陣営):\nジャッカルはすべてのプレイヤーを殺すことができる。\nインポスターが残っておらず、生き残っているジャッカルの人数がクルーと同じかそれ以上でジャッカルが勝利する。,(独立阵营):\n豺狼需要击杀所有人。\n存活的玩家只剩豺狼和一名其他船员时，豺狼获得胜利。,"(中立):\n豺狼需要殺死所有人來獲得勝利,\n如果場上存活的玩家只剩下豺狼和另一名不帶刀職業時,豺狼將獲勝。"
+JClientInfoLong,"(Neutrals):\nCrewmate, but they belong to team Jackal, one type of Jackal's Madmates.\nThey can see who is the Jackal after finishing all their tasks.\nDepending on option, they can use vents.",(ジャッカル陣営):\nクルーだがジャッカルの味方をする。\nジャッカルと互いに認識できないが、タスクを全て完了させるとジャッカルを認識できるようになる。,(独立阵营):\n请求者与豺狼不互认，不可以击杀、破坏或者使用管道。\n请求者完成所有任务之后，其与豺狼互认。,"(中立):\n船員,但是他們屬於豺狼陣營.\n豺狼和他們無法互相知道誰是叛徒,誰是狼\n當請求者做完任務時,豺狼和請求者將可以互相知道對方。"
 
 # HideAndSeek
 HASFoxInfoLong,(HideAndSeek):\nThey win the game with other Roles (except Troll) only if they are alive at the game end.,(かくれんぼ):\nトロールを除くいずれかの陣営が勝利したときに生き残っていれば、勝利した陣営に追加で勝利することができる。,（躲猫猫）:\n狐狸活到最后便与获胜阵营一同获胜。,"(躲貓貓):\n除了其他的中立陣營以外,只要狐妖活下來即可獲勝\n他們將跟著遊戲結束的獲勝陣營一起獲勝。"
@@ -265,6 +268,8 @@ DisableAdmin,Disable Admin,アドミン無効化,禁用管理员,禁用管理室
 WhichDisableAdmin,Unavailable Admins,無効なアドミン,禁用哪个管理员,管理室地圖分區禁用
 RandomSpawn,Random Spawn,ランダムスポーン,,
 AirshipAdditionalSpawn,Additional Spawn(Airship),追加スポーン位置(エアシップ),,
+JClientBereavementMode.None,None,なし,无,無
+JClientBereavementMode.Following,Following,後追い,追逐,追逐
 
 ## モード説明
 HideAndSeekInfo,"HideAndSeek:\nNo one can call emergency meeting, Crewmates (Blue) can win only by completing tasks\nand Impostors (Red) can win only by killing all the Crewmates.",かくれんぼ:\n会議を開くことはできず、クルーはタスク完了、インポスターは全クルー殺害でのみ勝利することができる。\nインポスターは赤、クルーは青に体の色が変更される。,躲猫猫:\n没有会议阶段；船员只能完成任务；\n内鬼需要杀死所有船员来获得胜利；\n内鬼的皮肤颜色将变为红色，船员变为蓝色，以示区分。,"躲貓貓:\n不能拍桌或舉報,船員只能做任務\n狼人的勝利條件為殺光所有船員\n狼人的身體顏色會轉變為紅色,船員則會變為藍色。"
@@ -344,6 +349,13 @@ TimeThiefReturnStolenTimeUponDeath,Return Stolen Time After Death,死亡後に�
 EvilTrackerCanSeeKillFlash,EvilTracker Can See The Flash Of Impostor Kills,インポスターキル時にフラッシュが見える,当内鬼进行击杀时邪恶的追踪者可以看到闪光
 EvilTrackerResetTargetAfterMeeting,EvilTracker Can Reset Target After Meeting,会議後に再度ターゲットを設定できる,会议后重置邪恶的追踪者追踪目标
 KillFlashDuration,Kill Flash Duration(s),キルフラッシュの長さ(秒)
+JClientHasImpostorVision,Client Have Impostor Vision,インポスターと同じ視界を持つ,请求者有内鬼视野,請求者有跟狼人一樣的視野
+JClientCanVent,Client Can Use Vent,ベントを使用できる,请求者可以使用管道,請求者可以使用管道
+JClientVentCooldown,Client Vent Cooldown,ベントクールダウン,请求者跳管道冷却时间,請求者跳管道冷卻
+JClientVentMaxTime,Client Max Time In Vents(s),ベント内での最大時間,请求者在管道中停留的最大时间,請求者在管道中可以停留的最大時間
+CanSeeTaskFinishedJClientFromJackal,Can see task finished Client from Jackal,タスクが終わるとジャッカルからも視認できる,任务完成后 豺狼也能看到,任務完成後 豺狼也能看到
+JClientBereavementMode,Jackal Bereavement Mode,ジャッカル死亡後のモード,豺狼丧亲模式,豺狼喪親模式
+JClientTasks,Client Tasks,タスク数,请求者任务数,請求者任務數量
 
 ## かくれんぼ設定
 HideAndSeekOptions,HideAndSeek Options,かくれんぼの設定,躲猫猫设置,躲貓貓設定
@@ -367,6 +379,7 @@ DeathReason.Sniped,Sniped,狙撃,狙杀,被狙
 DeathReason.Execution,Executed,処刑,处刑,處刑
 DeathReason.Disconnected,Disconnected,回線切断,断连,斷線
 DeathReason.Fall,Fall,転落,摔死,摔死
+DeathReason.JClientSuicide,Client Suicide,後追い,为交易而死,朋友一起死
 DeathReason.etc,etc,その他,其他,其他
 Alive,Alive,生存,存活,存活
 Win," Wins",勝利,胜利,勝利

--- a/Roles/Sheriff.cs
+++ b/Roles/Sheriff.cs
@@ -24,6 +24,7 @@ namespace TownOfHost
         public static CustomOption CanKillExecutioner;
         public static CustomOption CanKillJackal;
         public static CustomOption CanKillJSchrodingerCat;
+        public static CustomOption CanKillJClient;
 
         public static Dictionary<byte, float> ShotLimit = new();
         public static Dictionary<byte, float> CurrentKillCooldown = new();
@@ -56,6 +57,7 @@ namespace TownOfHost
             CanKillExecutioner = CustomOption.Create(Id + 21, TabGroup.CrewmateRoles, Color.white, "SheriffCanKill%role%", true, CanKillNeutrals, replacementDic: SheriffCanKillRole(CustomRoles.Executioner));
             CanKillJackal = CustomOption.Create(Id + 22, TabGroup.CrewmateRoles, Color.white, "SheriffCanKill%role%", true, CanKillNeutrals, replacementDic: SheriffCanKillRole(CustomRoles.Jackal));
             CanKillJSchrodingerCat = CustomOption.Create(Id + 23, TabGroup.CrewmateRoles, Color.white, "SheriffCanKill%role%", true, CanKillNeutrals, replacementDic: SheriffCanKillRole(CustomRoles.JSchrodingerCat));
+            CanKillJClient = CustomOption.Create(Id + 24, TabGroup.CrewmateRoles, Color.white, "SheriffCanKill%role%", true, CanKillNeutrals, replacementDic: SheriffCanKillRole(CustomRoles.JClient));
         }
         public static void Init()
         {
@@ -145,6 +147,7 @@ namespace TownOfHost
                 CustomRoles.EgoSchrodingerCat => CanKillEgoSchrodingerCat.GetBool(),
                 CustomRoles.Jackal => CanKillJackal.GetBool(),
                 CustomRoles.JSchrodingerCat => CanKillJSchrodingerCat.GetBool(),
+                CustomRoles.JClient => CanKillJClient.GetBool(),
                 CustomRoles.SchrodingerCat => true,
                 _ => cRole.GetRoleType() switch
                 {

--- a/main.cs
+++ b/main.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -218,6 +218,7 @@ namespace TownOfHost
                     {CustomRoles.EgoSchrodingerCat, "#5600ff"},
                     {CustomRoles.Jackal, "#00b4eb"},
                     {CustomRoles.JSchrodingerCat, "#00b4eb"},
+                    {CustomRoles.JClient, "#00b4eb"},
                     //HideAndSeek
                     {CustomRoles.HASFox, "#e478ff"},
                     {CustomRoles.HASTroll, "#00ff00"},
@@ -345,6 +346,7 @@ namespace TownOfHost
         Terrorist,
         Executioner,
         Jackal,
+        JClient,//Jクライアント ※Clientだがソース内ではJClientと表記
         JSchrodingerCat,//ジャッカル陣営のシュレディンガーの猫
         //HideAndSeek
         HASFox,


### PR DESCRIPTION
新役職「クライアント」追加
　ジャッカル陣営のマッドスニッチ

設定
・インポスターと同じ視界を持つ
・ベントを使用できる
・ベントクールダウン
・ベント内での最大時間
・タスクが終わるとジャッカルからも視認できる
・ジャッカル死亡後のモード
・クライアントのタスク数

以下の不具合対応を含む
・MODクライアントがスニッチでタスクを終了した場合、会議でジャッカル、エゴイストの名前の色が変わらない