### PR TITLE
bugfix Worlock can't curse after meeting

### DIFF
--- a/Roles/Impostor/Warlock.cs
+++ b/Roles/Impostor/Warlock.cs
@@ -126,5 +126,6 @@ public sealed class Warlock : RoleBase, IImpostor
     public override void AfterMeetingTasks()
     {
         CursedPlayer = null;
+        IsCursed = false;
     }
 }


### PR DESCRIPTION
bugfix）ウォーロックが呪ったままキルせずに会議になると、次のターンにシェイプするまで呪いができない