### PR TITLE
解像度に1920x1080を追加

### DIFF
--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -10,7 +10,7 @@ namespace TownOfHost
     {
         static readonly System.Random random = new();
         static PlayerControl bot;
-        static readonly (int, int)[] resolutions = { (480, 270), (640, 360), (800, 450), (1280, 720), (1600, 900) };
+        static readonly (int, int)[] resolutions = { (480, 270), (640, 360), (800, 450), (1280, 720), (1600, 900), (1920, 1080) };
         static int resolutionIndex = 0;
         public static void Postfix(ControllerManager __instance)
         {


### PR DESCRIPTION
## 概要
UnityExplore等でオブジェクトを見るときに1600x900だと狭いので、F11で変えられる解像度のリストに1920x1080を追加。