### PR TITLE
Fix bug / Vented player stuck for others players after desync "BootFromVent"

### DIFF
--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -642,16 +642,7 @@ namespace TownOfHost
                 !user.CanUseImpostorVentButton()) //インポスターベントも使えない
                 )
                 {
-                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(__instance.NetId, (byte)RpcCalls.BootFromVent, SendOption.Reliable, -1);
-                    writer.WritePacked(127);
-                    AmongUsClient.Instance.FinishRpcImmediately(writer);
-                    _ = new LateTask(() =>
-                    {
-                        int clientId = user.GetClientId();
-                        MessageWriter writer2 = AmongUsClient.Instance.StartRpcImmediately(__instance.NetId, (byte)RpcCalls.BootFromVent, SendOption.Reliable, clientId);
-                        writer2.Write(id);
-                        AmongUsClient.Instance.FinishRpcImmediately(writer2);
-                    }, 0.5f, "Fix DesyncImpostor Stuck");
+                    __instance.RpcBootFromVent(id);
                     return false;
                 }
             }


### PR DESCRIPTION
Fixed an issue where the player got stuck for some players after desync `BootFromVent` and null errors appeared in the logs (Unity errors)

Instead of using desync `BootFromVent` and using id vent `127` it is better to use `RpcBootFromVent`, it prevents getting stuck

Example bug:
![image](https://github.com/tukasa0001/TownOfHost/assets/104814436/cd6f5ab5-def7-4e9b-b63c-48272d15006b)

After fix:
![image](https://github.com/tukasa0001/TownOfHost/assets/104814436/277622f5-d17b-44c1-b735-80276b09b65f)
