### PR TITLE
Bug Fix /  Engineer based role can be stuck in vent during comms sabotage

### DIFF
--- a/Patches/UsablesPatch.cs
+++ b/Patches/UsablesPatch.cs
@@ -38,7 +38,7 @@ namespace TownOfHost
 
             // カスタムロールを元にベントを使えるか判定
             // エンジニアベースの役職は常にtrue
-            couldUse = playerControl.CanUseImpostorVentButton() || (pc.Role.Role == RoleTypes.Engineer && !Utils.IsActive(SystemTypes.Comms));
+            couldUse = playerControl.CanUseImpostorVentButton() || (pc.Role.Role == RoleTypes.Engineer && pc.Role.CanUse(__instance.Cast<IUsable>()));
 
             canUse = couldUse;
             // カスタムロールが使えなかったら使用不可

--- a/Patches/UsablesPatch.cs
+++ b/Patches/UsablesPatch.cs
@@ -38,7 +38,7 @@ namespace TownOfHost
 
             // カスタムロールを元にベントを使えるか判定
             // エンジニアベースの役職は常にtrue
-            couldUse = playerControl.CanUseImpostorVentButton() || pc.Role.Role == RoleTypes.Engineer;
+            couldUse = playerControl.CanUseImpostorVentButton() || (pc.Role.Role == RoleTypes.Engineer && !Utils.IsActive(SystemTypes.Comms));
 
             canUse = couldUse;
             // カスタムロールが使えなかったら使用不可


### PR DESCRIPTION
When Engineer based role enter in vent during comms sabotage, it can be stuck in vent

Note: impostors do not have this problem since the AU code allows the use of vent during comms sabotage, but for the Engineer role vent is automatically blocked