### PR TITLE
bugFix) 固定アサインでのアサインカウントが正しくなるよう修正

### DIFF
--- a/Roles/RoleAssignManager.cs
+++ b/Roles/RoleAssignManager.cs
@@ -141,7 +141,7 @@ namespace TownOfHost.Roles
                 if (numImpostorsLeft <= 0 && numOthersLeft <= 0) break;
 
                 var targetRoles = role.GetAssignUnitRolesArray();
-                var numImpostorAssign = targetRoles.Count(role => role.IsImpostor());
+                var numImpostorAssign = targetRoles.Count(role => role.GetAssignRoleType() == CustomRoleTypes.Impostor);
                 var numOthersAssign = targetRoles.Length - numImpostorAssign;
                 //アサイン枠が足りてない場合
                 if (numImpostorAssign > numImpostorsLeft


### PR DESCRIPTION
固定アサインの場合にインポスター以外でインポスターカウントする役職を正しい属性でカウントされるように修正
例）
　エゴイストはロールアサインとしてはインポスターとしてアサインされるが、
　アサインカウントとしてはクルーでカウントされてしまう
　
エゴイストが配役されたときに１人役職が割当たらない場合がある問題の対応