### PR TITLE
DisableAdminのオプションを細分化

### DIFF
--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -47,21 +47,29 @@ namespace TownOfHost
                             //アドミンチェック
                             if ((AdminPatch.DisableAdmin || Options.IsStandardHAS) && pc.IsAlive())
                             {
-                                if (AdminPatch.DisableAllAdmins || Options.IsStandardHAS)
+                                float distance;
+                                switch (PlayerControl.GameOptions.MapId)
                                 {
-                                    var AdminDistance = Vector2.Distance(PlayerPos, GetAdminTransform());
-                                    IsGuard = AdminDistance <= UsableDistance();
-
-                                    if (!IsGuard && PlayerControl.GameOptions.MapId == 2) //Polus用のアドミンチェック。Polusはアドミンが2つあるから
-                                    {
-                                        var SecondaryPolusAdminDistance = Vector2.Distance(PlayerPos, AdminPatch.SecondaryPolusAdminPos);
-                                        IsGuard = SecondaryPolusAdminDistance <= UsableDistance();
-                                    }
-                                }
-                                if (!IsGuard && (AdminPatch.DisableAllAdmins || AdminPatch.DisableArchiveAdmin || Options.IsStandardHAS)) //憎きアーカイブのアドミンチェック
-                                {
-                                    var ArchiveAdminDistance = Vector2.Distance(PlayerPos, AdminPatch.ArchiveAdminPos);
-                                    IsGuard = ArchiveAdminDistance <= UsableDistance();
+                                    case 0:
+                                        distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["SkeldAdmin"]);
+                                        IsGuard = distance <= UsableDistance();
+                                        break;
+                                    case 1:
+                                        distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["MiraHQAdmin"]);
+                                        IsGuard = distance <= UsableDistance();
+                                        break;
+                                    case 2:
+                                        distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["PolusLeftAdmin"]);
+                                        IsGuard = distance <= UsableDistance();
+                                        distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["PolusRightAdmin"]);
+                                        IsGuard = distance <= UsableDistance() || IsGuard;
+                                        break;
+                                    case 4:
+                                        distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["AirshipCockpitAdmin"]);
+                                        IsGuard = distance <= UsableDistance();
+                                        distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["AirshipRecordsAdmin"]);
+                                        IsGuard = distance <= UsableDistance();
+                                        break;
                                 }
                             }
                             if (IsGuard && !pc.inVent)

--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -121,18 +121,5 @@ namespace TownOfHost
                 }
             }
         }
-        public static Vector2 GetAdminTransform()
-        {
-            var MapName = (MapNames)PlayerControl.GameOptions.MapId;
-            return MapName switch
-            {
-                MapNames.Skeld => new Vector2(3.48f, -8.624401f),
-                //MapNames.Mira => new Vector2(20.524f, 20.595f),
-                MapNames.Polus => new Vector2(22.13707f, -21.523f),
-                //MapNames.Dleks => new Vector2(-3.48f, -8.624401f),
-                MapNames.Airship => new Vector2(-22.323f, 0.9099998f),
-                _ => new Vector2(1000, 1000)
-            };
-        }
     }
 }

--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -17,7 +17,7 @@ namespace TownOfHost
             return Map switch
             {
                 MapNames.Skeld => 1.5f,
-                //MapNames.Mira => 2.2f,
+                MapNames.Mira => 2.2f,
                 MapNames.Polus => 1.5f,
                 //MapNames.Dleks => 1.5f,
                 MapNames.Airship => 1.5f,

--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -83,34 +83,15 @@ namespace TownOfHost
                                 SabotageFixWriter.Write((byte)128);
                                 AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
                             }
