### PR TITLE
ホストは死んでいてもキックとBANを可能に

### DIFF
--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -72,6 +72,20 @@ namespace TownOfHost
             if (ThisAssembly.Git.Branch != "main" && CultureInfo.CurrentCulture.Name != "ja-JP") canOnline = false;
         }
     }
+    [HarmonyPatch(typeof(BanMenu), nameof(BanMenu.SetVisible))]
+    class BanMenuSetVisiblePatch
+    {
+        public static bool Prefix(BanMenu __instance, bool show)
+        {
+            if (!AmongUsClient.Instance.AmHost) return true;
+            show &= PlayerControl.LocalPlayer && PlayerControl.LocalPlayer.Data != null;
+            __instance.BanButton.gameObject.SetActive(AmongUsClient.Instance.CanBan());
+            __instance.KickButton.gameObject.SetActive(AmongUsClient.Instance.CanKick());
+            __instance.MenuButton.gameObject.SetActive(show);
+            __instance.hotkeyGlyph.SetActive(show);
+            return false;
+        }
+    }
     [HarmonyPatch(typeof(InnerNet.InnerNetClient), nameof(InnerNet.InnerNetClient.CanBan))]
     class InnerNetClientCanBanPatch
     {

--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -72,4 +72,13 @@ namespace TownOfHost
             if (ThisAssembly.Git.Branch != "main" && CultureInfo.CurrentCulture.Name != "ja-JP") canOnline = false;
         }
     }
+    [HarmonyPatch(typeof(InnerNet.InnerNetClient), nameof(InnerNet.InnerNetClient.CanBan))]
+    class InnerNetClientCanBanPatch
+    {
+        public static bool Prefix(InnerNet.InnerNetClient __instance, ref bool __result)
+        {
+            __result = __instance.AmHost;
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
## 概要
本来、死亡しているときにキックを行うことが出来ないが、ホストのみ可能に変更。

## 変更点
- ゲームが開始してもBANを可能に変更
- ホストが死亡していてもBANとKICKを表示
- ゲーム中でもホストは投票を行わずに即時キックが可能