### PR TITLE
チャットコマンドでラストインポスターのキルクールの表示がInvalidを起こす問題を修正

### DIFF
--- a/Modules/OptionShower.cs
+++ b/Modules/OptionShower.cs
@@ -48,7 +48,7 @@ namespace TownOfHost
                     if (Options.EnableLastImpostor.GetBool())
                     {
                         text += $"<color={Utils.GetRoleColorCode(CustomRoles.LastImpostor)}>{Utils.GetRoleName(CustomRoles.LastImpostor)}:</color> {Options.EnableLastImpostor.GetString()}\n";
-                        text += $"\t{GetString("LastImpostorKillCooldown")}: {Options.LastImpostorKillCooldown.GetString()}\n\n";
+                        text += $"\t{GetString("KillCooldown")}: {Options.LastImpostorKillCooldown.GetString()}\n\n";
                     }
                 }
                 nameAndValue(Options.EnableGM);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -430,7 +430,7 @@ namespace TownOfHost
                     }
                     text += "\n";
                 }
-                if (Options.EnableLastImpostor.GetBool()) text += String.Format("\n{0}:{1}", GetString("LastImpostorKillCooldown"), Options.LastImpostorKillCooldown.GetString());
+                if (Options.EnableLastImpostor.GetBool()) text += String.Format("\n{0}:{1}", GetString("KillCooldown"), Options.LastImpostorKillCooldown.GetString());
                 if ((CustomRoles.EvilTracker.IsEnable() && EvilTracker.CanSeeKillFlash.GetBool())
                 || CustomRoles.Seer.IsEnable())
                     text += String.Format("\n{0}:{1}", GetString("KillFlashDuration"), Options.KillFlashDuration.GetString());


### PR DESCRIPTION
LastImpostorKillCooldownからKillCooldownに変更