### PR TITLE
Executioner.csのCopyrightテキストを削除

### DIFF
--- a/Roles/Executioner.cs
+++ b/Roles/Executioner.cs
@@ -1,9 +1,3 @@
-/*
-* Executioner.cs created on Wed Aug 31 2022
-* This software is released under the GNU General Public License v3.0.
-* Copyright (c) 2022 空き瓶/EmptyBottle
-*/
-
 using System.Collections.Generic;
 using UnityEngine;
 using HarmonyLib;


### PR DESCRIPTION
CopyrightはGPLと離れるから不適切