-                            else
+                            else if (!Utils.IsActive(SystemTypes.Comms) && OldDesyncCommsPlayers.Contains(pc.PlayerId))
                             {
-                                if (!Utils.IsActive(SystemTypes.Comms) && OldDesyncCommsPlayers.Contains(pc.PlayerId))
-                                {
-                                    OldDesyncCommsPlayers.Remove(pc.PlayerId);
+                                OldDesyncCommsPlayers.Remove(pc.PlayerId);
 
-                                    /*var sender = CustomRpcSender.Create("DisableDevice", SendOption.Reliable);
-
-                                    sender.AutoStartRpc(ShipStatus.Instance.NetId, (byte)RpcCalls.RepairSystem, clientId)
-                                            .Write((byte)SystemTypes.Comms)
-                                            .WriteNetObject(pc)
-                                            .Write((byte)16)
-                                            .EndRpc();
-                                    if (PlayerControl.GameOptions.MapId == 2)
-                                        sender.AutoStartRpc(ShipStatus.Instance.NetId, (byte)RpcCalls.RepairSystem, clientId)
-                                                .Write((byte)SystemTypes.Comms)
-                                                .WriteNetObject(pc)
-                                                .Write((byte)17)
-                                                .EndRpc();
-
-                                    sender.SendMessage();*/
-
-                                    MessageWriter SabotageFixWriter = AmongUsClient.Instance.StartRpcImmediately(ShipStatus.Instance.NetId, (byte)RpcCalls.RepairSystem, SendOption.Reliable, clientId);
-                                    SabotageFixWriter.Write((byte)SystemTypes.Comms);
-                                    MessageExtensions.WriteNetObject(SabotageFixWriter, pc);
-                                    SabotageFixWriter.Write((byte)16);
-                                    AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
-                                }
+                                MessageWriter SabotageFixWriter = AmongUsClient.Instance.StartRpcImmediately(ShipStatus.Instance.NetId, (byte)RpcCalls.RepairSystem, SendOption.Reliable, clientId);
+                                SabotageFixWriter.Write((byte)SystemTypes.Comms);
+                                MessageExtensions.WriteNetObject(SabotageFixWriter, pc);
+                                SabotageFixWriter.Write((byte)16);
+                                AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
                             }
                         }
                     }

--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -62,13 +62,13 @@ namespace TownOfHost
                                         distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["PolusLeftAdmin"]);
                                         IsGuard = distance <= UsableDistance();
                                         distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["PolusRightAdmin"]);
-                                        IsGuard = distance <= UsableDistance() || IsGuard;
+                                        IsGuard |= distance <= UsableDistance();
                                         break;
                                     case 4:
                                         distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["AirshipCockpitAdmin"]);
                                         IsGuard = distance <= UsableDistance();
                                         distance = Vector2.Distance(PlayerPos, AdminPatch.AdminPos["AirshipRecordsAdmin"]);
-                                        IsGuard = distance <= UsableDistance();
+                                        IsGuard |= distance <= UsableDistance();
                                         break;
                                 }
                             }

--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -92,6 +92,15 @@ namespace TownOfHost
                                 MessageExtensions.WriteNetObject(SabotageFixWriter, pc);
                                 SabotageFixWriter.Write((byte)16);
                                 AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
+
+                                if (PlayerControl.GameOptions.MapId == 1)
+                                {
+                                    SabotageFixWriter = AmongUsClient.Instance.StartRpcImmediately(ShipStatus.Instance.NetId, (byte)RpcCalls.RepairSystem, SendOption.Reliable, clientId);
+                                    SabotageFixWriter.Write((byte)SystemTypes.Comms);
+                                    MessageExtensions.WriteNetObject(SabotageFixWriter, pc);
+                                    SabotageFixWriter.Write((byte)17);
+                                    AmongUsClient.Instance.FinishRpcImmediately(SabotageFixWriter);
+                                }
                             }
                         }
                     }

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -35,11 +35,6 @@ namespace TownOfHost
             "Standard", "HideAndSeek",
         };
 
-        public static readonly string[] whichDisableAdmin =
-        {
-            "All", "Archive",
-        };
-
         // 役職数・確率
         public static Dictionary<CustomRoles, int> roleCounts;
         public static Dictionary<CustomRoles, float> roleSpawnChances;
