### PR TITLE
クライアント設定画面のリワーク

### DIFF
--- a/Modules/ClientOptionItem.cs
+++ b/Modules/ClientOptionItem.cs
@@ -1,0 +1,145 @@
+using System;
+using BepInEx.Configuration;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace TownOfHost
+{
+    public class ClientOptionItem
+    {
+        public ConfigEntry<bool> Config;
+        public ToggleButtonBehaviour ToggleButton;
+
+        public static SpriteRenderer CustomBackground;
+        private static int numOptions = 0;
+
+        private ClientOptionItem(
+            string label,
+            string objectName,
+            ConfigEntry<bool> config,
+            OptionsMenuBehaviour optionsMenuBehaviour,
+            Action additionalOnClickAction = null)
+        {
+            try
+            {
+                Config = config;
+
+                var mouseMoveToggle = optionsMenuBehaviour.DisableMouseMovement;
+
+                // 1つ目のボタンの生成時に背景も生成
+                if (CustomBackground == null)
+                {
+                    numOptions = 0;
+                    CustomBackground = Object.Instantiate(optionsMenuBehaviour.Background, optionsMenuBehaviour.transform);
+                    CustomBackground.name = "CustomBackground";
+                    CustomBackground.transform.localScale = new(0.9f, 0.9f, 1f);
+                    CustomBackground.transform.localPosition += Vector3.back * 8;
+                    CustomBackground.gameObject.SetActive(false);
+
+                    var closeButton = Object.Instantiate(mouseMoveToggle, CustomBackground.transform);
+                    closeButton.transform.localPosition = new(1.3f, -2.3f, -6f);
+                    closeButton.name = "Close";
+                    closeButton.Text.text = Translator.GetString("Close");
+                    closeButton.Background.color = Palette.DisabledGrey;
+                    var closePassiveButton = closeButton.GetComponent<PassiveButton>();
+                    closePassiveButton.OnClick = new();
+                    closePassiveButton.OnClick.AddListener(new Action(() =>
+                    {
+                        CustomBackground.gameObject.SetActive(false);
+                    }));
+
+                    UiElement[] selectableButtons = optionsMenuBehaviour.ControllerSelectable.ToArray();
+                    PassiveButton leaveButton = null;
+                    PassiveButton returnButton = null;
+                    for (int i = 0; i < selectableButtons.Length; i++)
+                    {
+                        var button = selectableButtons[i];
+                        if (button == null)
+                        {
+                            continue;
+                        }
+
+                        if (button.name == "LeaveGameButton")
+                        {
+                            leaveButton = button.GetComponent<PassiveButton>();
+                        }
+                        else if (button.name == "ReturnToGameButton")
+                        {
+                            returnButton = button.GetComponent<PassiveButton>();
+                        }
+                    }
+                    var generalTab = mouseMoveToggle.transform.parent.parent.parent;
+
+                    var modOptionsButton = Object.Instantiate(mouseMoveToggle, generalTab);
+                    modOptionsButton.transform.localPosition = leaveButton?.transform?.localPosition ?? new(0f, -2.4f, 1f);
+                    modOptionsButton.name = "TOHOptions";
+                    modOptionsButton.Text.text = Translator.GetString("TOHOptions");
+                    modOptionsButton.Background.color = new Color32(0x00, 0xbf, 0xff, 0xff);
+                    var modOptionsPassiveButton = modOptionsButton.GetComponent<PassiveButton>();
+                    modOptionsPassiveButton.OnClick = new();
+                    modOptionsPassiveButton.OnClick.AddListener(new Action(() =>
+                    {
+                        CustomBackground.gameObject.SetActive(true);
+                    }));
+
+                    if (leaveButton != null)
+                    {
+                        leaveButton.transform.localPosition = new(-1.35f, -2.411f, -1f);
+                    }
+                    if (returnButton != null)
+                    {
+                        returnButton.transform.localPosition = new(1.35f, -2.411f, -1f);
+                    }
+                }
+
+                // ボタン生成
+                ToggleButton = Object.Instantiate(mouseMoveToggle, CustomBackground.transform);
+                ToggleButton.transform.localPosition = new Vector3(
+                    // 現在のオプション数を基に位置を計算
+                    numOptions % 2 == 0 ? -1.3f : 1.3f,
+                    2.2f - (0.5f * (numOptions / 2)),
+                    -6f);
+                ToggleButton.name = objectName;
+                ToggleButton.Text.text = label;
+                var passiveButton = ToggleButton.GetComponent<PassiveButton>();
+                passiveButton.OnClick = new();
+                passiveButton.OnClick.AddListener(new Action(() =>
+                {
+                    config.Value = !config.Value;
+                    UpdateToggle();
+                    additionalOnClickAction?.Invoke();
+                }));
+                UpdateToggle();
+            }
+            finally
+            {
+                numOptions++;
+            }
+        }
+
+        public static ClientOptionItem Create(
+            string label,
+            string objectName,
+            ConfigEntry<bool> config,
+            OptionsMenuBehaviour optionsMenuBehaviour,
+            Action additionalOnClickAction = null)
+        {
+            return new(label, objectName, config, optionsMenuBehaviour, additionalOnClickAction);
+        }
+
+        public void UpdateToggle()
+        {
+            if (ToggleButton == null)
+            {
+                return;
+            }
+
+            var color = Config.Value ? Color.green : Color.red;
+            ToggleButton.Background.color = color;
+            if (ToggleButton.Rollover != null)
+            {
+                ToggleButton.Rollover.ChangeOutColor(color);
+            }
+        }
+    }
+}

