### PR TITLE
新オプション/エアシップにおけるランダムスポーンのタイミングを同期

### DIFF
--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -162,6 +162,7 @@ namespace TownOfHost
         // ランダムスポーン
         public static OptionItem RandomSpawn;
         public static OptionItem AirshipAdditionalSpawn;
+        public static OptionItem AirshipSynchronizeSpawn;
 
         // 投票モード
         public static OptionItem VoteMode;
@@ -569,6 +570,8 @@ namespace TownOfHost
                 .SetHeader(true)
                 .SetGameMode(CustomGameMode.All);
             AirshipAdditionalSpawn = BooleanOptionItem.Create(101301, "AirshipAdditionalSpawn", false, TabGroup.MainSettings, false).SetParent(RandomSpawn)
+                .SetGameMode(CustomGameMode.All);
+            AirshipSynchronizeSpawn = BooleanOptionItem.Create(101302, "AirshipSynchronizeSpawn", false, TabGroup.MainSettings, false).SetParent(RandomSpawn)
                 .SetGameMode(CustomGameMode.All);
 
             // ボタン回数同期

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -80,10 +80,7 @@ namespace TownOfHost
                 }
                 AntiBlackout.OnDisconnect(data.Character.Data);
                 PlayerGameOptionsSender.RemoveSender(data.Character);
-                if (Options.AirshipSynchronizeSpawn.GetBool() && RandomSpawn.IsProcessing && RandomSpawn.IsSpawnReady)
-                {
-                    RandomSpawn.SpawnAll();
-                }
+                RandomSpawn.OnDisconnect();
             }
             Logger.Info($"{data.PlayerName}(ClientID:{data.Id})が切断(理由:{reason}, ping:{AmongUsClient.Instance.Ping})", "Session");
         }

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -80,6 +80,10 @@ namespace TownOfHost
                 }
                 AntiBlackout.OnDisconnect(data.Character.Data);
                 PlayerGameOptionsSender.RemoveSender(data.Character);
+                if (Options.AirshipSynchronizeSpawn.GetBool() && RandomSpawn.IsProcessing && RandomSpawn.IsSpawnReady)
+                {
+                    RandomSpawn.SpawnAll();
+                }
             }
             Logger.Info($"{data.PlayerName}(ClientID:{data.Id})が切断(理由:{reason}, ping:{AmongUsClient.Instance.Ping})", "Session");
         }

--- a/Patches/RandomSpawnPatch.cs
+++ b/Patches/RandomSpawnPatch.cs
@@ -43,7 +43,6 @@ namespace TownOfHost
                         if (Options.FixFirstKillCooldown.GetBool() && !MeetingStates.MeetingCalled) player.SetKillCooldown(Main.AllPlayerKillCooldown[player.PlayerId]);
                         if (!Options.RandomSpawn.GetBool()) return; //ランダムスポーンが無効ならreturn
 
-                        if (player.IsAlive()) AirshipSpawnedPlayerCount++;
                         if (Options.AirshipSynchronizeSpawn.GetBool()) AirshipSynchronizedRandomTeleport(player);
                         else new AirshipSpawnMap().RandomTeleport(player);
                     }
@@ -53,6 +52,7 @@ namespace TownOfHost
             private static void AirshipSynchronizedRandomTeleport(PlayerControl player)
             {
                 CloneSpeed ??= new(Main.AllPlayerSpeed);
+                if (player.IsAlive()) AirshipSpawnedPlayerCount++;
                 if (!IsSpawnReady)
                 {
                     Main.PlayerStates[player.PlayerId].IsBlackOut = true;

--- a/Patches/RandomSpawnPatch.cs
+++ b/Patches/RandomSpawnPatch.cs
@@ -14,6 +14,7 @@ namespace TownOfHost
         // 生存プレイヤーが全員スポーン選択を終えたときにスポーンの準備が完了します
         // 死亡済みプレイヤーは準備完了まで待機しますが，条件には含まれません
         public static bool IsSpawnReady => AirshipSpawnedPlayerCount >= Main.AllAlivePlayerControls.Count();
+        public static bool IsProcessing => AirshipSpawnedPlayerCount > 0;
 
         [HarmonyPatch(typeof(CustomNetworkTransform), nameof(CustomNetworkTransform.SnapTo), typeof(Vector2), typeof(ushort))]
         public class CustomNetworkTransformPatch

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -118,6 +118,7 @@ namespace TownOfHost
             CustomWinnerHolder.Reset();
             AntiBlackout.Reset();
             IRandom.SetInstanceById(Options.RoleAssigningAlgorithm.GetValue());
+            RandomSpawn.InitAirshipSpawnState();
 
             MeetingStates.MeetingCalled = false;
             MeetingStates.FirstMeeting = true;

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -118,7 +118,7 @@ namespace TownOfHost
             CustomWinnerHolder.Reset();
             AntiBlackout.Reset();
             IRandom.SetInstanceById(Options.RoleAssigningAlgorithm.GetValue());
-            RandomSpawn.InitAirshipSpawnState();
+            RandomSpawn.InitSpawnState();
 
             MeetingStates.MeetingCalled = false;
             MeetingStates.FirstMeeting = true;

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -299,6 +299,7 @@
 "DisableAirshipCargoLightsPanel","Disable Cargo Lights Panel(Airship)","貨物室の配電盤を無効化（エアシップ）","禁用货舱配电箱(飞艇地图)","","Отключить починку света в грузовом отсеке на Airship","Desativar Painel de Luzes das Cargas(Airship)"
 "RandomSpawn","Random Spawn","ランダムスポーン","随机出生点","隨機出生點","Случайный Спавн","Spawn Aleatório"
 "AirshipAdditionalSpawn","Additional Spawn(Airship)","追加スポーン位置(エアシップ)","额外出生点（飞艇地图）","額外出生點(The Airship地圖)","Дополнительный Спавн(Airship)","Spawn Adicional(Airship)"
+"AirshipSynchronizeSpawn","Synchronize Spawn Timing(Airship)","スポーンのタイミングを同期する(エアシップ)",,,,
 "CommsCamouflage","Camouflage During Comms","コミュサボ時のカモフラージュ","通信破坏时伪装","","Камуфляж При Саботаже Связи","Camuflagem Durante Comunicação"
 "EnableDebugMode","Enable Debug Mode","デバッグモードを有効化する","开启调试模式","","Включить режим отладки","Ativar Modo de Depuração"
 "ChangeNameToRoleInfo","Show Role Descriptions to Unmodded Client","役職説明を非modクライアントにも表示する","对未安装本mod的玩家显示职业说明","","Показать описания ролей игрокам играющие без модов","Mostrar Descrição de Classe para Clientes Não Modificados"


### PR DESCRIPTION
ランダムスポーンの子オプション`スポーンのタイミングを同期する(エアシップ)`を作成

元のランダムスポーンだと選択した場所に一瞬現れることで視認ミスなどが発生するので作成しました

湧き位置を選択すると一旦選んだ通りの場所に湧き，移動不可&視界0になります
生存プレイヤーが全員選択を終えると全員にランダムスポーンとクールリセットを行い，`Utils.AfterMeetingTasks()`(バウハンとシリアルキラーのタイマーリセット，エレキ構造シャッフル)を呼びます
幽霊は生存者が全員湧くまで同様に待機しますが，湧きの完了判定には含まれません(タスクが終わって霊界でのんびりしていても迷惑になりません)

デフォルトはfalseにしています