@@ -110,7 +105,11 @@ namespace TownOfHost
         //デバイスブロック
         public static CustomOption DisableDevices;
         public static CustomOption DisableAdmin;
-        public static CustomOption WhichDisableAdmin;
+        public static CustomOption DisableSkeldAdmin;
+        public static CustomOption DisableMiraHQAdmin;
+        public static CustomOption DisablePolusAdmin;
+        public static CustomOption DisableAirshipCockpitAdmin;
+        public static CustomOption DisableAirshipRecordsAdmin;
 
         // ボタン回数
         public static CustomOption SyncButtonMode;
@@ -395,7 +394,15 @@ namespace TownOfHost
                 .SetGameMode(CustomGameMode.Standard);
             DisableAdmin = CustomOption.Create(101210, TabGroup.MainSettings, Color.white, "DisableAdmin", false, DisableDevices)
                 .SetGameMode(CustomGameMode.Standard);
-            WhichDisableAdmin = CustomOption.Create(101211, TabGroup.MainSettings, Color.white, "WhichDisableAdmin", whichDisableAdmin, whichDisableAdmin[0], DisableAdmin)
+            DisableSkeldAdmin = CustomOption.Create(101211, TabGroup.MainSettings, Color.white, "DisableSkeldAdmin", false, DisableAdmin)
+                .SetGameMode(CustomGameMode.Standard);
+            DisableMiraHQAdmin = CustomOption.Create(101212, TabGroup.MainSettings, Color.white, "DisableMiraHQAdmin", false, DisableAdmin)
+                .SetGameMode(CustomGameMode.Standard);
+            DisablePolusAdmin = CustomOption.Create(101213, TabGroup.MainSettings, Color.white, "DisablePolusAdmin", false, DisableAdmin)
+                .SetGameMode(CustomGameMode.Standard);
+            DisableAirshipCockpitAdmin = CustomOption.Create(101214, TabGroup.MainSettings, Color.white, "DisableAirshipCockpitAdmin", false, DisableAdmin)
+                .SetGameMode(CustomGameMode.Standard);
+            DisableAirshipRecordsAdmin = CustomOption.Create(101215, TabGroup.MainSettings, Color.white, "DisableAirshipRecordsAdmin", false, DisableAdmin)
                 .SetGameMode(CustomGameMode.Standard);
 
             // ボタン回数同期

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -438,11 +438,11 @@ namespace TownOfHost
                 {
                     if (Options.DisableAdmin.GetBool())
                     {
-                        text += String.Format("\n{0}:{1}", Options.DisableSkeldAdmin.GetName(disableColor: true), Options.DisableSkeldAdmin.GetString());
-                        text += String.Format("\n{0}:{1}", Options.DisableMiraHQAdmin.GetName(disableColor: true), Options.DisableMiraHQAdmin.GetString());
-                        text += String.Format("\n{0}:{1}", Options.DisablePolusAdmin.GetName(disableColor: true), Options.DisablePolusAdmin.GetString());
-                        text += String.Format("\n{0}:{1}", Options.DisableAirshipCockpitAdmin.GetName(disableColor: true), Options.DisableAirshipCockpitAdmin.GetString());
-                        text += String.Format("\n{0}:{1}", Options.DisableAirshipRecordsAdmin.GetName(disableColor: true), Options.DisableAirshipRecordsAdmin.GetString());
+                        text += String.Format("\n{0}:{1}", Options.DisableSkeldAdmin.GetName(disableColor: true), GetOnOff(Options.DisableSkeldAdmin.GetBool()));
+                        text += String.Format("\n{0}:{1}", Options.DisableMiraHQAdmin.GetName(disableColor: true), GetOnOff(Options.DisableMiraHQAdmin.GetBool()));
+                        text += String.Format("\n{0}:{1}", Options.DisablePolusAdmin.GetName(disableColor: true), GetOnOff(Options.DisablePolusAdmin.GetBool()));
+                        text += String.Format("\n{0}:{1}", Options.DisableAirshipCockpitAdmin.GetName(disableColor: true), GetOnOff(Options.DisableAirshipCockpitAdmin.GetBool()));
+                        text += String.Format("\n{0}:{1}", Options.DisableAirshipRecordsAdmin.GetName(disableColor: true), GetOnOff(Options.DisableAirshipRecordsAdmin.GetBool()));
                     }
                 }
                 if (Options.SyncButtonMode.GetBool()) text += String.Format("\n{0}:{1}", GetString("SyncedButtonCount"), Options.SyncedButtonCount.GetInt());

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -436,7 +436,14 @@ namespace TownOfHost
                     text += String.Format("\n{0}:{1}", GetString("KillFlashDuration"), Options.KillFlashDuration.GetString());
                 if (Options.DisableDevices.GetBool())
                 {
-                    if (Options.DisableDevices.GetBool()) text += String.Format("\n{0}:{1}", Options.DisableAdmin.GetName(disableColor: true), Options.WhichDisableAdmin.GetString());
+                    if (Options.DisableAdmin.GetBool())
+                    {
+                        text += String.Format("\n{0}:{1}", Options.DisableSkeldAdmin.GetName(disableColor: true), Options.DisableSkeldAdmin.GetString());
+                        text += String.Format("\n{0}:{1}", Options.DisableMiraHQAdmin.GetName(disableColor: true), Options.DisableMiraHQAdmin.GetString());
+                        text += String.Format("\n{0}:{1}", Options.DisablePolusAdmin.GetName(disableColor: true), Options.DisablePolusAdmin.GetString());
+                        text += String.Format("\n{0}:{1}", Options.DisableAirshipCockpitAdmin.GetName(disableColor: true), Options.DisableAirshipCockpitAdmin.GetString());
+                        text += String.Format("\n{0}:{1}", Options.DisableAirshipRecordsAdmin.GetName(disableColor: true), Options.DisableAirshipRecordsAdmin.GetString());
+                    }
                 }
                 if (Options.SyncButtonMode.GetBool()) text += String.Format("\n{0}:{1}", GetString("SyncedButtonCount"), Options.SyncedButtonCount.GetInt());
                 if (Options.SabotageTimeControl.GetBool())

