### PR TITLE
function-初手会議で自身の役職説明を表示させる/属性も表示させる

### DIFF
--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -208,6 +208,7 @@ namespace TownOfHost
         public static OptionItem GhostCanSeeDeathReason;
         public static OptionItem GhostIgnoreTasks;
         public static OptionItem CommsCamouflage;
+        public static OptionItem ShowRoleInfoAtFirstMeeting;
 
         // プリセット対象外
         public static OptionItem NoGameEnd;
@@ -533,6 +534,8 @@ namespace TownOfHost
             DisableTaskWin = BooleanOptionItem.Create(900_001, "DisableTaskWin", false, TabGroup.MainSettings, false)
                 .SetGameMode(CustomGameMode.All);
             NoGameEnd = BooleanOptionItem.Create(900_002, "NoGameEnd", false, TabGroup.MainSettings, false)
+                .SetGameMode(CustomGameMode.All);
+            ShowRoleInfoAtFirstMeeting = BooleanOptionItem.Create(900_022, "ShowRoleInfoAtFirstMeeting", false, TabGroup.MainSettings, false)
                 .SetGameMode(CustomGameMode.All);
             GhostCanSeeOtherRoles = BooleanOptionItem.Create(900_010, "GhostCanSeeOtherRoles", true, TabGroup.MainSettings, false)
                 .SetGameMode(CustomGameMode.All);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -308,6 +308,26 @@ namespace TownOfHost
             return hexColor;
         }
 
+        public static string GetMyRoleInfo(PlayerControl player)
+        {
+            if (!GameStates.IsInGame) return null;
+
+            var sb = new StringBuilder();
+            var role = player.GetCustomRole();
+            sb.Append(GetString(role.ToString())).Append(player.GetRoleInfo(true));
+
+            foreach (var subRole in player.GetCustomSubRoles())
+            {
+                if (subRole != CustomRoles.NotAssigned)
+                {
+                    var RoleName = subRole.ToString();
+                    sb.Append("\n--------------------------------------------------------\n")
+                        .Append(GetString(RoleName)).Append(GetString($"{RoleName}InfoLong"));
+                }
+            }
+            return sb.ToString();
+        }
+
         public static string GetVitalText(byte playerId, bool RealKillerColor = false)
         {
             var state = PlayerState.GetByPlayerId(playerId);

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -198,9 +198,7 @@ namespace TownOfHost
                     case "/m":
                     case "/myrole":
                         canceled = true;
-                        var role = PlayerControl.LocalPlayer.GetCustomRole();
-                        if (GameStates.IsInGame)
-                            HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, GetString(role.ToString()) + PlayerControl.LocalPlayer.GetRoleInfo(true));
+                        HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, Utils.GetMyRoleInfo(PlayerControl.LocalPlayer));
                         break;
 
                     case "/t":
@@ -382,9 +380,7 @@ namespace TownOfHost
 
                 case "/m":
                 case "/myrole":
-                    var role = player.GetCustomRole();
-                    if (GameStates.IsInGame)
-                        Utils.SendMessage(GetString(role.ToString()) + player.GetRoleInfo(true), player.PlayerId);
+                    Utils.SendMessage(Utils.GetMyRoleInfo(player), player.PlayerId);
                     break;
 
                 case "/t":

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -317,6 +317,14 @@ namespace TownOfHost
                 var target = Utils.GetPlayerById(pva.TargetPlayerId);
                 if (target == null) continue;
 
+                // 初手会議での役職説明表示
+                if (Options.ShowRoleInfoAtFirstMeeting.GetBool() && MeetingStates.FirstMeeting)
+                {
+                    String RoleInfoTitleString = $"{GetString("RoleInfoTitle")}";
+                    String RoleInfoTitle = $"{Utils.ColorString(Utils.GetRoleColor(target.GetCustomRole()), RoleInfoTitleString)}";
+                    Utils.SendMessage(Utils.GetMyRoleInfo(target), sendTo: pva.TargetPlayerId, title: RoleInfoTitle);
+                }
+
                 var sb = new StringBuilder();
 
                 //会議画面での名前変更

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -318,6 +318,7 @@
 "ApplyDenyNameList","Apply DenyName List","DenyNameリストを適用する","启用违禁昵称名单","","Применить файл запрещённых имён (DenyName)",""
 "KickPlayerFriendCodeNotExist","Kick Players Whose Friend Code Does Not Exist","フレンドコードが存在しないプレイヤーをキックする","踢出好友编号无效的玩家","","Кикнуть игроков у которых нет Кода Друга",""
 "ApplyBanList","Apply BanList","BANリストを適用する","启用封禁名单","","Применить файл с забаненными игроками (BanList)",""
+"ShowRoleInfoAtFirstMeeting","Show Role description at the first meeting","初めの会議で役職説明を表示する","在第一次会议上显示角色介绍"
 
 "## モード説明"
 "HideAndSeekInfo","Hide and Seek:\nNo emergency meetings. Crewmates (Blue) can only win by finishing tasks\nand impostors (Red) can only win by killing all crewmates.","かくれんぼ:\n会議を開くことはできず、クルーはタスク完了、インポスターは全クルー殺害でのみ勝利することができる。\nインポスターは赤、クルーは青に体の色が変更される。","躲猫猫:\n不能开会；船员只能通过完成任务获得胜利；\n内鬼需要杀死所有船员来获得胜利；\n内鬼的皮肤颜色将变为红色，船员变为蓝色，以示区分。","躲貓貓:\n不能拍桌或舉報，船員只能做任務\n偽裝者的勝利條件為殺光所有船員\n狼人的顏色會轉變為紅色，船員則會變為藍色。","Прятки:\nНикто не может созвать срочное собрание, Члены Экипажа могут победить, только выполняя задания. \nПредатели меняют цвет тела на красный, а экипажи на синий.","Esconde-Esconde:\nNão há reuniões de emergência. Tripulantes (Azul) podem ganhar apenas ao completar todas as tarefas,\ne Impostores (Vermelho) ganham apenas quando matarem todos os tripulantes."
@@ -539,6 +540,7 @@
 "## その他"
 "DefaultSystemMessageTitle","【===== System Message =====】","【===== システムメッセージ ======】","【===== 系统信息 ======】","【===== 系統訊息 ======】","【=== Системное сообщение ===】","【===== Mensagem do Sistema ======】"
 "MessageFromTheHost","【Message From The Host】","【ホストからの伝言】","【房主消息】","【房主訊息】","【Сообщение от Хоста】",""
+"RoleInfoTitle","【Your Role Description】","【あなたの役職説明】","【你的职业介绍】"
 "TabGroup.MainSettings","Main Settings","メイン設定","主要设置","主要設定","Основная настройка","Configurações Principais"
 "TabGroup.CrewmateRoles","Crewmate Roles","クルー役職","船员阵营职业","","Роли Членов Экипажа","Classes de Tripulante"
 "TabGroup.NeutralRoles","Neutral Roles","ニュートラル役職","独立阵营职业","中立職業設定","Нейтральные Роли","Classes Neutras"


### PR DESCRIPTION
初手会議に自身の役職説明を表示させる機能を追加。
また、合わせて属性も表示される説明のものに変更。
/myroleも合わせて変更。

タイトルの色は役職の色に合わせてあります。

![Info](https://github.com/tukasa0001/TownOfHost/assets/107914133/9020aae2-ada0-4a7c-a6e0-61e41d24cf28)