### PR TITLE
CustomOptionsのGetBoolの改善

### DIFF
--- a/Modules/CustomOption.cs
+++ b/Modules/CustomOption.cs
@@ -218,7 +218,7 @@ namespace TownOfHost
 
         public bool GetBool()
         {
-            return Selection > 0;
+            return Selection > 0 && (Parent == null || Parent.GetBool());
         }
 
         public float GetFloat()


### PR DESCRIPTION
## 概要
CustomOptionsでGetBoolをしたときに親が存在し、親がFalseならFalseを返すように変更。