--- a/Patches/Devices/Admin.cs
+++ b/Patches/Devices/Admin.cs
@@ -25,4 +25,32 @@ namespace TownOfHost
             ["AirshipRecordsAdmin"] = new(19.89f, 12.60f)
         };
     }
+    [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Start))]
+    public class RemoveAdminPatch
+    {
+        public static void Postfix()
+        {
+            if (!AdminPatch.DisableAdmin) return;
+            var map = GameObject.FindObjectsOfType<MapConsole>();
+            if (map == null) return;
+            switch (PlayerControl.GameOptions.MapId)
+            {
+                case 0:
+                case 1:
+                    map[0].gameObject.GetComponent<CircleCollider2D>().enabled = false;
+                    break;
+                case 2:
+                    map.Do(x => x.gameObject.GetComponent<BoxCollider2D>().enabled = false);
+                    break;
+                case 4:
+                    map.Do(x =>
+                    {
+                        if (Options.DisableAirshipCockpitAdmin.GetBool() && x.name == "panel_cockpit_map" ||
+                            Options.DisableAirshipRecordsAdmin.GetBool() && x.name == "records_admin_map")
+                            x.gameObject.GetComponent<BoxCollider2D>().enabled = false;
+                    });
+                    break;
+            }
+        }
+    }
 }

--- a/Patches/Devices/Admin.cs
+++ b/Patches/Devices/Admin.cs
@@ -1,6 +1,6 @@
+using System.Collections.Generic;
 using HarmonyLib;
 using UnityEngine;
-using static TownOfHost.Translator;
 
 namespace TownOfHost
 {
@@ -24,55 +24,5 @@ namespace TownOfHost
             ["AirshipCockpitAdmin"] = new(-22.32f, 0.91f),
             ["AirshipRecordsAdmin"] = new(19.89f, 12.60f)
         };