--- a/Modules/ClientOptionItem.cs
+++ b/Modules/ClientOptionItem.cs
@@ -14,8 +14,7 @@ namespace TownOfHost
         private static int numOptions = 0;
 
         private ClientOptionItem(
-            string label,
-            string objectName,
+            string name,
             ConfigEntry<bool> config,
             OptionsMenuBehaviour optionsMenuBehaviour,
             Action additionalOnClickAction = null)
@@ -99,8 +98,8 @@ namespace TownOfHost
                     numOptions % 2 == 0 ? -1.3f : 1.3f,
                     2.2f - (0.5f * (numOptions / 2)),
                     -6f);
-                ToggleButton.name = objectName;
-                ToggleButton.Text.text = label;
+                ToggleButton.name = name;
+                ToggleButton.Text.text = Translator.GetString(name);
                 var passiveButton = ToggleButton.GetComponent<PassiveButton>();
                 passiveButton.OnClick = new();
                 passiveButton.OnClick.AddListener(new Action(() =>
@@ -118,13 +117,12 @@ namespace TownOfHost
         }
 
         public static ClientOptionItem Create(
-            string label,
-            string objectName,
+            string name,
             ConfigEntry<bool> config,
             OptionsMenuBehaviour optionsMenuBehaviour,
             Action additionalOnClickAction = null)
         {
-            return new(label, objectName, config, optionsMenuBehaviour, additionalOnClickAction);
+            return new(name, config, optionsMenuBehaviour, additionalOnClickAction);
         }
 
         public void UpdateToggle()

--- a/Patches/ClientOptionsPatch.cs
+++ b/Patches/ClientOptionsPatch.cs
@@ -17,19 +17,11 @@ namespace TownOfHost
 
             if (ForceJapanese == null || ForceJapanese.ToggleButton == null)
             {
-                ForceJapanese = ClientOptionItem.Create(
-                    Translator.GetString("ForceJapanese"),
-                    "ForceJapanese",
-                    Main.ForceJapanese,
-                    __instance);
+                ForceJapanese = ClientOptionItem.Create("ForceJapanese", Main.ForceJapanese, __instance);
             }
             if (JapaneseRoleName == null || JapaneseRoleName.ToggleButton == null)
             {
-                JapaneseRoleName = ClientOptionItem.Create(
-                    Translator.GetString("JapaneseRoleName"),
-                    "JapaneseRoleName",
-                    Main.JapaneseRoleName,
-                    __instance);
+                JapaneseRoleName = ClientOptionItem.Create("JapaneseRoleName", Main.JapaneseRoleName, __instance);
             }
         }
     }

--- a/Patches/ClientOptionsPatch.cs
+++ b/Patches/ClientOptionsPatch.cs
@@ -1,88 +1,47 @@
 using HarmonyLib;
