### PR TITLE
ミーティング中のBGMをミュート

### DIFF
--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -151,6 +151,7 @@ namespace TownOfHost
                         exiled.Object.RpcExileV2();
                     }
                 }, 0.5f, "Restore IsDead Task");
+            SoundManager.Instance.ChangeMusicVolume(SaveManager.MusicVolume);
             Logger.Info("タスクフェイズ開始", "Phase");
         }
     }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -230,6 +230,7 @@ namespace TownOfHost
         }
         public static void Postfix(MeetingHud __instance)
         {
+            SoundManager.Instance.ChangeMusicVolume(0f);
             foreach (var pva in __instance.playerStates)
             {
                 var pc = Utils.GetPlayerById(pva.TargetPlayerId);

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -12,6 +12,7 @@ namespace TownOfHost
             Logger.Info($"{__instance.GameId}に参加", "OnGameJoined");
             Main.playerVersion = new Dictionary<byte, PlayerVersion>();
             RPC.RpcVersionCheck();
+            SoundManager.Instance.ChangeMusicVolume(SaveManager.MusicVolume);
 
             NameColorManager.Begin();
             Options.Load();


### PR DESCRIPTION
## 概要
展望とかで会議に入るととてもうるさいので、会議中のみBGMを自動ミュートする。

## 備考
- 会議開始時から追放画面終了時までミュートされる
- 会議中に強制終了しても入室時に自動で音量がリストアされる