-        private static TMPro.TextMeshPro DisabledText;
-        [HarmonyPatch(typeof(MapCountOverlay), nameof(MapCountOverlay.Update))]
-        public static class MapCountOverlayUpdatePatch
-        {
-            public static bool Prefix(MapCountOverlay __instance)
-            {
-                if (DisabledText == null)
-                    DisabledText = Object.Instantiate(__instance.SabotageText, __instance.SabotageText.transform.parent);
-                bool isGuard = false;
-
-                DisabledText.gameObject.SetActive(false);
-                if (PlayerControl.LocalPlayer.IsAlive())
-                {
-                    if (DisableAdmin)
-                    {
-                        var PlayerPos = PlayerControl.LocalPlayer.GetTruePosition();
-                        if (DisableAllAdmins)
-                        {
-                            var AdminDistance = Vector2.Distance(PlayerPos, DisableDevice.GetAdminTransform());
-                            isGuard = AdminDistance <= DisableDevice.UsableDistance();
-
-                            if (!isGuard && PlayerControl.GameOptions.MapId == 2) //Polus用のアドミンチェック。Polusはアドミンが2つあるから
-                            {
-                                var SecondaryPolusAdminDistance = Vector2.Distance(PlayerPos, SecondaryPolusAdminPos);
-                                isGuard = SecondaryPolusAdminDistance <= DisableDevice.UsableDistance();
-                            }
-                        }
-
-                        if (!isGuard && (DisableAllAdmins || DisableArchiveAdmin)) //憎きアーカイブのアドミンチェック
-                        {
-                            var ArchiveAdminDistance = Vector2.Distance(PlayerPos, ArchiveAdminPos);
-                            isGuard = ArchiveAdminDistance <= DisableDevice.UsableDistance();
-                        }
-                    }
-                    if (Options.StandardHAS.GetBool()) isGuard = true;
-                }
-                if (isGuard)
-                {
-                    __instance.SabotageText.gameObject.SetActive(false);
-
-                    __instance.BackgroundColor.SetColor(Palette.DisabledGrey);
-                    __instance.SabotageText.gameObject.SetActive(false);
-                    DisabledText.gameObject.SetActive(true);
-                    DisabledText.text = GetString("DisabledBySettings");
-                    return false;
-                }
-
-                return true;
-            }
-        }
     }
 }

--- a/Patches/Devices/Admin.cs
+++ b/Patches/Devices/Admin.cs
@@ -7,7 +7,14 @@ namespace TownOfHost
     public class AdminPatch
     {
         //参考元 : https://github.com/yukinogatari/TheOtherRoles-GM/blob/gm-main/TheOtherRoles/Patches/AdminPatch.cs
-        public static bool DisableAdmin => DisableAllAdmins || DisableArchiveAdmin;
+        public static bool DisableAdmin => PlayerControl.GameOptions.MapId switch
+        {
+            0 => Options.DisableSkeldAdmin.GetBool(),
+            1 => Options.DisableMiraHQAdmin.GetBool(),
+            2 => Options.DisablePolusAdmin.GetBool(),
+            4 => Options.DisableAirshipCockpitAdmin.GetBool() || Options.DisableAirshipRecordsAdmin.GetBool(),
+            _ => false
+        };
         public static bool DisableAllAdmins => Options.DisableAdmin.GetBool() && Options.WhichDisableAdmin.GetString() == GetString(Options.whichDisableAdmin[0]);
         public static bool DisableArchiveAdmin => Options.DisableAdmin.GetBool() && PlayerControl.GameOptions.MapId == 4 && Options.WhichDisableAdmin.GetString() == GetString(Options.whichDisableAdmin[1]);
         public static Vector2 ArchiveAdminPos = new(20.0f, 12.3f);

--- a/Patches/Devices/Admin.cs
+++ b/Patches/Devices/Admin.cs
@@ -15,8 +15,6 @@ namespace TownOfHost
             4 => Options.DisableAirshipCockpitAdmin.GetBool() || Options.DisableAirshipRecordsAdmin.GetBool(),
             _ => false
         };
