### PR TITLE
Fix bug when pets at dead players return after end camouflage

### DIFF
--- a/Modules/Camouflague.cs
+++ b/Modules/Camouflague.cs
@@ -57,7 +57,7 @@ namespace TownOfHost
                 {
                     Camouflage.RpcSetSkin(pc);
 
-                    if (!(IsCamouflage && pc.IsAlive()))
+                    if (!IsCamouflage && !pc.IsAlive())
                     {
                         pc.RpcSetPet("");
                     }

--- a/Modules/Camouflague.cs
+++ b/Modules/Camouflague.cs
@@ -55,7 +55,7 @@ namespace TownOfHost
             {
                 foreach (var pc in Main.AllPlayerControls)
                 {
-                    Camouflage.RpcSetSkin(pc);
+                    RpcSetSkin(pc);
 
                     if (!IsCamouflage && !pc.IsAlive())
                     {

--- a/Modules/Camouflague.cs
+++ b/Modules/Camouflague.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using HarmonyLib;
 using TownOfHost.Attributes;
 
 namespace TownOfHost
@@ -57,6 +56,7 @@ namespace TownOfHost
                 {
                     RpcSetSkin(pc);
 
+                    // The code is intended to remove pets at dead players to combat a vanilla bug
                     if (!IsCamouflage && !pc.IsAlive())
                     {
                         pc.RpcSetPet("");

--- a/Modules/Camouflague.cs
+++ b/Modules/Camouflague.cs
@@ -53,7 +53,15 @@ namespace TownOfHost
 
             if (oldIsCamouflage != IsCamouflage)
             {
-                Main.AllPlayerControls.Do(pc => Camouflage.RpcSetSkin(pc));
+                foreach (var pc in Main.AllPlayerControls)
+                {
+                    Camouflage.RpcSetSkin(pc);
+
+                    if (!(IsCamouflage && pc.IsAlive()))
+                    {
+                        pc.RpcSetPet("");
+                    }
+                }
                 Utils.NotifyRoles(NoCache: true);
             }
         }


### PR DESCRIPTION
Note: If a player dead during camouflage, his pet disappears, but after the end of camouflage, the pet will return back