### PR TITLE
feature/ Disable Interference FixLights

### DIFF
--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -190,6 +190,7 @@ namespace TownOfHost
 
         // 停電の特殊設定
         public static OptionItem LightsOutSpecialSettings;
+        public static OptionItem DisableInterferenceFixLights;
         public static OptionItem DisableAirshipViewingDeckLightsPanel;
         public static OptionItem DisableAirshipGapRoomLightsPanel;
         public static OptionItem DisableAirshipCargoLightsPanel;
@@ -376,6 +377,8 @@ namespace TownOfHost
 
             // 停電の特殊設定
             LightsOutSpecialSettings = BooleanOptionItem.Create(101500, "LightsOutSpecialSettings", false, TabGroup.MainSettings, false)
+                .SetGameMode(CustomGameMode.Standard);
+            DisableInterferenceFixLights = BooleanOptionItem.Create(101514, "DisableInterferenceFixLights", false, TabGroup.MainSettings, false).SetParent(LightsOutSpecialSettings)
                 .SetGameMode(CustomGameMode.Standard);
             DisableAirshipViewingDeckLightsPanel = BooleanOptionItem.Create(101511, "DisableAirshipViewingDeckLightsPanel", false, TabGroup.MainSettings, false).SetParent(LightsOutSpecialSettings)
                 .SetGameMode(CustomGameMode.Standard);

--- a/Patches/SwitchSystem.cs
+++ b/Patches/SwitchSystem.cs
@@ -1,0 +1,23 @@
+using System;
+using HarmonyLib;
+
+namespace TownOfHost;
+
+[HarmonyPatch(typeof(SwitchSystem), nameof(SwitchSystem.RepairDamage))]
+class SwitchSystemRepairPatch
+{
+    public static void Postfix(SwitchSystem __instance, [HarmonyArgument(0)] PlayerControl player, [HarmonyArgument(1)] byte amount)
+    {
+        if (amount is >= 0 and <= 4 &&
+            Options.DisableInterferenceFixLights.GetBool())
+        {
+            byte change = (byte)(1U << (int)amount);
+            if ((__instance.ActualSwitches & change) != (__instance.ExpectedSwitches & change))
+            {
+                __instance.ActualSwitches ^= change;
+                Logger.Info($"SwitchChange ActualSwitches: {Convert.ToString(__instance.ActualSwitches, toBase: 2)} => {Convert.ToString(__instance.ActualSwitches ^ change, toBase: 2)}", "SwitchSystem.RepairDamage");
+            }
+        }
+
+    }
+}

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -298,6 +298,7 @@
 "IgnoreCrewmates","Ignore Crewmates","クルーを除く","忽略船员","船員陣營除外","Игнорируют Члены Экипажа","Ignorar Tripulantes"
 "IgnoreAfterAnyoneDied","Ignore After Anyone Has Died","死人が出た後を除く","忽略幽灵","當所有人都死亡時除外","Игнорируют умершие игроки","Ignorar Depois de Alguém Morrer"
 "LightsOutSpecialSettings","Fix Lights Special Settings","停電の特殊設定","停电特殊设定","關燈特殊設定","Специальные настройки при отключении Света","Configuração Especial de Consertar Luzes"
+"DisableInterferenceFixLights","Disable Interference With Fix Lights","停電の復旧妨害を無効化","","","",""
 "DisableAirshipViewingDeckLightsPanel","Disable Viewing Deck Lights Panel(Airship)","展望の配電盤を無効化（エアシップ）","禁用瞭望台配电箱(飞艇地图)","關閉觀景台的配電箱 (Airship)","Отключить починку Света на Смотровой Палубе (Airship)","Desativar Painel de Luzes do Deck Panorâmico(Airship)"
 "DisableAirshipGapRoomLightsPanel","Disable Gap Room Lights Panel(Airship)","昇降機の配電盤を無効化（エアシップ）","禁用升降机配电箱(飞艇地图)","關閉間隙室右側的配電箱 (Airship)","Отключить починку Света в Комнате Пролета (Airship)","Desativar Painel de Luzes da Sala Suspensa(Airship)"
 "DisableAirshipCargoLightsPanel","Disable Cargo Lights Panel(Airship)","貨物室の配電盤を無効化（エアシップ）","禁用货舱配电箱(飞艇地图)","關閉貨艙的配電箱 (Airship)","Отключить починку Света в Грузовом Отсеке (Airship)","Desativar Painel de Luzes das Cargas(Airship)"


### PR DESCRIPTION
設定：停電の復旧妨害を無効化 の追加

停電の復旧妨害を無効化 がオンの場合、
停電サボタージュの時に配電盤でONになってるスイッチをOFFにできなくなる

過度な停電復旧妨害によるゲーム混乱の防止、
デバイスによる妨害可否の不公平感の抑止、のため