-        public static bool DisableAllAdmins => Options.DisableAdmin.GetBool() && Options.WhichDisableAdmin.GetString() == GetString(Options.whichDisableAdmin[0]);
-        public static bool DisableArchiveAdmin => Options.DisableAdmin.GetBool() && PlayerControl.GameOptions.MapId == 4 && Options.WhichDisableAdmin.GetString() == GetString(Options.whichDisableAdmin[1]);
         public static Vector2 ArchiveAdminPos = new(20.0f, 12.3f);
         public static Vector2 SecondaryPolusAdminPos = new(24.66107f, -21.523f);
         private static TMPro.TextMeshPro DisabledText;

--- a/Patches/Devices/Admin.cs
+++ b/Patches/Devices/Admin.cs
@@ -15,8 +15,15 @@ namespace TownOfHost
             4 => Options.DisableAirshipCockpitAdmin.GetBool() || Options.DisableAirshipRecordsAdmin.GetBool(),
             _ => false
         };
-        public static Vector2 ArchiveAdminPos = new(20.0f, 12.3f);
-        public static Vector2 SecondaryPolusAdminPos = new(24.66107f, -21.523f);
+        public static readonly Dictionary<string, Vector2> AdminPos = new()
+        {
+            ["SkeldAdmin"] = new(3.48f, -8.62f),
+            ["MiraHQAdmin"] = new(21.02f, 19.09f),
+            ["PolusLeftAdmin"] = new(23.14f, -21.52f),
+            ["PolusRightAdmin"] = new(24.66f, -21.52f),
+            ["AirshipCockpitAdmin"] = new(-22.32f, 0.91f),
+            ["AirshipRecordsAdmin"] = new(19.89f, 12.60f)
+        };
         private static TMPro.TextMeshPro DisabledText;
         [HarmonyPatch(typeof(MapCountOverlay), nameof(MapCountOverlay.Update))]
         public static class MapCountOverlayUpdatePatch

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -268,7 +268,11 @@ TieMode.All,All,Все,全員,全员,
 TieMode.Random,Random,Случайно,ランダム,随机,
 DisableDevices,Disable Devices,Отключить Устройства,デバイスを無効化,禁用设备,禁用裝置
 DisableAdmin,Disable Admin,Отключить Стол Администратора,アドミン無効化,禁用管理员,禁用管理室地圖
-WhichDisableAdmin,Unavailable Admins,Недоступные Столы Администратора,無効なアドミン,禁用哪个管理员,管理室地圖分區禁用
+DisableSkeldAdmin,Disable Skeld Admin,,アドミン無効化（スケルド）,,
+DisableMiraHQAdmin,Disable MiraHQ Admin,,アドミン無効化（ミラHQ）,,
+DisablePolusAdmin,Disable Polus Admin,,アドミン無効化（ポーラス）,,
+DisableAirshipCockpitAdmin,Disable Airship Cockpit Admin,,アドミン無効化（コックピット）,,
+DisableAirshipRecordsAdmin,Disable Airship Records Admin,,アドミン無効化（アーカイブ）,,
 RandomSpawn,Random Spawn,Случайный Спавн,ランダムスポーン,随机出生点,
 AirshipAdditionalSpawn,Additional Spawn(Airship),Дополнительный Спавн(Airship),追加スポーン位置(エアシップ),额外出生点（飞船地图）,
 


### PR DESCRIPTION
## 概要
DisableAdminのオプションをアドミンごとに有効/無効を変えられるように細分化。

また、MODクライアントはアドミンを開けないように変更。

## 変更点
- アドミンごとに切り替えオプションを追加
- MiraHQ用のコミュサボ解除処理を追加
- 無効化時ホストのアドミンから使用判定の削除