### PR TITLE
Fix/CustomWinnerHolder

### DIFF
--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -26,6 +26,30 @@ namespace TownOfHost
             WinnerRoles = new();
             WinnerIds = new();
         }
+        public static void ClearWinners()
+        {
+            WinnerRoles.Clear();
+            WinnerIds.Clear();
+        }
+        /// <summary><para>WinnerTeamに値を代入します。</para><para>すでに代入されている場合、AdditionalWinnerTeamsに追加します。</para></summary>
+        public static void SetWinnerOrAdditonalWinner(CustomWinner winner)
+        {
+            if (WinnerTeam == CustomWinner.Default) WinnerTeam = winner;
+            else AdditionalWinnerTeams.Add((AdditionalWinners)winner);
+        }
+        /// <summary><para>WinnerTeamに値を代入します。</para><para>すでに代入されている場合、既存の値をAdditionalWinnerTeamsに追加してから代入します。</para></summary>
+        public static void ShiftWinnerAndSetWinner(CustomWinner winner)
+        {
+            if (WinnerTeam != CustomWinner.Default)
+                AdditionalWinnerTeams.Add((AdditionalWinners)WinnerTeam);
+            WinnerTeam = winner;
+        }
+        /// <summary><para>既存の値をすべて削除してから、WinnerTeamに値を代入します。</para></summary>
+        public static void ResetAndSetWinner(CustomWinner winner)
+        {
+            Reset();
+            WinnerTeam = winner;
+        }
 
         public static MessageWriter WriteTo(MessageWriter writer)
         {

--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -7,6 +7,7 @@ namespace TownOfHost
     {
         // 勝者のチームが格納されます。
         // リザルトの背景色の決定などに使用されます。
+        // 注: この変数を変更する時、WinnerRoles・WinnerIdsを同時に変更しないと予期せぬ勝者が現れる可能性があります。
         public static CustomWinner WinnerTeam;
         // 追加勝利するプレイヤーのチームが格納されます。
         // リザルトの表示に使用されます。

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -558,7 +558,7 @@ namespace TownOfHost
                         PlayerState.SetDead(pc.PlayerId);
                     }
                 }
-                CustomWinnerHolder.WinnerTeam = CustomWinner.Terrorist;
+                CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Terrorist);
                 CustomWinnerHolder.WinnerIds.Add(Terrorist.PlayerId);
             }
         }

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -45,7 +45,7 @@ namespace TownOfHost
             //廃村
             if (GetKeysDown(new[] { KeyCode.Return, KeyCode.L, KeyCode.LeftShift }) && GameStates.IsInGame)
             {
-                CustomWinnerHolder.WinnerTeam = CustomWinner.Draw;
+                CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Draw);
             }
             //ミーティングを強制終了
             if (GetKeysDown(new[] { KeyCode.Return, KeyCode.M, KeyCode.LeftShift }) && GameStates.IsMeeting)

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -54,7 +54,7 @@ namespace TownOfHost
                 var role = exiled.GetCustomRole();
                 if (role == CustomRoles.Jester && AmongUsClient.Instance.AmHost)
                 {
-                    CustomWinnerHolder.WinnerTeam = CustomWinner.Jester;
+                    CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Jester);
                     CustomWinnerHolder.WinnerIds.Add(exiled.PlayerId);
                     //吊られたJesterをターゲットにしているExecutionerも追加勝利
                     foreach (var executioner in Executioner.playerIdList)
@@ -62,8 +62,8 @@ namespace TownOfHost
                         var GetValue = Executioner.Target.TryGetValue(executioner, out var targetId);
                         if (GetValue && exiled.PlayerId == targetId)
                         {
-                            CustomWinnerHolder.WinnerIds.Add(executioner);
                             CustomWinnerHolder.AdditionalWinnerTeams.Add(AdditionalWinners.Executioner);
+                            CustomWinnerHolder.WinnerIds.Add(executioner);
                         }
                     }
                     DecidedWinner = true;

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -1110,7 +1110,7 @@ namespace TownOfHost
                                 RPC.PlaySoundRPC(pc.PlayerId, Sounds.KillSound);
                         }
                     }
-                    CustomWinnerHolder.WinnerTeam = CustomWinner.Arsonist;
+                    CustomWinnerHolder.ShiftWinnerAndSetWinner(CustomWinner.Arsonist); //焼殺で勝利した人も勝利させる
                     CustomWinnerHolder.WinnerIds.Add(__instance.myPlayer.PlayerId);
                     return true;
                 }

--- a/Roles/Executioner.cs
+++ b/Roles/Executioner.cs
@@ -91,7 +91,8 @@ namespace TownOfHost
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
                     break;
                 case "WinCheck":
-                    CustomWinnerHolder.WinnerTeam = CustomWinner.Executioner;
+                    if (CustomWinnerHolder.WinnerTeam != CustomWinner.Default) break; //まだ勝者が設定されていない場合
+                    CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Executioner);
                     CustomWinnerHolder.WinnerIds.Add(executionerId);
                     break;
             }


### PR DESCRIPTION
アーソニストとテロリストが同時に勝利する元バグの表示の正常化と、それにより露呈した勝者リスト関連のバグの対策です。
# 変更点
- 勝者を指定する3種類の関数を作成
- WinnerTeamへの代入処理のほとんどを関数に置き換え
- 現時点でアーソニスト勝利の処理のみShiftWinnerAndSetWinnerを使用しています。