### PR TITLE
BugFix/ DarkAfterMeeting JackalsArsonists

### DIFF
--- a/Roles/Neutral/Arsonist.cs
+++ b/Roles/Neutral/Arsonist.cs
@@ -21,6 +21,7 @@ public sealed class Arsonist : RoleBase, IKiller
             SetupOptionItem,
             "ar",
             "#ff6633",
+            true,
             introSound: () => GetIntroSound(RoleTypes.Crewmate)
         );
     public Arsonist(PlayerControl player)

--- a/Roles/Neutral/Jackal.cs
+++ b/Roles/Neutral/Jackal.cs
@@ -18,6 +18,7 @@ namespace TownOfHost.Roles.Neutral
                 SetupOptionItem,
                 "jac",
                 "#00b4eb",
+                true,
                 countType: CountTypes.Jackal
             );
         public Jackal(PlayerControl player)


### PR DESCRIPTION
ジャッカル、アーソニストが死亡した会議後に暗転する問題対応

暗転抜けでジャッカル、アーソニスト透けるため