### PR TITLE
Fix bug / April Fools mode not sync for clients

### DIFF
--- a/Modules/GameOptionsSender/GameOptionsSender.cs
+++ b/Modules/GameOptionsSender/GameOptionsSender.cs
@@ -30,12 +30,14 @@ namespace TownOfHost.Modules
         public virtual void SendGameOptions()
         {
             var opt = BuildGameOptions();
-
+            var currentGameMode = AprilFoolsMode.IsAprilFoolsModeToggledOn //April fools mode toggled on by host
+                ? opt.AprilFoolsOnMode : opt.GameMode; //Change game mode, same as well as in "RpcSyncSettings()"
+            
             // option => byte[]
             MessageWriter writer = MessageWriter.Get(SendOption.None);
             writer.Write(opt.Version);
             writer.StartMessage(0);
-            writer.Write((byte)opt.GameMode);
+            writer.Write((byte)currentGameMode);
             if (opt.TryCast<NormalGameOptionsV07>(out var normalOpt))
                 NormalGameOptionsV07.Serialize(writer, normalOpt);
             else if (opt.TryCast<HideNSeekGameOptionsV07>(out var hnsOpt))


### PR DESCRIPTION
Before:
![image](https://github.com/tukasa0001/TownOfHost/assets/104814436/61e32f7f-f2b0-40ba-9cbf-e1400548c73d)

After:
![image](https://github.com/tukasa0001/TownOfHost/assets/104814436/5236af5b-f97a-48f8-a087-f1e522f5c7d2)


Since the vanilla code changes the game mode to april fools, then in `SendGameOptions()` need to do the same
![image](https://github.com/tukasa0001/TownOfHost/assets/104814436/f276ef68-9ecb-46ab-8dc9-08f90c370286)

