### PR TITLE
Fix bug / April Fools mode not sync correctly for clients

### DIFF
--- a/Modules/GameOptionsSender/GameOptionsSender.cs
+++ b/Modules/GameOptionsSender/GameOptionsSender.cs
@@ -36,11 +36,11 @@ namespace TownOfHost.Modules
             if (AprilFoolsMode.IsAprilFoolsModeToggledOn)
             {
                 // if current game mode is classic
-                if (opt.GameMode == GameModes.Normal)
+                if (currentGameMode == GameModes.Normal)
                     currentGameMode = GameModes.NormalFools;
             
                 // if current game mode is vanilla HideNSeek
-                else if (opt.GameMode == GameModes.HideNSeek)
+                else if (currentGameMode == GameModes.HideNSeek)
                     currentGameMode = GameModes.SeekFools;
             }
 

--- a/Modules/GameOptionsSender/GameOptionsSender.cs
+++ b/Modules/GameOptionsSender/GameOptionsSender.cs
@@ -35,11 +35,12 @@ namespace TownOfHost.Modules
             //April fools mode toggled on by host
             if (AprilFoolsMode.IsAprilFoolsModeToggledOn)
             {
-                // if current game mode is classic
+                //Change the game mode to april fools instead of normal
+                //Because it doesn't change automatically 
+                
                 if (currentGameMode == GameModes.Normal)
                     currentGameMode = GameModes.NormalFools;
-            
-                // if current game mode is vanilla HideNSeek
+                
                 else if (currentGameMode == GameModes.HideNSeek)
                     currentGameMode = GameModes.SeekFools;
             }

--- a/Modules/GameOptionsSender/GameOptionsSender.cs
+++ b/Modules/GameOptionsSender/GameOptionsSender.cs
@@ -30,12 +30,25 @@ namespace TownOfHost.Modules
         public virtual void SendGameOptions()
         {
             var opt = BuildGameOptions();
+            var currentGameMode = opt.GameMode; // temp the current game mode for further changes if necessary
+
+            //April fools mode toggled on by host
+            if (AprilFoolsMode.IsAprilFoolsModeToggledOn)
+            {
+                // if current game mode is classic
+                if (opt.GameMode == GameModes.Normal)
+                    currentGameMode = GameModes.NormalFools;
+            
+                // if current game mode is vanilla HideNSeek
+                else if (opt.GameMode == GameModes.HideNSeek)
+                    currentGameMode = GameModes.SeekFools;
+            }
 
             // option => byte[]
             MessageWriter writer = MessageWriter.Get(SendOption.None);
             writer.Write(opt.Version);
             writer.StartMessage(0);
-            writer.Write((byte)opt.GameMode);
+            writer.Write((byte)currentGameMode);
             if (opt.TryCast<NormalGameOptionsV07>(out var normalOpt))
                 NormalGameOptionsV07.Serialize(writer, normalOpt);
             else if (opt.TryCast<HideNSeekGameOptionsV07>(out var hnsOpt))

--- a/Modules/GameOptionsSender/GameOptionsSender.cs
+++ b/Modules/GameOptionsSender/GameOptionsSender.cs
@@ -30,7 +30,7 @@ namespace TownOfHost.Modules
         public virtual void SendGameOptions()
         {
             var opt = BuildGameOptions();
-            var currentGameMode = opt.GameMode; // temp the current game mode for further changes if necessary
+            var currentGameMode = opt.GameMode; // remember the current game mode for further changes if necessary
 
             //April fools mode toggled on by host
             if (AprilFoolsMode.IsAprilFoolsModeToggledOn)


### PR DESCRIPTION
Before:
![image](https://github.com/tukasa0001/TownOfHost/assets/104814436/e90a8df2-73c5-48e3-a353-790f04b16ec3)

After:
![image](https://github.com/tukasa0001/TownOfHost/assets/104814436/7e98af11-b1bc-47bd-8389-9321d2dfc539)

Synchronization of the current game mode does not sync correctly between the host and clients