### PR TITLE
シェリフのイントロにImpostorTextが表示されるように

### DIFF
--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -148,6 +148,12 @@ namespace TownOfHost
                 case CustomRoles.Sheriff:
                     PlayerControl.LocalPlayer.Data.Role.IntroSound = GetIntroSound(RoleTypes.Crewmate);
                     __instance.BackgroundBar.material.color = Palette.CrewmateBlue;
+                    __instance.ImpostorText.gameObject.SetActive(true);
+                    var numImpostors = Main.NormalOptions.NumImpostors;
+                    __instance.ImpostorText.text = numImpostors == 1
+                        ? DestroyableSingleton<TranslationController>.Instance.GetString(StringNames.NumImpostorsS)
+                        : __instance.ImpostorText.text = string.Format(DestroyableSingleton<TranslationController>.Instance.GetString(StringNames.NumImpostorsP), numImpostors);
+                    __instance.ImpostorText.text = __instance.ImpostorText.text.Replace("[FF1919FF]", "<color=#FF1919FF>").Replace("[]", "</color>");
                     break;
                 case CustomRoles.Arsonist:
                     PlayerControl.LocalPlayer.Data.Role.IntroSound = GetIntroSound(RoleTypes.Crewmate);


### PR DESCRIPTION
Mod導入済み非ホストプレイヤーがシェリフのとき，イントロにImpostorText(`この中にインポスターがn人いる`)が表示されていなかった事象の修正
処理はアモアス本体のコードを軽く書き直したものです