-using UnityEngine;
-using UnityEngine.UI;
 
 namespace TownOfHost
 {
     [HarmonyPatch(typeof(OptionsMenuBehaviour), nameof(OptionsMenuBehaviour.Start))]
-    class OptionsMenuBehaviourStartPatch
+    public static class OptionsMenuBehaviourStartPatch
     {
-        private static Vector3? origin;
-        private static ToggleButtonBehaviour ForceJapanese;
-        private static ToggleButtonBehaviour JapaneseRoleName;
-        public static float xOffset = 1.75f;
-        public static float yOffset = -0.25f;
-        private static void UpdateToggle(ToggleButtonBehaviour button, string text, bool on)
-        {
-            if (button == null || button.gameObject == null) return;
-
-            Color color = on ? new Color(0f, 1f, 0.16470589f, 1f) : Color.white;
-            button.Background.color = color;
-            button.Text.text = $"{text}{(on ? "On" : "Off")}";
-            if (button.Rollover) button.Rollover.ChangeOutColor(color);
-        }
-        private static ToggleButtonBehaviour CreateCustomToggle(string text, bool on, Vector3 offset, UnityEngine.Events.UnityAction onClick, OptionsMenuBehaviour __instance)
-        {
-            if (__instance.CensorChatButton != null)
-            {
-                var button = UnityEngine.Object.Instantiate(__instance.CensorChatButton, __instance.CensorChatButton.transform.parent);
-                button.transform.localPosition = (origin ?? Vector3.zero) + offset;
-                PassiveButton passiveButton = button.GetComponent<PassiveButton>();
-                passiveButton.OnClick = new Button.ButtonClickedEvent();
-                passiveButton.OnClick.AddListener(onClick);
-                UpdateToggle(button, text, on);
-
-                return button;
-            }
-            return null;
-        }
+        private static ClientOptionItem ForceJapanese;
+        private static ClientOptionItem JapaneseRoleName;
 
         public static void Postfix(OptionsMenuBehaviour __instance)
         {
-            if (__instance.CensorChatButton != null)
+            if (__instance.DisableMouseMovement == null)
             {
-                if (origin == null) origin = __instance.CensorChatButton.transform.localPosition;
-                __instance.CensorChatButton.transform.localPosition = origin.Value + Vector3.left * 0.375f + Vector3.up * 0.08f;
-                __instance.CensorChatButton.transform.localScale = Vector3.one * 0.7f;
-            }
-            if (__instance.EnableFriendInvitesButton != null)
-            {
-                if (origin == null) origin = __instance.EnableFriendInvitesButton.transform.localPosition;
-                __instance.EnableFriendInvitesButton.transform.localPosition = origin.Value + Vector3.right * 3.125f + Vector3.up * 0.08f;
-                __instance.EnableFriendInvitesButton.transform.localScale = Vector3.one * 0.7f;
-            }
-            if (__instance.ColorBlindButton != null)
-            {
-                if (origin == null) origin = __instance.ColorBlindButton.transform.localPosition;
-                __instance.ColorBlindButton.transform.localPosition = origin.Value + Vector3.right * 3.125f + Vector3.up * 0.74f;
-                __instance.ColorBlindButton.transform.localScale = Vector3.one * 0.7f;
-            }
-            if (__instance.StreamerModeButton != null)
-            {
-                if (origin == null) origin = __instance.StreamerModeButton.transform.localPosition;
-                __instance.StreamerModeButton.transform.localPosition = origin.Value + Vector3.right * 1.375f + Vector3.up * 1.071f;
-                __instance.StreamerModeButton.transform.localScale = Vector3.one * 0.7f;
+                return;
             }
 
-            if (ForceJapanese == null || ForceJapanese?.gameObject == null)
+            if (ForceJapanese == null || ForceJapanese.ToggleButton == null)
             {
-                ForceJapanese = CreateCustomToggle("Force Japanese: ", Main.ForceJapanese.Value, new Vector3(-0.375f, yOffset, 0), (UnityEngine.Events.UnityAction)ForceJapaneseButtonToggle, __instance);
-
-                void ForceJapaneseButtonToggle()
-                {
-                    Main.ForceJapanese.Value = !Main.ForceJapanese.Value;
-                    UpdateToggle(ForceJapanese, "Force Japanese: ", Main.ForceJapanese.Value);
-                }
+                ForceJapanese = ClientOptionItem.Create(
+                    Translator.GetString("ForceJapanese"),
+                    "ForceJapanese",
+                    Main.ForceJapanese,
+                    __instance);
             }
-            if (JapaneseRoleName == null || JapaneseRoleName.gameObject == null)
+            if (JapaneseRoleName == null || JapaneseRoleName.ToggleButton == null)
             {
-                JapaneseRoleName = CreateCustomToggle("Japanese Role Name: ", Main.JapaneseRoleName.Value, new Vector3(1.375f, yOffset, 0), (UnityEngine.Events.UnityAction)LangModeButtonToggle, __instance);
+                JapaneseRoleName = ClientOptionItem.Create(
+                    Translator.GetString("JapaneseRoleName"),
+                    "JapaneseRoleName",
+                    Main.JapaneseRoleName,
+                    __instance);
+            }
+        }
+    }
 
-                void LangModeButtonToggle()
-                {
-                    Main.JapaneseRoleName.Value = !Main.JapaneseRoleName.Value;
-                    UpdateToggle(JapaneseRoleName, "Japanese Role Name: ", Main.JapaneseRoleName.Value);
-                }
+    [HarmonyPatch(typeof(OptionsMenuBehaviour), nameof(OptionsMenuBehaviour.Close))]
+    public static class OptionsMenuBehaviourClosePatch
+    {
+        public static void Postfix()
+        {
+            if (ClientOptionItem.CustomBackground != null)
+            {
+                ClientOptionItem.CustomBackground.gameObject.SetActive(false);
             }
         }
     }

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -263,7 +263,6 @@
 "HideGameSettings","Hide Game Settings","ゲーム設定を隠す","隐藏游戏设置","隱藏遊戲設定","Скрыть настройки Игры","Esconder Configurações"
 "RoleOptions","Role Options","役職設定","职业设置","職業設定","Настройка Ролей","Opções de Papéis"
 "ModeOptions","Mode Options","モード設定","模组设置","模式設定","Настройка Режима","Opções de Modos"
-"ForceJapanese","Force Japanese","日本語に強制","强制使用日语","強制使用日語","Принудительный Японский","Forçar Japonês"
 "AutoDisplayLastResult","Auto Display Last Result","自動的に試合結果を表示","自动显示最终结果","自動顯示上一回合結果","Отображать результат последней игры в чате","Mostrar Ultimo Resultado"
 "AutoDisplayKillLog","Auto Display KillLog","自動的にキルログを表示","自动显示击杀日志","","Отображать историю убийств в чате",""
 "VoteMode","Voting Mode","投票モード","投票相关设定","投票設定","Режим Голосования","Modo de Votação"
@@ -457,6 +456,12 @@
 "SabotageTimeControl","Sabotage Duration Control","サボタージュの時間制御","更改修理时限","重新設定緊急任務時間","Изменить время Саботажа","Controle da Duração de Sabotagem"
 "PolusReactorTimeLimit","Polus Reactor Duration","ポーラスのリアクター制限時間","波鲁斯抗震稳定器修理时限","Polus地震抑制器破壞最大時間","Polus время саботажа Реактора","Duração do Reator em Polus"
 "AirshipReactorTimeLimit","Airship Reactor Duration","エアシップのリアクター制限時間","飞艇坠毁路线修理时限","Airship間隙室破壞最大時間","Airship время саботажа Реактора","Duração do Reator em Airship"
+
+"## クライアント設定"
+"Close","Close","閉じる","","","",""
+"TOHOptions","<color=#00bfff>TOH</color> Options","<color=#00bfff>TOH</color>の設定","","","",""
+"ForceJapanese","Force Japanese","日本語に強制","强制使用日语","強制使用日語","Принудительный Японский","Forçar Japonês"
+"JapaneseRoleName","Japanese Role Name","日本語の役職名","","","",""
 
 "## ヘルプテキスト"
 "CommandList","Command List:","コマンド一覧:","指令列表:","指令列表:","Список команд:","Lista de Comandos:"


### PR DESCRIPTION
歯車のMod設定画面のリワークを行いました

![image](https://user-images.githubusercontent.com/86903430/230294424-0f8c55be-39b1-4844-a2ae-766055220ce3.png)
![image](https://user-images.githubusercontent.com/86903430/230294524-31cac62f-39c3-45a7-9787-95c300e5f856.png)

バニラ設定のすし詰め状態が解消されて見やすくなり，新しい設定の追加もかなり容易になっています．
設定項目への翻訳の適用も行っていますが，意図的に未翻訳にしていた理由がありましたら元に戻します．
`additionalOnClickAction`は現時点で未使用ですが，設定変更時に表示の更新を行うような用途を想定しています．

設定項目を増やすとこんな感じになります

![image](https://user-images.githubusercontent.com/86903430/230294322-8cf6bbca-6938-4dc6-9b50-c23c81ee1da6.png)

