### PR TITLE
カスタム翻訳ファイルに無効なキーで発生する例外を修正

### DIFF
--- a/Modules/Translator.cs
+++ b/Modules/Translator.cs
@@ -114,7 +114,14 @@ namespace TownOfHost
                     tmp = text.Split(":");
                     if (tmp.Length > 1 && tmp[1] != "")
                     {
-                        tr[tmp[0]][(int)lang] = tmp.Skip(1).Join(delimiter: ":").Replace("\\n", "\n").Replace("\\r", "\r");
+                        try
+                        {
+                            tr[tmp[0]][(int)lang] = tmp.Skip(1).Join(delimiter: ":").Replace("\\n", "\n").Replace("\\r", "\r");
+                        }
+                        catch (KeyNotFoundException)
+                        {
+                            Logger.Warn($"「{tmp[0]}」は有効なキーではありません。", "LoadCustomTranslation");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 概要
カスタム翻訳ファイルに無効なキーが含まれていた場合、キーが見つからずに例外が発生する問題を修正。

## 修正
- 無効なキーの際に警告をログに出力し読み込みを続行