### PR TITLE
BugFix / Desync Impostor Resets Sabotages Cooldown

### DIFF
--- a/Patches/ISystemType/SabotageSystemTypePatch.cs
+++ b/Patches/ISystemType/SabotageSystemTypePatch.cs
@@ -62,9 +62,9 @@ public static class SabotageSystemTypeUpdateSystemPatch
         }
         return true;
     }
-    public static void Postfix(SabotageSystemType __instance)
+    public static void Postfix(SabotageSystemType __instance, [HarmonyArgument(0)] PlayerControl player)
     {
-        if (!isCooldownModificationEnabled || !AmongUsClient.Instance.AmHost)
+        if (!AmongUsClient.Instance.AmHost || !isCooldownModificationEnabled || !CanSabotage(player))
         {
             return;
         }


### PR DESCRIPTION
Reason bug:
If setting `Sabotage Cooldown Control` is enabled, then when desync impostors click on any sabotage, it will be reset