### PR TITLE
Color player names with role color for ghosts

### DIFF
--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -30,6 +30,7 @@ namespace TownOfHost
         {
             return seer == target
                 || target.Is(CustomRoles.GM)
+                || (Main.PlayerStates[seer.Data.PlayerId].IsDead && Options.GhostCanSeeOtherRoles.GetBool()) //seer.Data.IsDead
                 || (seer.Is(CustomRoleTypes.Impostor) && target.Is(CustomRoleTypes.Impostor))
                 || Mare.KnowTargetRoleColor(target, isMeeting);
         }


### PR DESCRIPTION
Colors the names of every player with their role color as a ghost. Visual change that looks nice.

### Preview (shown in Town of Host Edited as it originates from there)
![image](https://github.com/tukasa0001/TownOfHost/assets/51543683/f2519333-a04a-425d-95b2-a32382595e14)
